### PR TITLE
Update obsolete Threads code

### DIFF
--- a/cYo.Common/Threading/ThreadUtility.cs
+++ b/cYo.Common/Threading/ThreadUtility.cs
@@ -249,39 +249,37 @@ namespace cYo.Common.Threading
 			}
 		}
 
-		private static void DumpThread(TextWriter tw, Thread t)
-		{
-			try
-			{
-				if (!t.IsAlive)
-				{
-					return;
-				}
-				tw.WriteLine(new string('-', 20));
-				tw.WriteLine("{0}: {1} ({2})", t.Name, t.ThreadState, t.IsBackground ? "B" : string.Empty);
-				StackTrace stackTrace;
-				if (t == Thread.CurrentThread)
-				{
-					stackTrace = new StackTrace();
-				}
-				else
-				{
-					t.Suspend();
-					try
-					{
-						stackTrace = new StackTrace(t, needFileInfo: true);
-					}
-					finally
-					{
-						t.Resume();
-					}
-				}
-				tw.WriteLine(stackTrace.ToString());
-			}
-			catch
-			{
-			}
-		}
+        private static void DumpThread(TextWriter tw, Thread t)
+        {
+            try
+            {
+                if (!t.IsAlive)
+                {
+                    return;
+                }
+
+                tw.WriteLine(new string('-', 20));
+                tw.WriteLine("{0}: {1} ({2})", t.Name, t.ThreadState, t.IsBackground ? "B" : string.Empty);
+
+                StackTrace stackTrace;
+                if (t == Thread.CurrentThread)
+                {
+                    stackTrace = new StackTrace();
+                }
+                else
+                {
+                    lock (t)
+                    {
+                        stackTrace = new StackTrace(true);
+                    }
+                }
+
+                tw.WriteLine(stackTrace.ToString());
+            }
+            catch
+            {
+            }
+        }
 
 		public static void DumpStacks(TextWriter tw)
 		{

--- a/cYo.Common/Threading/ThreadUtility.cs
+++ b/cYo.Common/Threading/ThreadUtility.cs
@@ -259,7 +259,7 @@ namespace cYo.Common.Threading
                 }
 
                 tw.WriteLine(new string('-', 20));
-                tw.WriteLine("{0}: {1} ({2})", t.Name, t.ThreadState, t.IsBackground ? "B" : string.Empty);
+                tw.WriteLine($"{t.Name}: {t.ThreadState} ({(t.IsBackground ? "B" : string.Empty)})");
 
                 StackTrace stackTrace;
                 if (t == Thread.CurrentThread)


### PR DESCRIPTION
**Pull Request Summary:**

 I've made adjustments to the DumpThread method to address Microsoft's deprecation of certain thread-related methods in .NET Framework 4.8. 

The changes include using the newer StackTrace constructor and introducing a lock for thread safety when creating the stack trace. 

I'm starting working by updating obsoletes pieces of code.