### PR TITLE
README spelling and installer Format() fixes

### DIFF
--- a/Installer.iss
+++ b/Installer.iss
@@ -194,7 +194,7 @@ begin
       Result := True;
     end
     else begin
-      Log(Format('%s installation failed: [Result Code: %s] {tmp}\%s', [NETFrameworkLabel, ResultCode, NETFrameworkFilename]));
+      Log(Format('%s installation failed: [Result Code: %d] {tmp}\%s', [NETFrameworkLabel, ResultCode, NETFrameworkFilename]));
       Result := False;
     end;
   finally

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ComicRack Community Edition
 
-#### These are automatically build for each commit, so this nightly will always be up to date and is build directly by Github, so you know the code you downloaded is the same than from the repo. When using the installer, I highly suggest you uninstall the original ComicRack before installing the Community Edition. It will prevent duplicates with the Open With menu.
+#### These are automatically build for each commit, so this nightly will always be up to date and is built directly by GitHub, so you know the code you downloaded is the same as the repo. When using the installer, I highly suggest you uninstall the original ComicRack before installing the Community Edition. It will prevent duplicates with the Open With menu.
 
-_Please keep in mind that this build isn't considered a stable build, It will change multiple times perhaps daily. There are still some bugs that might have came from the decompiling process, as such please be careful when "upgrading" to this version. There are also some reports of False Positive by Windows Defender, since this is an ever changing build, we cannot submit all version for removal._
+_Please keep in mind that this build isn't considered stable. It will change multiple times, perhaps daily. There are still some bugs that might have came from the decompiling process, as such please be careful when "upgrading" to this version. There are also some reports of False Positive by Windows Defender. Since this is an ever changing build, we cannot submit all version for removal._
 
 <p align="center">
     <b><u><span style='font-size:14.0pt'>👇 Download Links 👇</span></u></b>
@@ -28,13 +28,13 @@ _Please keep in mind that this build isn't considered a stable build, It will ch
 </p>
 
 
-This project is an attempt to resurrect the legendary Comic Manager ComicRack from the dead. It's been 10 years since we had an update. We hoped that the original author would be back to it but it never happened. The website went down, the application was taken from the App Store and later the Android Store. Late last year, the Android application even stopped working for people that bought it previsouly, forcing the use of a cracked version. That meant modifying the desktop client to allow syncing for cracked application. There was multiple attempt to contact him by various people that failed to release or buy the source code. There is also the grey area that this project is still the intellectual property of cYo (Markus Eisenstöck), so if he would give signs of life (with proof) and require that this project be taken down, I will acknowledge his request.
+This project is an attempt to resurrect the legendary Comic Manager ComicRack from the dead. It's been 10 years since we had an update. We hoped that the original author would be back to it but it never happened. The website went down, the application was taken from the App Store and later the Android Store. Late last year, the Android application even stopped working for people that bought it previously, forcing the use of a cracked version. That meant modifying the desktop client to allow syncing for cracked application. There was multiple attempt to contact him by various people that failed to release or buy the source code. There is also the grey area that this project is still the intellectual property of cYo (Markus Eisenstöck), so if he would give signs of life (with proof) and require that this project be taken down, I will acknowledge his request.
 
 So in the spirit of reviving this program for the community, I decided to release the decompiled I had. I really want this to be a Community Edition. By the Community for the Community. Although no License can prevent Commercial Use, I really don't want someone rebranding it as their own and selling it, that would be really bad.
 
 I want to temper expectations, don't expect some sweeping changes, like a complete rewrite of all the program and UI. There are plenty of things that needs doing, but don't just expect for me to do them all. I am also just a hobbyist programmer and can understand most of the code with enough time to follow it. If you really want a new feature, than I suggest that the best is to try to implement it yourself. This is why it's called Community Edition, because it should be a work by and for the community. This is very much a work in progress, and please expect update very often.
 
-For anyone that wants to cooperate, start by opening a Issue in the tracker so we can all know what you are working on. There is also a discussion are here on Github you can use. I would start by doing some Pull Request. I would ask that you keep your commit small and just to 1 change. Not commits like "changed stuff" with changes to 150 files. This is a BIG code base, so knowing what you changed easily is important. You can have multiple commits for 1 PR.
+For anyone that wants to cooperate, start by opening a Issue in the tracker so we can all know what you are working on. There is also a discussion are here on GitHub you can use. I would start by doing some Pull Request. I would ask that you keep your commit small and just to 1 change. Not commits like "changed stuff" with changes to 150 files. This is a BIG code base, so knowing what you changed easily is important. You can have multiple commits for 1 PR.
 
 Also for all the ChatGPT fans out there, it can be helpful, but in small snippets of code. Don't expect it to rewrite the whole program for you. And if you want to understand what does what, then just use the debugging function of Visual Studio. Speaking of please stick to Visual Studio 2022 Community Edition. VS Code isn't at the same level (but that is your choice).
 
@@ -44,7 +44,7 @@ See the current changelog [here.](https://raw.githubusercontent.com/maforget/Com
 
 ## Installation
 
-To install, download the [nightly installer](https://github.com/maforget/ComicRackCE/releases/download/nightly/ComicRackCESetup_nightly.exe "Nightly Release"), doublie-click the installer provided and follow the instructions. When using the installer, I highly suggest you uninstall the original ComicRack before installing the Community Edition. It will prevent duplicates with the Open With menu. It will still work correctly even if you have both together.
+To install, download the [nightly installer](https://github.com/maforget/ComicRackCE/releases/download/nightly/ComicRackCESetup_nightly.exe "Nightly Release"), double-click the installer provided and follow the instructions. When using the installer, I highly suggest you uninstall the original ComicRack before installing the Community Edition. It will prevent duplicates with the Open With menu. It will still work correctly even if you have both together.
 
 ## Upgrading from classic ComicRack
 


### PR DESCRIPTION
When testing the installer on a bare Windows 7 SP1, I realized I made a mistake in `Format()`. I also noticed a couple of misspellings in the README.