### PR TITLE
NEW FEATURE: Virtual TAGS #4

### DIFF
--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -201,7 +201,7 @@ namespace cYo.Projects.ComicRack.Engine
 
 		private static Dictionary<string, CultureInfo> languages;
 
-		public static readonly ComicBook Default;
+        public static readonly ComicBook Default;
 
 		private static readonly Dictionary<string, string> hasAsText;
 
@@ -912,6 +912,7 @@ namespace cYo.Projects.ComicRack.Engine
 			}
 		}
 
+		//TODO: check to update Caption to a Virtual Tag
 		[Browsable(true)]
 		public string Caption => GetFullTitle(EngineConfiguration.Default.ComicCaptionFormat);
 
@@ -1597,7 +1598,48 @@ namespace cYo.Projects.ComicRack.Engine
 
 		public static event EventHandler<ParseFilePathEventArgs> ParseFilePath;
 
-		static ComicBook()
+        private void UpdateVirtualTags(object sender, EventArgs e)
+        {
+			for (int i = 1; i <= 10; i++)
+			{
+				string prop = $"VirtualTag{i:00}";
+				SetValue(prop, GetFullTitle(VirtualTagsCollection.Tags.GetValue(i)?.CaptionFormat));
+            }
+        }
+
+        [Browsable(true)]
+		[DefaultValue("")]
+		public string VirtualTag01 { get; set; }
+        [Browsable(true)]
+        [DefaultValue("")]
+        public string VirtualTag02 { get; set; }
+        [Browsable(true)]
+        [DefaultValue("")]
+        public string VirtualTag03 { get; set; }
+        [Browsable(true)]
+        [DefaultValue("")]
+        public string VirtualTag04 { get; set; }
+        [Browsable(true)]
+        [DefaultValue("")]
+        public string VirtualTag05 { get; set; }
+        [Browsable(true)]
+        [DefaultValue("")]
+        public string VirtualTag06 { get; set; }
+        [Browsable(true)]
+        [DefaultValue("")]
+        public string VirtualTag07 { get; set; }
+        [Browsable(true)]
+        [DefaultValue("")]
+        public string VirtualTag08 { get; set; }
+        [Browsable(true)]
+        [DefaultValue("")]
+        public string VirtualTag09 { get; set; }
+        [Browsable(true)]
+        [DefaultValue("")]
+        public string VirtualTag10 { get; set; }
+        [DefaultValue("")]
+
+        static ComicBook()
 		{
 			GuidEquality = new Equality<ComicBook>((ComicBook a, ComicBook b) => a.Id == b.Id, (ComicBook a) => a.Id.GetHashCode());
 			EnableGroupNameCompression = false;
@@ -1637,9 +1679,10 @@ namespace cYo.Projects.ComicRack.Engine
 
 		public ComicBook()
 		{
-		}
+            VirtualTagsCollection.TagsRefresh += UpdateVirtualTags;
+        }
 
-		public ComicBook(ComicBook cb)
+        public ComicBook(ComicBook cb)
 		{
 			CopyFrom(cb);
 			if (cb.CreateComicProvider != null)
@@ -1650,9 +1693,10 @@ namespace cYo.Projects.ComicRack.Engine
 			{
 				ComicProviderCreated += cb.ComicProviderCreated;
 			}
-		}
+            VirtualTagsCollection.TagsRefresh += UpdateVirtualTags;
+        }
 
-		public static ComicBook Create(string file, RefreshInfoOptions options)
+        public static ComicBook Create(string file, RefreshInfoOptions options)
 		{
 			ComicBook comicBook = new ComicBook
 			{
@@ -2657,7 +2701,7 @@ namespace cYo.Projects.ComicRack.Engine
 
 		public static IEnumerable<string> GetProperties(bool onlyWritable, Type t = null)
 		{
-			return from pi in typeof(ComicBook).GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            return from pi in typeof(ComicBook).GetProperties(BindingFlags.Instance | BindingFlags.Public)
 				where pi.CanRead && (pi.CanWrite || !onlyWritable) && (t == null || pi.PropertyType == t) && pi.Browsable(forced: true)
 				select pi.Name;
 		}

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -1598,12 +1598,16 @@ namespace cYo.Projects.ComicRack.Engine
 
 		public static event EventHandler<ParseFilePathEventArgs> ParseFilePath;
 
-        private void UpdateVirtualTags()
+        private void UpdateVirtualTags(bool skip = false)
         {
+			//Skip is used to prevent a recursive loop, because updating the SetValue would call Update, which calls SetValue and so forth.
+			if (skip)
+				return;
+
 			for (int i = 1; i <= 10; i++)
 			{
 				string prop = $"VirtualTag{i:00}";
-				SetValue(prop, GetFullTitle(VirtualTagsCollection.Tags.GetValue(i)?.CaptionFormat));
+				SetValue(prop, GetFullTitle(VirtualTagsCollection.Tags.GetValue(i)?.CaptionFormat), true);
             }
         }
 
@@ -2180,11 +2184,15 @@ namespace cYo.Projects.ComicRack.Engine
 			}
 		}
 
-		public void SetValue(string propertyName, object value)
+		public void SetValue(string propertyName, object value, bool skipUpdateTags = false)
 		{
 			try
 			{
 				GetType().GetProperty(propertyName).SetValue(this, value, null);
+
+                //Skip is used to prevent a recursive loop, because updating the SetValue would call Update, which calls SetValue and so forth.
+				if (skipUpdateTags == false)
+					UpdateVirtualTags(skipUpdateTags);
 			}
 			catch (Exception)
 			{

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -1607,37 +1607,55 @@ namespace cYo.Projects.ComicRack.Engine
             }
         }
 
+        [XmlIgnore]
         [Browsable(true)]
 		[DefaultValue("")]
 		public string VirtualTag01 { get; set; }
+
+        [XmlIgnore]
         [Browsable(true)]
         [DefaultValue("")]
         public string VirtualTag02 { get; set; }
+
+        [XmlIgnore]
         [Browsable(true)]
         [DefaultValue("")]
         public string VirtualTag03 { get; set; }
+
+        [XmlIgnore]
         [Browsable(true)]
         [DefaultValue("")]
         public string VirtualTag04 { get; set; }
+
+        [XmlIgnore]
         [Browsable(true)]
         [DefaultValue("")]
         public string VirtualTag05 { get; set; }
+
+        [XmlIgnore]
         [Browsable(true)]
         [DefaultValue("")]
         public string VirtualTag06 { get; set; }
+
+        [XmlIgnore]
         [Browsable(true)]
         [DefaultValue("")]
         public string VirtualTag07 { get; set; }
+
+        [XmlIgnore]
         [Browsable(true)]
         [DefaultValue("")]
         public string VirtualTag08 { get; set; }
+
+        [XmlIgnore]
         [Browsable(true)]
         [DefaultValue("")]
         public string VirtualTag09 { get; set; }
+
+        [XmlIgnore]
         [Browsable(true)]
         [DefaultValue("")]
         public string VirtualTag10 { get; set; }
-        [DefaultValue("")]
 
         static ComicBook()
 		{

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -28,2791 +28,2771 @@ using cYo.Projects.ComicRack.Engine.Sync;
 
 namespace cYo.Projects.ComicRack.Engine
 {
-	[Serializable]
-	[ComVisible(true)]
-	public class ComicBook : ComicInfo, IImageKeyProvider, ICloneable
-	{
-		private class ComicTextNumberFloat : TextNumberFloat
-		{
-			public ComicTextNumberFloat(string text)
-				: base(text)
-			{
-			}
+    [Serializable]
+    [ComVisible(true)]
+    public class ComicBook : ComicInfo, IImageKeyProvider, ICloneable
+    {
+        private class ComicTextNumberFloat : TextNumberFloat
+        {
+            public ComicTextNumberFloat(string text)
+                : base(text)
+            {
+            }
 
-			protected override void OnParseText(string s)
-			{
-				if (s == "1/2")
-				{
-					base.Number = 0.5f;
-				}
-				else
-				{
-					base.OnParseText(s);
-				}
-			}
-		}
+            protected override void OnParseText(string s)
+            {
+                if (s == "1/2")
+                {
+                    base.Number = 0.5f;
+                }
+                else
+                {
+                    base.OnParseText(s);
+                }
+            }
+        }
 
-		public class ParseFilePathEventArgs : EventArgs
-		{
-			private readonly string path;
+        public class ParseFilePathEventArgs : EventArgs
+        {
+            private readonly string path;
 
-			private readonly ComicNameInfo nameInfo;
+            private readonly ComicNameInfo nameInfo;
 
-			public string Path => path;
+            public string Path => path;
 
-			public ComicNameInfo NameInfo => nameInfo;
+            public ComicNameInfo NameInfo => nameInfo;
 
-			public ParseFilePathEventArgs(string path)
-			{
-				this.path = path;
-				nameInfo = ComicNameInfo.FromFilePath(path);
-			}
-		}
+            public ParseFilePathEventArgs(string path)
+            {
+                this.path = path;
+                nameInfo = ComicNameInfo.FromFilePath(path);
+            }
+        }
 
-		public const int ReadPercentageAsRead = 95;
+        public const int ReadPercentageAsRead = 95;
 
-		public const string ClipboardFormat = "ComicBook";
+        public const string ClipboardFormat = "ComicBook";
 
-		public const string DefaultCaptionFormat = "[{format} ][{series}][ {volume}][ #{number}][ - {title}][ ({year}[/{month}[/{day}]])]";
+        public const string DefaultCaptionFormat = "[{format} ][{series}][ {volume}][ #{number}][ - {title}][ ({year}[/{month}[/{day}]])]";
 
-		public const string DefaultAlternateCaptionFormat = "[{alternateseries}][ #{alternatenumber}]";
+        public const string DefaultAlternateCaptionFormat = "[{alternateseries}][ #{alternatenumber}]";
 
-		public const string DefaultComicExportFileNameFormat = "[{format} ][{series}][ {volume}][ #{number}][ ({year}[/{month}])]";
+        public const string DefaultComicExportFileNameFormat = "[{format} ][{series}][ {volume}][ #{number}][ ({year}[/{month}])]";
 
-		public static readonly Equality<ComicBook> GuidEquality;
+        public static readonly Equality<ComicBook> GuidEquality;
 
-		public static bool EnableGroupNameCompression;
+        public static bool EnableGroupNameCompression;
 
-		private static TR tr;
+        private static TR tr;
 
-		private static readonly Lazy<string> unkownText;
+        private static readonly Lazy<string> unkownText;
 
-		private static readonly Lazy<string> pagesText;
+        private static readonly Lazy<string> pagesText;
 
-		private static readonly Lazy<string> lastTimeOpenedAtText;
+        private static readonly Lazy<string> lastTimeOpenedAtText;
 
-		private static readonly Lazy<string> readingAtPageText;
+        private static readonly Lazy<string> readingAtPageText;
 
-		private static readonly Lazy<string> lastPageReadIsText;
+        private static readonly Lazy<string> lastPageReadIsText;
 
-		private static readonly Lazy<string> noneText;
+        private static readonly Lazy<string> noneText;
 
-		private static readonly Lazy<string> notFoundText;
+        private static readonly Lazy<string> notFoundText;
 
-		private static readonly Lazy<string> neverText;
+        private static readonly Lazy<string> neverText;
 
-		private static readonly Lazy<string> volumeFormat;
+        private static readonly Lazy<string> volumeFormat;
 
-		private static readonly Lazy<string> ofText;
+        private static readonly Lazy<string> ofText;
 
-		[NonSerialized]
-		private volatile ComicBookContainer container;
+        [NonSerialized]
+        private volatile ComicBookContainer container;
 
-		private Guid id = Guid.NewGuid();
+        private Guid id = Guid.NewGuid();
 
-		private DateTime addedTime = DateTime.MinValue;
+        private DateTime addedTime = DateTime.MinValue;
 
-		private DateTime releasedTime = DateTime.MinValue;
+        private DateTime releasedTime = DateTime.MinValue;
 
-		private DateTime openedTime = DateTime.MinValue;
+        private DateTime openedTime = DateTime.MinValue;
 
-		private volatile int openCount;
+        private volatile int openCount;
 
-		private volatile int currentPage;
+        private volatile int currentPage;
 
-		private volatile int lastPage;
+        private volatile int lastPage;
 
-		private float rating;
+        private float rating;
 
-		private BitmapAdjustment colorAdjustment = BitmapAdjustment.Empty;
+        private BitmapAdjustment colorAdjustment = BitmapAdjustment.Empty;
 
-		private bool enableProposed = true;
+        private bool enableProposed = true;
 
-		private YesNo seriesComplete = YesNo.Unknown;
+        private YesNo seriesComplete = YesNo.Unknown;
 
-		private bool enableDynamicUpdate = true;
+        private bool enableDynamicUpdate = true;
 
-		private bool check = NewBooksChecked;
+        private bool check = NewBooksChecked;
 
-		[NonSerialized]
-		private volatile bool fileInfoRetrieved;
+        [NonSerialized]
+        private volatile bool fileInfoRetrieved;
 
-		private volatile bool comicInfoIsDirty;
+        private volatile bool comicInfoIsDirty;
 
-		private volatile string filePath = string.Empty;
+        private volatile string filePath = string.Empty;
 
-		private long fileSize = -1L;
+        private long fileSize = -1L;
 
-		private volatile bool fileIsMissing;
+        private volatile bool fileIsMissing;
 
-		private DateTime fileModifiedTime = DateTime.MinValue;
+        private DateTime fileModifiedTime = DateTime.MinValue;
 
-		private DateTime fileCreationTime = DateTime.MinValue;
+        private DateTime fileCreationTime = DateTime.MinValue;
 
-		private string customThumbnailKey;
+        private string customThumbnailKey;
 
-		private float bookPrice = -1f;
+        private float bookPrice = -1f;
 
-		private string bookAge = string.Empty;
+        private string bookAge = string.Empty;
 
-		private string bookCondition = string.Empty;
+        private string bookCondition = string.Empty;
 
-		private string bookStore = string.Empty;
+        private string bookStore = string.Empty;
 
-		private string bookOwner = string.Empty;
+        private string bookOwner = string.Empty;
 
-		private string bookCollectionStatus = string.Empty;
+        private string bookCollectionStatus = string.Empty;
 
-		private string bookNotes = string.Empty;
+        private string bookNotes = string.Empty;
 
-		private string bookLocation = string.Empty;
+        private string bookLocation = string.Empty;
 
-		private string isbn = string.Empty;
+        private string isbn = string.Empty;
 
-		private volatile string fileName;
+        private volatile string fileName;
 
-		private volatile string fileNameWithExtension;
+        private volatile string fileNameWithExtension;
 
-		private volatile string fileFormat;
+        private volatile string fileFormat;
 
-		private volatile string fileDirectory;
+        private volatile string fileDirectory;
 
-		private static readonly Calendar weekCalendar;
+        private static readonly Calendar weekCalendar;
 
-		private string fileLocation;
+        private string fileLocation;
 
-		private int newPages;
+        private int newPages;
 
-		private ComicNameInfo proposed;
+        private ComicNameInfo proposed;
 
-		[NonSerialized]
-		private TextNumberFloat compareNumber;
+        [NonSerialized]
+        private TextNumberFloat compareNumber;
 
-		[NonSerialized]
-		private TextNumberFloat compareAlternateNumber;
+        [NonSerialized]
+        private TextNumberFloat compareAlternateNumber;
 
-		private static readonly Dictionary<ComicBook, ExtraSyncInformation> syncInfo;
+        private static readonly Dictionary<ComicBook, ExtraSyncInformation> syncInfo;
 
-		private string customValuesStore = string.Empty;
+        private string customValuesStore = string.Empty;
 
-		private static HashSet<string> searchableProperties;
+        private static HashSet<string> searchableProperties;
 
-		private static readonly Regex rxField;
+        private static readonly Regex rxField;
 
-		private static Dictionary<string, CultureInfo> languages;
+        private static Dictionary<string, CultureInfo> languages;
 
         public static readonly ComicBook Default;
 
-		private static readonly Dictionary<string, string> hasAsText;
+        private static readonly Dictionary<string, string> hasAsText;
 
-		private static readonly ImagePackage publisherIcons;
+        private static readonly ImagePackage publisherIcons;
 
-		private static readonly ImagePackage ageRatingIcons;
+        private static readonly ImagePackage ageRatingIcons;
 
-		private static readonly ImagePackage formatIcons;
+        private static readonly ImagePackage formatIcons;
 
-		private static readonly ImagePackage specialIcons;
+        private static readonly ImagePackage specialIcons;
 
-		public static TR TR
-		{
-			get
-			{
-				if (tr == null)
-				{
-					tr = TR.Load("ComicBook");
-				}
-				return tr;
-			}
-		}
-
-		[XmlIgnore]
-		public ComicBookContainer Container
-		{
-			get
-			{
-				return container;
-			}
-			internal set
-			{
-				container = value;
-			}
-		}
-
-		[XmlAttribute]
-		public Guid Id
-		{
-			get
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					return id;
-				}
-			}
-			set
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					if (id == value)
-					{
-						return;
-					}
-					id = value;
-				}
-				FireBookChanged("Id");
-			}
-		}
-
-		[Browsable(true)]
-		[XmlElement("Added")]
-		[DefaultValue(typeof(DateTime), "01.01.0001")]
-		[ResetValue(1)]
-		public DateTime AddedTime
-		{
-			get
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					return addedTime;
-				}
-			}
-			set
-			{
-				SetProperty("AddedTime", ref addedTime, value, lockItem: true, !IsLinked);
-			}
-		}
-
-		[Browsable(true)]
-		[XmlElement("Released")]
-		[DefaultValue(typeof(DateTime), "01.01.0001")]
-		[ResetValue(1)]
-		public DateTime ReleasedTime
-		{
-			get
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					return releasedTime.DateOnly();
-				}
-			}
-			set
-			{
-				SetProperty("ReleasedTime", ref releasedTime, value, lockItem: true);
-			}
-		}
-
-		[Browsable(true)]
-		[XmlElement("Opened")]
-		[DefaultValue(typeof(DateTime), "01.01.0001")]
-		[ResetValue(1)]
-		public DateTime OpenedTime
-		{
-			get
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					return openedTime;
-				}
-			}
-			set
-			{
-				SetProperty("OpenedTime", ref openedTime, value, lockItem: true, !IsLinked);
-			}
-		}
-
-		[Browsable(true)]
-		[XmlElement("OpenCount")]
-		[DefaultValue(0)]
-		[ResetValue(1)]
-		public int OpenedCount
-		{
-			get
-			{
-				return openCount;
-			}
-			set
-			{
-				if (openCount != value)
-				{
-					openCount = value;
-					FireBookChanged("OpenedCount");
-				}
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue(0)]
-		[ResetValue(1)]
-		public int CurrentPage
-		{
-			get
-			{
-				return currentPage;
-			}
-			set
-			{
-				value = Math.Max(0, value);
-				if (currentPage != value)
-				{
-					currentPage = value;
-					FireBookChanged("CurrentPage");
-					if (currentPage > LastPageRead)
-					{
-						LastPageRead = value;
-					}
-				}
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue(0)]
-		[ResetValue(1)]
-		public int LastPageRead
-		{
-			get
-			{
-				return lastPage;
-			}
-			set
-			{
-				value = Math.Max(0, value);
-				if (lastPage != value)
-				{
-					lastPage = value;
-					FireBookChanged("LastPageRead");
-				}
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue(0)]
-		[ResetValue(0)]
-		public float Rating
-		{
-			get
-			{
-				return rating;
-			}
-			set
-			{
-				SetProperty("Rating", ref rating, value.Clamp(0f, 5f));
-			}
-		}
-
-		[DefaultValue(typeof(BitmapAdjustment), "Empty")]
-		public BitmapAdjustment ColorAdjustment
-		{
-			get
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					return colorAdjustment;
-				}
-			}
-			set
-			{
-				BitmapAdjustment bitmapAdjustment;
-				using (ItemMonitor.Lock(this))
-				{
-					if (colorAdjustment == value)
-					{
-						return;
-					}
-					bitmapAdjustment = colorAdjustment;
-					colorAdjustment = value;
-				}
-				FireBookChanged("ColorAdjustment", bitmapAdjustment, colorAdjustment);
-			}
-		}
-
-		public bool ColorAdjustmentSpecified => ColorAdjustment != BitmapAdjustment.Empty;
-
-		[Browsable(true)]
-		[DefaultValue(true)]
-		[ResetValue(0)]
-		public bool EnableProposed
-		{
-			get
-			{
-				return enableProposed;
-			}
-			set
-			{
-				SetProperty("EnableProposed", ref enableProposed, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue(YesNo.Unknown)]
-		[ResetValue(0)]
-		public YesNo SeriesComplete
-		{
-			get
-			{
-				return seriesComplete;
-			}
-			set
-			{
-				SetProperty("SeriesComplete", ref seriesComplete, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue(true)]
-		[ResetValue(1)]
-		public bool EnableDynamicUpdate
-		{
-			get
-			{
-				return enableDynamicUpdate;
-			}
-			set
-			{
-				SetProperty("EnableDynamicUpdate", ref enableDynamicUpdate, value);
-			}
-		}
-
-		public Guid LastOpenedFromListId
-		{
-			get;
-			set;
-		}
-
-		public bool LastOpenedFromListIdSpecified => LastOpenedFromListId != Guid.Empty;
-
-		[XmlAttribute]
-		[DefaultValue(true)]
-		public bool Checked
-		{
-			get
-			{
-				return check;
-			}
-			set
-			{
-				SetProperty("Checked", ref check, value);
-			}
-		}
-
-		[Browsable(true)]
-		[XmlIgnore]
-		public bool FileInfoRetrieved
-		{
-			get
-			{
-				return fileInfoRetrieved;
-			}
-			set
-			{
-				fileInfoRetrieved = value;
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue(false)]
-		public bool ComicInfoIsDirty
-		{
-			get
-			{
-				return comicInfoIsDirty;
-			}
-			set
-			{
-				if (comicInfoIsDirty != value)
-				{
-					comicInfoIsDirty = value;
-					FireBookChanged("ComicInfoIsDirty");
-				}
-			}
-		}
-
-		[Browsable(true)]
-		[XmlAttribute("File")]
-		[DefaultValue("")]
-		public string FilePath
-		{
-			get
-			{
-				return filePath;
-			}
-			set
-			{
-				if (value == null)
-				{
-					throw new ArgumentNullException();
-				}
-				if (!(filePath == value))
-				{
-					string text = FilePath;
-					filePath = value;
-					fileName = (fileNameWithExtension = (fileFormat = (fileDirectory = null)));
-					proposed = null;
-					FireBookChanged("FilePath", text, filePath);
-					if (!string.IsNullOrEmpty(text))
-					{
-						OnFileRenamed(new ComicBookFileRenameEventArgs(text, filePath));
-					}
-				}
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue(-1)]
-		public long FileSize
-		{
-			get
-			{
-				return Interlocked.Read(ref fileSize);
-			}
-			set
-			{
-				if (Interlocked.Read(ref fileSize) != value)
-				{
-					Interlocked.Exchange(ref fileSize, value);
-					FireBookChanged("FileSize");
-				}
-			}
-		}
-
-		[Browsable(true)]
-		[XmlElement("Missing")]
-		[DefaultValue(false)]
-		public bool FileIsMissing
-		{
-			get
-			{
-				return fileIsMissing;
-			}
-			set
-			{
-				if (fileIsMissing != value)
-				{
-					fileIsMissing = value;
-					FireBookChanged("FileIsMissing");
-				}
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue(typeof(DateTime), "01.01.0001")]
-		public DateTime FileModifiedTime
-		{
-			get
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					return fileModifiedTime;
-				}
-			}
-			set
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					if (fileModifiedTime == value)
-					{
-						return;
-					}
-					fileModifiedTime = value;
-				}
-				FireBookChanged("FileModifiedTime");
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue(typeof(DateTime), "01.01.0001")]
-		public DateTime FileCreationTime
-		{
-			get
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					return fileCreationTime;
-				}
-			}
-			set
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					if (fileCreationTime == value)
-					{
-						return;
-					}
-					fileCreationTime = value;
-				}
-				FireBookChanged("FileCreationTime");
-			}
-		}
-
-		[DefaultValue(null)]
-		[ResetValue(0)]
-		public string CustomThumbnailKey
-		{
-			get
-			{
-				return customThumbnailKey;
-			}
-			set
-			{
-				if (!(customThumbnailKey == value))
-				{
-					customThumbnailKey = value;
-					FireBookChanged("CustomThumbnailKey");
-				}
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue(-1f)]
-		[ResetValue(0)]
-		public float BookPrice
-		{
-			get
-			{
-				return bookPrice;
-			}
-			set
-			{
-				SetProperty("BookPrice", ref bookPrice, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string BookAge
-		{
-			get
-			{
-				return bookAge;
-			}
-			set
-			{
-				SetProperty("BookAge", ref bookAge, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string BookCondition
-		{
-			get
-			{
-				return bookCondition;
-			}
-			set
-			{
-				SetProperty("BookCondition", ref bookCondition, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string BookStore
-		{
-			get
-			{
-				return bookStore;
-			}
-			set
-			{
-				SetProperty("BookStore", ref bookStore, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string BookOwner
-		{
-			get
-			{
-				return bookOwner;
-			}
-			set
-			{
-				SetProperty("BookOwner", ref bookOwner, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string BookCollectionStatus
-		{
-			get
-			{
-				return bookCollectionStatus;
-			}
-			set
-			{
-				SetProperty("BookCollectionStatus", ref bookCollectionStatus, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string BookNotes
-		{
-			get
-			{
-				return bookNotes;
-			}
-			set
-			{
-				SetProperty("BookNotes", ref bookNotes, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string BookLocation
-		{
-			get
-			{
-				return bookLocation;
-			}
-			set
-			{
-				SetProperty("BookLocation", ref bookLocation, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string ISBN
-		{
-			get
-			{
-				return isbn;
-			}
-			set
-			{
-				SetProperty("ISBN", ref isbn, value);
-			}
-		}
-
-		[XmlIgnore]
-		public string PagesAsTextSimple
-		{
-			get
-			{
-				if (base.PageCount > 0)
-				{
-					return base.PageCount.ToString();
-				}
-				return "-";
-			}
-			set
-			{
-				if (int.TryParse(value, out var result) && result >= 0)
-				{
-					base.PageCount = result;
-				}
-			}
-		}
-
-		[Browsable(true)]
-		public string FileName
-		{
-			get
-			{
-				if (fileName != null)
-				{
-					return fileName;
-				}
-				try
-				{
-					fileName = Path.GetFileNameWithoutExtension(filePath);
-				}
-				catch (Exception)
-				{
-					fileName = string.Empty;
-				}
-				return fileName;
-			}
-		}
-
-		[Browsable(true)]
-		public string FileNameWithExtension
-		{
-			get
-			{
-				if (fileNameWithExtension != null)
-				{
-					return fileNameWithExtension;
-				}
-				try
-				{
-					fileNameWithExtension = Path.GetFileName(filePath);
-				}
-				catch (Exception)
-				{
-					fileNameWithExtension = string.Empty;
-				}
-				return fileNameWithExtension;
-			}
-		}
-
-		[Browsable(true)]
-		public string FileFormat
-		{
-			get
-			{
-				if (fileFormat != null)
-				{
-					return fileFormat;
-				}
-				try
-				{
-					fileFormat = Providers.Readers.GetSourceFormatName(filePath);
-				}
-				catch (Exception)
-				{
-					fileFormat = string.Empty;
-				}
-				return fileFormat;
-			}
-		}
-
-		[Browsable(true)]
-		public string FileDirectory
-		{
-			get
-			{
-				if (fileDirectory != null)
-				{
-					return fileDirectory;
-				}
-				try
-				{
-					fileDirectory = Path.GetDirectoryName(filePath);
-				}
-				catch (Exception)
-				{
-					fileDirectory = string.Empty;
-				}
-				return fileDirectory;
-			}
-		}
-
-		[Browsable(true)]
-		public bool IsValidComicBook
-		{
-			get
-			{
-				if (!string.IsNullOrEmpty(FilePath))
-				{
-					return Providers.Readers.GetSourceProviderType(FilePath) != null;
-				}
-				return false;
-			}
-		}
-
-		//TODO: check to update Caption to a Virtual Tag
-		[Browsable(true)]
-		public string Caption => GetFullTitle(EngineConfiguration.Default.ComicCaptionFormat);
-
-		[Browsable(true)]
-		public string CaptionWithoutTitle => GetFullTitle(EngineConfiguration.Default.ComicCaptionFormat, "title");
-
-		[Browsable(true)]
-		public string CaptionWithoutFormat => GetFullTitle(EngineConfiguration.Default.ComicCaptionFormat, "format");
-
-		[Browsable(true)]
-		public string AlternateCaption => GetFullTitle(DefaultAlternateCaptionFormat);
-
-		public string TargetFilename => GetFullTitle(EngineConfiguration.Default.ComicExportFileNameFormat);
-
-		[Browsable(true)]
-		public int ReadPercentage
-		{
-			get
-			{
-				if (base.PageCount <= 0 || LastPageRead <= 0)
-				{
-					return 0;
-				}
-				return ((LastPageRead + 1) * 100 / base.PageCount).Clamp(1, 100);
-			}
-		}
-
-		public string ReadPercentageAsText => $"{ReadPercentage}%";
-
-		[Browsable(true)]
-		public bool HasBeenOpened => OpenedTime != DateTime.MinValue;
-
-		[Browsable(true)]
-		[XmlIgnore]
-		public bool HasBeenRead
-		{
-			get
-			{
-				return ReadPercentage >= ReadPercentageAsRead;
-			}
-			set
-			{
-				if (value)
-				{
-					MarkAsRead();
-				}
-				else
-				{
-					MarkAsNotRead();
-				}
-			}
-		}
-
-		public string PagesAsText => FormatPages(base.PageCount);
-
-		public string OpenedCountAsText => OpenedCount.ToString();
-
-		public string InfoText
-		{
-			get
-			{
-				StringBuilder stringBuilder = new StringBuilder();
-				stringBuilder.AppendFormat("{0}\n", FileName);
-				stringBuilder.AppendFormat("{0} ({1})\n\n", FileSizeAsText, PagesAsText);
-				stringBuilder.AppendFormat("{0}\n", FileFormat);
-				stringBuilder.AppendFormat("{0}\n\n", FileDirectory);
-				stringBuilder.Append(StringUtility.Format(lastTimeOpenedAtText.Value, OpenedTimeAsText));
-				stringBuilder.AppendLine();
-				stringBuilder.Append(StringUtility.Format(readingAtPageText.Value, CurrentPage + 1));
-				stringBuilder.AppendLine();
-				stringBuilder.Append(StringUtility.Format(lastPageReadIsText.Value, LastPageRead + 1));
-				return stringBuilder.ToString();
-			}
-		}
-
-		public string NumberAsText => FormatNumber(base.Number, ShadowCount);
-
-		public string NumberOnly => ShadowNumber;
-
-		public string AlternateNumberAsText => FormatNumber(base.AlternateNumber, base.AlternateCount);
-
-		public string VolumeAsText => FormatVolume(base.Volume);
-
-		public string VolumeOnly
-		{
-			get
-			{
-				if (base.Volume >= 0)
-				{
-					return base.Volume.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public string LastPageReadAsText
-		{
-			get
-			{
-				if (LastPageRead > 0)
-				{
-					return (LastPageRead + 1).ToString();
-				}
-				return noneText.Value;
-			}
-		}
-
-		public string LanguageAsText
-		{
-			get
-			{
-				if (!string.IsNullOrEmpty(base.LanguageISO))
-				{
-					return GetLanguageName(base.LanguageISO);
-				}
-				return string.Empty;
-			}
-		}
-
-		public string ArtistInfo
-		{
-			get
-			{
-				StringBuilder stringBuilder = new StringBuilder(base.Writer);
-				AppendString(stringBuilder, "/", base.Penciller);
-				AppendString(stringBuilder, "/", base.Inker);
-				AppendString(stringBuilder, "/", base.Colorist);
-				AppendString(stringBuilder, "/", base.Letterer);
-				AppendString(stringBuilder, "/", base.CoverArtist);
-				return stringBuilder.ToString();
-			}
-		}
-
-		public string YearAsText => FormatYear(base.Year);
-
-		public string MonthAsText
-		{
-			get
-			{
-				if (base.Month != -1)
-				{
-					return base.Month.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public string DayAsText
-		{
-			get
-			{
-				if (base.Day != -1)
-				{
-					return base.Day.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public int Week
-		{
-			get
-			{
-				DateTime published = Published;
-				if (published == DateTime.MinValue)
-				{
-					return -1;
-				}
-				return weekCalendar.GetWeekOfYear(published, CalendarWeekRule.FirstDay, DayOfWeek.Monday);
-			}
-		}
-
-		public string WeekAsText
-		{
-			get
-			{
-				int week = Week;
-				if (week != -1)
-				{
-					return week.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public string PublishedAsText
-		{
-			get
-			{
-				string shadowYearAsText = ShadowYearAsText;
-				string text = string.Empty;
-				if (!string.IsNullOrEmpty(shadowYearAsText))
-				{
-					string monthAsText = MonthAsText;
-					if (!string.IsNullOrEmpty(monthAsText))
-					{
-						string dayAsText = DayAsText;
-						if (!string.IsNullOrEmpty(dayAsText))
-						{
-							text = text + dayAsText + "/";
-						}
-						text = text + monthAsText + "/";
-					}
-					text += shadowYearAsText;
-				}
-				return text;
-			}
-		}
-
-		public DateTime Published
-		{
-			get
-			{
-				if (ShadowYear <= 0)
-				{
-					return DateTime.MinValue;
-				}
-				int year = ShadowYear.Clamp(1, 10000);
-				int month = base.Month.Clamp(1, 12);
-				int day = base.Day.Clamp(1, DateTime.DaysInMonth(year, month));
-				return new DateTime(year, month, day);
-			}
-		}
-
-		public string CountAsText
-		{
-			get
-			{
-				if (base.Count != -1)
-				{
-					return base.Count.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public string NewPagesAsText
-		{
-			get
-			{
-				if (!IsDynamicSource || NewPages <= 0)
-				{
-					return string.Empty;
-				}
-				return NewPages.ToString();
-			}
-		}
-
-		public string AlternateCountAsText
-		{
-			get
-			{
-				if (base.AlternateCount != -1)
-				{
-					return base.AlternateCount.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public string RatingAsText => FormatRating(Rating);
-
-		public string CommunityRatingAsText => FormatRating(base.CommunityRating);
-
-		public string CoverAsText => ComicInfo.GetYesNoAsText((base.FrontCoverCount != 0) ? YesNo.Yes : YesNo.No);
-
-		public string FileSizeAsText
-		{
-			get
-			{
-				long num = FileSize;
-				if (num == -1)
-				{
-					return notFoundText.Value;
-				}
-				return string.Format(new FileLengthFormat(), "{0}", new object[1]
-				{
-					num
-				});
-			}
-		}
-
-		public string MangaAsText => ComicInfo.GetYesNoAsText(base.Manga);
-
-		public string SeriesCompleteAsText => ComicInfo.GetYesNoAsText(SeriesComplete);
-
-		public string EnableProposedAsText => ComicInfo.GetYesNoAsText(EnableProposed ? YesNo.Yes : YesNo.No);
-
-		public string HasBeenReadAsText => ComicInfo.GetYesNoAsText(HasBeenRead ? YesNo.Yes : YesNo.No);
-
-		public string IsLinkedAsText => ComicInfo.GetYesNoAsText(IsLinked);
-
-		public string BlackAndWhiteAsText => ComicInfo.GetYesNoAsText(base.BlackAndWhite);
-
-		public string BookmarkCountAsText
-		{
-			get
-			{
-				if (base.BookmarkCount > 0)
-				{
-					return base.BookmarkCount.ToString();
-				}
-				return noneText.Value;
-			}
-		}
-
-		public ComicPageInfo CurrentPageInfo => GetPage(CurrentPage);
-
-		public string FileLocation
-		{
-			get
-			{
-				if (!string.IsNullOrEmpty(fileLocation))
-				{
-					return fileLocation;
-				}
-				return FilePath;
-			}
-		}
-
-		public string DisplayFileLocation
-		{
-			get
-			{
-				if (!IsInContainer)
-				{
-					return FilePath;
-				}
-				return Caption;
-			}
-		}
-
-		public int Status
-		{
-			get
-			{
-				int num = 0;
-				if (FileIsMissing && IsLinked)
-				{
-					num |= 1;
-				}
-				if (ComicInfoIsDirty)
-				{
-					num |= 2;
-				}
-				return num;
-			}
-		}
-
-		[Browsable(true)]
-		public bool IsLinked => !string.IsNullOrEmpty(filePath);
-
-		[XmlIgnore]
-		public string BookPriceAsText
-		{
-			get
-			{
-				if (!(bookPrice < 0f))
-				{
-					return $"{bookPrice:0.00}";
-				}
-				return unkownText.Value;
-			}
-			set
-			{
-				if (float.TryParse(value, out var result))
-				{
-					BookPrice = result;
-				}
-				else
-				{
-					BookPrice = -1f;
-				}
-			}
-		}
-
-		public string OpenedTimeAsText => FormatDate(OpenedTime);
-
-		public string AddedTimeAsText => FormatDate(AddedTime, ComicDateFormat.Long, toLocal: false, unkownText.Value);
-
-		public string ReleasedTimeAsText => FormatDate(ReleasedTime, ComicDateFormat.Short, toLocal: false, unkownText.Value);
-
-		public string FileCreationTimeAsText => FormatFileDate(FileCreationTime);
-
-		public string FileModifiedTimeAsText => FormatFileDate(FileModifiedTime);
-
-		public bool IsInContainer => container != null;
-
-		public ComicsEditModes EditMode
-		{
-			get
-			{
-				if (!IsInContainer)
-				{
-					return ComicsEditModes.Default;
-				}
-				return Container.EditMode;
-			}
-		}
-
-		[DefaultValue(false)]
-		[XmlAttribute]
-		public bool IsDynamicSource
-		{
-			get;
-			set;
-		}
-
-		[DefaultValue(0)]
-		public int NewPages
-		{
-			get
-			{
-				return newPages;
-			}
-			set
-			{
-				SetProperty("NewPages", ref newPages, value);
-			}
-		}
-
-		public string ProposedSeries
-		{
-			get
-			{
-				UpdateProposed();
-				return proposed.Series;
-			}
-		}
-
-		public string ProposedTitle
-		{
-			get
-			{
-				UpdateProposed();
-				return proposed.Title;
-			}
-		}
-
-		public string ProposedFormat
-		{
-			get
-			{
-				UpdateProposed();
-				return proposed.Format;
-			}
-		}
-
-		public int ProposedVolume
-		{
-			get
-			{
-				UpdateProposed();
-				return proposed.Volume;
-			}
-		}
-
-		public string ProposedNumber
-		{
-			get
-			{
-				UpdateProposed();
-				if (!(base.Number == "-"))
-				{
-					return proposed.Number;
-				}
-				return string.Empty;
-			}
-		}
-
-		public int ProposedCount
-		{
-			get
-			{
-				UpdateProposed();
-				return proposed.Count;
-			}
-		}
-
-		public int ProposedYear
-		{
-			get
-			{
-				UpdateProposed();
-				return proposed.Year;
-			}
-		}
-
-		public string ProposedYearAsText => FormatYear(ProposedYear);
-
-		public string ProposedNumberAsText => FormatNumber(ProposedNumber, ProposedCount);
-
-		public string ProposedVolumeAsText => FormatVolume(ProposedVolume);
-
-		public string ProposedNakedVolumeAsText
-		{
-			get
-			{
-				if (ProposedVolume != -1)
-				{
-					return ProposedVolume.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public string ProposedCountAsText
-		{
-			get
-			{
-				if (ProposedCount != -1)
-				{
-					return ProposedCount.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public string ShadowSeries
-		{
-			get
-			{
-				if (!EnableProposed || !string.IsNullOrEmpty(base.Series))
-				{
-					return base.Series;
-				}
-				return ProposedSeries;
-			}
-		}
-
-		public string ShadowTitle
-		{
-			get
-			{
-				if (!EnableProposed || !string.IsNullOrEmpty(base.Title))
-				{
-					return base.Title;
-				}
-				return ProposedTitle;
-			}
-		}
-
-		public string ShadowFormat
-		{
-			get
-			{
-				if (!EnableProposed || !string.IsNullOrEmpty(base.Format))
-				{
-					return base.Format;
-				}
-				return ProposedFormat;
-			}
-		}
-
-		public int ShadowVolume
-		{
-			get
-			{
-				if (!EnableProposed || base.Volume != -1)
-				{
-					return base.Volume;
-				}
-				return ProposedVolume;
-			}
-		}
-
-		public string ShadowNumber
-		{
-			get
-			{
-				if (!EnableProposed || !string.IsNullOrEmpty(base.Number))
-				{
-					return base.Number;
-				}
-				return ProposedNumber;
-			}
-		}
-
-		public int ShadowCount
-		{
-			get
-			{
-				if (!EnableProposed || base.Count != -1)
-				{
-					return base.Count;
-				}
-				return ProposedCount;
-			}
-		}
-
-		public int ShadowYear
-		{
-			get
-			{
-				if (!EnableProposed || base.Year != -1)
-				{
-					return base.Year;
-				}
-				return ProposedYear;
-			}
-		}
-
-		[Browsable(true)]
-		public string ShadowYearAsText => FormatYear(ShadowYear);
-
-		public string ShadowNumberAsText => FormatNumber(ShadowNumber, ShadowCount);
-
-		public string ShadowVolumeAsText => FormatVolume(ShadowVolume);
-
-		public string ShadowCountAsText
-		{
-			get
-			{
-				if (ShadowCount != -1)
-				{
-					return ShadowCount.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public TextNumberFloat CompareNumber => compareNumber ?? (compareNumber = new ComicTextNumberFloat(ShadowNumber));
-
-		public TextNumberFloat CompareAlternateNumber => compareAlternateNumber ?? (compareAlternateNumber = new ComicTextNumberFloat(base.AlternateNumber));
-
-		[DefaultValue(null)]
-		public ExtraSyncInformation ExtraSyncInformation
-		{
-			get
-			{
-				using (ItemMonitor.Lock(syncInfo))
-				{
-					ExtraSyncInformation value;
-					return syncInfo.TryGetValue(this, out value) ? value : null;
-				}
-			}
-			set
-			{
-				using (ItemMonitor.Lock(syncInfo))
-				{
-					syncInfo[this] = value;
-				}
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string CustomValuesStore
-		{
-			get
-			{
-				return customValuesStore;
-			}
-			set
-			{
-				SetProperty("CustomValuesStore", ref customValuesStore, value);
-			}
-		}
-
-		public static ImagePackage PublisherIcons => publisherIcons;
-
-		public static ImagePackage AgeRatingIcons => ageRatingIcons;
-
-		public static ImagePackage FormatIcons => formatIcons;
-
-		public static ImagePackage SpecialIcons => specialIcons;
-
-		public static bool NewBooksChecked
-		{
-			get;
-			set;
-		}
-
-		[field: NonSerialized]
-		public event EventHandler<ComicBookFileRenameEventArgs> FileRenamed;
-
-		[field: NonSerialized]
-		public event EventHandler<CreateComicProviderEventArgs> CreateComicProvider;
-
-		[field: NonSerialized]
-		public event EventHandler<CreateComicProviderEventArgs> ComicProviderCreated;
-
-		public static event EventHandler<ParseFilePathEventArgs> ParseFilePath;
-
-        private void UpdateVirtualTags(bool skip = false)
+        public static TR TR
         {
-			//Skip is used to prevent a recursive loop, because updating the SetValue would call Update, which calls SetValue and so forth.
-			if (skip)
-				return;
-
-			for (int i = 1; i <= 10; i++)
-			{
-				string prop = $"VirtualTag{i:00}";
-				SetValue(prop, GetFullTitle(VirtualTagsCollection.Tags.GetValue(i)?.CaptionFormat), true);
+            get
+            {
+                if (tr == null)
+                {
+                    tr = TR.Load("ComicBook");
+                }
+                return tr;
             }
         }
 
         [XmlIgnore]
+        public ComicBookContainer Container
+        {
+            get
+            {
+                return container;
+            }
+            internal set
+            {
+                container = value;
+            }
+        }
+
+        [XmlAttribute]
+        public Guid Id
+        {
+            get
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    return id;
+                }
+            }
+            set
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    if (id == value)
+                    {
+                        return;
+                    }
+                    id = value;
+                }
+                FireBookChanged("Id");
+            }
+        }
+
         [Browsable(true)]
-        public string VirtualTag01 { get; set; }
+        [XmlElement("Added")]
+        [DefaultValue(typeof(DateTime), "01.01.0001")]
+        [ResetValue(1)]
+        public DateTime AddedTime
+        {
+            get
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    return addedTime;
+                }
+            }
+            set
+            {
+                SetProperty("AddedTime", ref addedTime, value, lockItem: true, !IsLinked);
+            }
+        }
+
+        [Browsable(true)]
+        [XmlElement("Released")]
+        [DefaultValue(typeof(DateTime), "01.01.0001")]
+        [ResetValue(1)]
+        public DateTime ReleasedTime
+        {
+            get
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    return releasedTime.DateOnly();
+                }
+            }
+            set
+            {
+                SetProperty("ReleasedTime", ref releasedTime, value, lockItem: true);
+            }
+        }
+
+        [Browsable(true)]
+        [XmlElement("Opened")]
+        [DefaultValue(typeof(DateTime), "01.01.0001")]
+        [ResetValue(1)]
+        public DateTime OpenedTime
+        {
+            get
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    return openedTime;
+                }
+            }
+            set
+            {
+                SetProperty("OpenedTime", ref openedTime, value, lockItem: true, !IsLinked);
+            }
+        }
+
+        [Browsable(true)]
+        [XmlElement("OpenCount")]
+        [DefaultValue(0)]
+        [ResetValue(1)]
+        public int OpenedCount
+        {
+            get
+            {
+                return openCount;
+            }
+            set
+            {
+                if (openCount != value)
+                {
+                    openCount = value;
+                    FireBookChanged("OpenedCount");
+                }
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue(0)]
+        [ResetValue(1)]
+        public int CurrentPage
+        {
+            get
+            {
+                return currentPage;
+            }
+            set
+            {
+                value = Math.Max(0, value);
+                if (currentPage != value)
+                {
+                    currentPage = value;
+                    FireBookChanged("CurrentPage");
+                    if (currentPage > LastPageRead)
+                    {
+                        LastPageRead = value;
+                    }
+                }
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue(0)]
+        [ResetValue(1)]
+        public int LastPageRead
+        {
+            get
+            {
+                return lastPage;
+            }
+            set
+            {
+                value = Math.Max(0, value);
+                if (lastPage != value)
+                {
+                    lastPage = value;
+                    FireBookChanged("LastPageRead");
+                }
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue(0)]
+        [ResetValue(0)]
+        public float Rating
+        {
+            get
+            {
+                return rating;
+            }
+            set
+            {
+                SetProperty("Rating", ref rating, value.Clamp(0f, 5f));
+            }
+        }
+
+        [DefaultValue(typeof(BitmapAdjustment), "Empty")]
+        public BitmapAdjustment ColorAdjustment
+        {
+            get
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    return colorAdjustment;
+                }
+            }
+            set
+            {
+                BitmapAdjustment bitmapAdjustment;
+                using (ItemMonitor.Lock(this))
+                {
+                    if (colorAdjustment == value)
+                    {
+                        return;
+                    }
+                    bitmapAdjustment = colorAdjustment;
+                    colorAdjustment = value;
+                }
+                FireBookChanged("ColorAdjustment", bitmapAdjustment, colorAdjustment);
+            }
+        }
+
+        public bool ColorAdjustmentSpecified => ColorAdjustment != BitmapAdjustment.Empty;
+
+        [Browsable(true)]
+        [DefaultValue(true)]
+        [ResetValue(0)]
+        public bool EnableProposed
+        {
+            get
+            {
+                return enableProposed;
+            }
+            set
+            {
+                SetProperty("EnableProposed", ref enableProposed, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue(YesNo.Unknown)]
+        [ResetValue(0)]
+        public YesNo SeriesComplete
+        {
+            get
+            {
+                return seriesComplete;
+            }
+            set
+            {
+                SetProperty("SeriesComplete", ref seriesComplete, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue(true)]
+        [ResetValue(1)]
+        public bool EnableDynamicUpdate
+        {
+            get
+            {
+                return enableDynamicUpdate;
+            }
+            set
+            {
+                SetProperty("EnableDynamicUpdate", ref enableDynamicUpdate, value);
+            }
+        }
+
+        public Guid LastOpenedFromListId
+        {
+            get;
+            set;
+        }
+
+        public bool LastOpenedFromListIdSpecified => LastOpenedFromListId != Guid.Empty;
+
+        [XmlAttribute]
+        [DefaultValue(true)]
+        public bool Checked
+        {
+            get
+            {
+                return check;
+            }
+            set
+            {
+                SetProperty("Checked", ref check, value);
+            }
+        }
+
+        [Browsable(true)]
+        [XmlIgnore]
+        public bool FileInfoRetrieved
+        {
+            get
+            {
+                return fileInfoRetrieved;
+            }
+            set
+            {
+                fileInfoRetrieved = value;
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue(false)]
+        public bool ComicInfoIsDirty
+        {
+            get
+            {
+                return comicInfoIsDirty;
+            }
+            set
+            {
+                if (comicInfoIsDirty != value)
+                {
+                    comicInfoIsDirty = value;
+                    FireBookChanged("ComicInfoIsDirty");
+                }
+            }
+        }
+
+        [Browsable(true)]
+        [XmlAttribute("File")]
+        [DefaultValue("")]
+        public string FilePath
+        {
+            get
+            {
+                return filePath;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException();
+                }
+                if (!(filePath == value))
+                {
+                    string text = FilePath;
+                    filePath = value;
+                    fileName = (fileNameWithExtension = (fileFormat = (fileDirectory = null)));
+                    proposed = null;
+                    FireBookChanged("FilePath", text, filePath);
+                    if (!string.IsNullOrEmpty(text))
+                    {
+                        OnFileRenamed(new ComicBookFileRenameEventArgs(text, filePath));
+                    }
+                }
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue(-1)]
+        public long FileSize
+        {
+            get
+            {
+                return Interlocked.Read(ref fileSize);
+            }
+            set
+            {
+                if (Interlocked.Read(ref fileSize) != value)
+                {
+                    Interlocked.Exchange(ref fileSize, value);
+                    FireBookChanged("FileSize");
+                }
+            }
+        }
+
+        [Browsable(true)]
+        [XmlElement("Missing")]
+        [DefaultValue(false)]
+        public bool FileIsMissing
+        {
+            get
+            {
+                return fileIsMissing;
+            }
+            set
+            {
+                if (fileIsMissing != value)
+                {
+                    fileIsMissing = value;
+                    FireBookChanged("FileIsMissing");
+                }
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue(typeof(DateTime), "01.01.0001")]
+        public DateTime FileModifiedTime
+        {
+            get
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    return fileModifiedTime;
+                }
+            }
+            set
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    if (fileModifiedTime == value)
+                    {
+                        return;
+                    }
+                    fileModifiedTime = value;
+                }
+                FireBookChanged("FileModifiedTime");
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue(typeof(DateTime), "01.01.0001")]
+        public DateTime FileCreationTime
+        {
+            get
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    return fileCreationTime;
+                }
+            }
+            set
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    if (fileCreationTime == value)
+                    {
+                        return;
+                    }
+                    fileCreationTime = value;
+                }
+                FireBookChanged("FileCreationTime");
+            }
+        }
+
+        [DefaultValue(null)]
+        [ResetValue(0)]
+        public string CustomThumbnailKey
+        {
+            get
+            {
+                return customThumbnailKey;
+            }
+            set
+            {
+                if (!(customThumbnailKey == value))
+                {
+                    customThumbnailKey = value;
+                    FireBookChanged("CustomThumbnailKey");
+                }
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue(-1f)]
+        [ResetValue(0)]
+        public float BookPrice
+        {
+            get
+            {
+                return bookPrice;
+            }
+            set
+            {
+                SetProperty("BookPrice", ref bookPrice, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string BookAge
+        {
+            get
+            {
+                return bookAge;
+            }
+            set
+            {
+                SetProperty("BookAge", ref bookAge, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string BookCondition
+        {
+            get
+            {
+                return bookCondition;
+            }
+            set
+            {
+                SetProperty("BookCondition", ref bookCondition, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string BookStore
+        {
+            get
+            {
+                return bookStore;
+            }
+            set
+            {
+                SetProperty("BookStore", ref bookStore, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string BookOwner
+        {
+            get
+            {
+                return bookOwner;
+            }
+            set
+            {
+                SetProperty("BookOwner", ref bookOwner, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string BookCollectionStatus
+        {
+            get
+            {
+                return bookCollectionStatus;
+            }
+            set
+            {
+                SetProperty("BookCollectionStatus", ref bookCollectionStatus, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string BookNotes
+        {
+            get
+            {
+                return bookNotes;
+            }
+            set
+            {
+                SetProperty("BookNotes", ref bookNotes, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string BookLocation
+        {
+            get
+            {
+                return bookLocation;
+            }
+            set
+            {
+                SetProperty("BookLocation", ref bookLocation, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string ISBN
+        {
+            get
+            {
+                return isbn;
+            }
+            set
+            {
+                SetProperty("ISBN", ref isbn, value);
+            }
+        }
 
         [XmlIgnore]
+        public string PagesAsTextSimple
+        {
+            get
+            {
+                if (base.PageCount > 0)
+                {
+                    return base.PageCount.ToString();
+                }
+                return "-";
+            }
+            set
+            {
+                if (int.TryParse(value, out var result) && result >= 0)
+                {
+                    base.PageCount = result;
+                }
+            }
+        }
+
         [Browsable(true)]
-        public string VirtualTag02 { get; set; }
+        public string FileName
+        {
+            get
+            {
+                if (fileName != null)
+                {
+                    return fileName;
+                }
+                try
+                {
+                    fileName = Path.GetFileNameWithoutExtension(filePath);
+                }
+                catch (Exception)
+                {
+                    fileName = string.Empty;
+                }
+                return fileName;
+            }
+        }
+
+        [Browsable(true)]
+        public string FileNameWithExtension
+        {
+            get
+            {
+                if (fileNameWithExtension != null)
+                {
+                    return fileNameWithExtension;
+                }
+                try
+                {
+                    fileNameWithExtension = Path.GetFileName(filePath);
+                }
+                catch (Exception)
+                {
+                    fileNameWithExtension = string.Empty;
+                }
+                return fileNameWithExtension;
+            }
+        }
+
+        [Browsable(true)]
+        public string FileFormat
+        {
+            get
+            {
+                if (fileFormat != null)
+                {
+                    return fileFormat;
+                }
+                try
+                {
+                    fileFormat = Providers.Readers.GetSourceFormatName(filePath);
+                }
+                catch (Exception)
+                {
+                    fileFormat = string.Empty;
+                }
+                return fileFormat;
+            }
+        }
+
+        [Browsable(true)]
+        public string FileDirectory
+        {
+            get
+            {
+                if (fileDirectory != null)
+                {
+                    return fileDirectory;
+                }
+                try
+                {
+                    fileDirectory = Path.GetDirectoryName(filePath);
+                }
+                catch (Exception)
+                {
+                    fileDirectory = string.Empty;
+                }
+                return fileDirectory;
+            }
+        }
+
+        [Browsable(true)]
+        public bool IsValidComicBook
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(FilePath))
+                {
+                    return Providers.Readers.GetSourceProviderType(FilePath) != null;
+                }
+                return false;
+            }
+        }
+
+        //TODO: check to update Caption to a Virtual Tag
+        [Browsable(true)]
+        public string Caption => GetFullTitle(EngineConfiguration.Default.ComicCaptionFormat);
+
+        [Browsable(true)]
+        public string CaptionWithoutTitle => GetFullTitle(EngineConfiguration.Default.ComicCaptionFormat, "title");
+
+        [Browsable(true)]
+        public string CaptionWithoutFormat => GetFullTitle(EngineConfiguration.Default.ComicCaptionFormat, "format");
+
+        [Browsable(true)]
+        public string AlternateCaption => GetFullTitle(DefaultAlternateCaptionFormat);
+
+        public string TargetFilename => GetFullTitle(EngineConfiguration.Default.ComicExportFileNameFormat);
+
+        [Browsable(true)]
+        public int ReadPercentage
+        {
+            get
+            {
+                if (base.PageCount <= 0 || LastPageRead <= 0)
+                {
+                    return 0;
+                }
+                return ((LastPageRead + 1) * 100 / base.PageCount).Clamp(1, 100);
+            }
+        }
+
+        public string ReadPercentageAsText => $"{ReadPercentage}%";
+
+        [Browsable(true)]
+        public bool HasBeenOpened => OpenedTime != DateTime.MinValue;
+
+        [Browsable(true)]
+        [XmlIgnore]
+        public bool HasBeenRead
+        {
+            get
+            {
+                return ReadPercentage >= ReadPercentageAsRead;
+            }
+            set
+            {
+                if (value)
+                {
+                    MarkAsRead();
+                }
+                else
+                {
+                    MarkAsNotRead();
+                }
+            }
+        }
+
+        public string PagesAsText => FormatPages(base.PageCount);
+
+        public string OpenedCountAsText => OpenedCount.ToString();
+
+        public string InfoText
+        {
+            get
+            {
+                StringBuilder stringBuilder = new StringBuilder();
+                stringBuilder.AppendFormat("{0}\n", FileName);
+                stringBuilder.AppendFormat("{0} ({1})\n\n", FileSizeAsText, PagesAsText);
+                stringBuilder.AppendFormat("{0}\n", FileFormat);
+                stringBuilder.AppendFormat("{0}\n\n", FileDirectory);
+                stringBuilder.Append(StringUtility.Format(lastTimeOpenedAtText.Value, OpenedTimeAsText));
+                stringBuilder.AppendLine();
+                stringBuilder.Append(StringUtility.Format(readingAtPageText.Value, CurrentPage + 1));
+                stringBuilder.AppendLine();
+                stringBuilder.Append(StringUtility.Format(lastPageReadIsText.Value, LastPageRead + 1));
+                return stringBuilder.ToString();
+            }
+        }
+
+        public string NumberAsText => FormatNumber(base.Number, ShadowCount);
+
+        public string NumberOnly => ShadowNumber;
+
+        public string AlternateNumberAsText => FormatNumber(base.AlternateNumber, base.AlternateCount);
+
+        public string VolumeAsText => FormatVolume(base.Volume);
+
+        public string VolumeOnly
+        {
+            get
+            {
+                if (base.Volume >= 0)
+                {
+                    return base.Volume.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public string LastPageReadAsText
+        {
+            get
+            {
+                if (LastPageRead > 0)
+                {
+                    return (LastPageRead + 1).ToString();
+                }
+                return noneText.Value;
+            }
+        }
+
+        public string LanguageAsText
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(base.LanguageISO))
+                {
+                    return GetLanguageName(base.LanguageISO);
+                }
+                return string.Empty;
+            }
+        }
+
+        public string ArtistInfo
+        {
+            get
+            {
+                StringBuilder stringBuilder = new StringBuilder(base.Writer);
+                AppendString(stringBuilder, "/", base.Penciller);
+                AppendString(stringBuilder, "/", base.Inker);
+                AppendString(stringBuilder, "/", base.Colorist);
+                AppendString(stringBuilder, "/", base.Letterer);
+                AppendString(stringBuilder, "/", base.CoverArtist);
+                return stringBuilder.ToString();
+            }
+        }
+
+        public string YearAsText => FormatYear(base.Year);
+
+        public string MonthAsText
+        {
+            get
+            {
+                if (base.Month != -1)
+                {
+                    return base.Month.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public string DayAsText
+        {
+            get
+            {
+                if (base.Day != -1)
+                {
+                    return base.Day.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public int Week
+        {
+            get
+            {
+                DateTime published = Published;
+                if (published == DateTime.MinValue)
+                {
+                    return -1;
+                }
+                return weekCalendar.GetWeekOfYear(published, CalendarWeekRule.FirstDay, DayOfWeek.Monday);
+            }
+        }
+
+        public string WeekAsText
+        {
+            get
+            {
+                int week = Week;
+                if (week != -1)
+                {
+                    return week.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public string PublishedAsText
+        {
+            get
+            {
+                string shadowYearAsText = ShadowYearAsText;
+                string text = string.Empty;
+                if (!string.IsNullOrEmpty(shadowYearAsText))
+                {
+                    string monthAsText = MonthAsText;
+                    if (!string.IsNullOrEmpty(monthAsText))
+                    {
+                        string dayAsText = DayAsText;
+                        if (!string.IsNullOrEmpty(dayAsText))
+                        {
+                            text = text + dayAsText + "/";
+                        }
+                        text = text + monthAsText + "/";
+                    }
+                    text += shadowYearAsText;
+                }
+                return text;
+            }
+        }
+
+        public DateTime Published
+        {
+            get
+            {
+                if (ShadowYear <= 0)
+                {
+                    return DateTime.MinValue;
+                }
+                int year = ShadowYear.Clamp(1, 10000);
+                int month = base.Month.Clamp(1, 12);
+                int day = base.Day.Clamp(1, DateTime.DaysInMonth(year, month));
+                return new DateTime(year, month, day);
+            }
+        }
+
+        public string CountAsText
+        {
+            get
+            {
+                if (base.Count != -1)
+                {
+                    return base.Count.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public string NewPagesAsText
+        {
+            get
+            {
+                if (!IsDynamicSource || NewPages <= 0)
+                {
+                    return string.Empty;
+                }
+                return NewPages.ToString();
+            }
+        }
+
+        public string AlternateCountAsText
+        {
+            get
+            {
+                if (base.AlternateCount != -1)
+                {
+                    return base.AlternateCount.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public string RatingAsText => FormatRating(Rating);
+
+        public string CommunityRatingAsText => FormatRating(base.CommunityRating);
+
+        public string CoverAsText => ComicInfo.GetYesNoAsText((base.FrontCoverCount != 0) ? YesNo.Yes : YesNo.No);
+
+        public string FileSizeAsText
+        {
+            get
+            {
+                long num = FileSize;
+                if (num == -1)
+                {
+                    return notFoundText.Value;
+                }
+                return string.Format(new FileLengthFormat(), "{0}", new object[1]
+                {
+                    num
+                });
+            }
+        }
+
+        public string MangaAsText => ComicInfo.GetYesNoAsText(base.Manga);
+
+        public string SeriesCompleteAsText => ComicInfo.GetYesNoAsText(SeriesComplete);
+
+        public string EnableProposedAsText => ComicInfo.GetYesNoAsText(EnableProposed ? YesNo.Yes : YesNo.No);
+
+        public string HasBeenReadAsText => ComicInfo.GetYesNoAsText(HasBeenRead ? YesNo.Yes : YesNo.No);
+
+        public string IsLinkedAsText => ComicInfo.GetYesNoAsText(IsLinked);
+
+        public string BlackAndWhiteAsText => ComicInfo.GetYesNoAsText(base.BlackAndWhite);
+
+        public string BookmarkCountAsText
+        {
+            get
+            {
+                if (base.BookmarkCount > 0)
+                {
+                    return base.BookmarkCount.ToString();
+                }
+                return noneText.Value;
+            }
+        }
+
+        public ComicPageInfo CurrentPageInfo => GetPage(CurrentPage);
+
+        public string FileLocation
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(fileLocation))
+                {
+                    return fileLocation;
+                }
+                return FilePath;
+            }
+        }
+
+        public string DisplayFileLocation
+        {
+            get
+            {
+                if (!IsInContainer)
+                {
+                    return FilePath;
+                }
+                return Caption;
+            }
+        }
+
+        public int Status
+        {
+            get
+            {
+                int num = 0;
+                if (FileIsMissing && IsLinked)
+                {
+                    num |= 1;
+                }
+                if (ComicInfoIsDirty)
+                {
+                    num |= 2;
+                }
+                return num;
+            }
+        }
+
+        [Browsable(true)]
+        public bool IsLinked => !string.IsNullOrEmpty(filePath);
 
         [XmlIgnore]
-        [Browsable(true)]
-        public string VirtualTag03 { get; set; }
+        public string BookPriceAsText
+        {
+            get
+            {
+                if (!(bookPrice < 0f))
+                {
+                    return $"{bookPrice:0.00}";
+                }
+                return unkownText.Value;
+            }
+            set
+            {
+                if (float.TryParse(value, out var result))
+                {
+                    BookPrice = result;
+                }
+                else
+                {
+                    BookPrice = -1f;
+                }
+            }
+        }
 
-        [XmlIgnore]
-        [Browsable(true)]
-        public string VirtualTag04 { get; set; }
+        public string OpenedTimeAsText => FormatDate(OpenedTime);
 
-        [XmlIgnore]
-        [Browsable(true)]
-        public string VirtualTag05 { get; set; }
+        public string AddedTimeAsText => FormatDate(AddedTime, ComicDateFormat.Long, toLocal: false, unkownText.Value);
 
-        [XmlIgnore]
-        [Browsable(true)]
-        public string VirtualTag06 { get; set; }
+        public string ReleasedTimeAsText => FormatDate(ReleasedTime, ComicDateFormat.Short, toLocal: false, unkownText.Value);
 
-        [XmlIgnore]
-        [Browsable(true)]
-        public string VirtualTag07 { get; set; }
+        public string FileCreationTimeAsText => FormatFileDate(FileCreationTime);
 
-        [XmlIgnore]
-        [Browsable(true)]
-        public string VirtualTag08 { get; set; }
+        public string FileModifiedTimeAsText => FormatFileDate(FileModifiedTime);
 
-        [XmlIgnore]
-        [Browsable(true)]
-        public string VirtualTag09 { get; set; }
+        public bool IsInContainer => container != null;
 
-        [XmlIgnore]
+        public ComicsEditModes EditMode
+        {
+            get
+            {
+                if (!IsInContainer)
+                {
+                    return ComicsEditModes.Default;
+                }
+                return Container.EditMode;
+            }
+        }
+
+        [DefaultValue(false)]
+        [XmlAttribute]
+        public bool IsDynamicSource
+        {
+            get;
+            set;
+        }
+
+        [DefaultValue(0)]
+        public int NewPages
+        {
+            get
+            {
+                return newPages;
+            }
+            set
+            {
+                SetProperty("NewPages", ref newPages, value);
+            }
+        }
+
+        public string ProposedSeries
+        {
+            get
+            {
+                UpdateProposed();
+                return proposed.Series;
+            }
+        }
+
+        public string ProposedTitle
+        {
+            get
+            {
+                UpdateProposed();
+                return proposed.Title;
+            }
+        }
+
+        public string ProposedFormat
+        {
+            get
+            {
+                UpdateProposed();
+                return proposed.Format;
+            }
+        }
+
+        public int ProposedVolume
+        {
+            get
+            {
+                UpdateProposed();
+                return proposed.Volume;
+            }
+        }
+
+        public string ProposedNumber
+        {
+            get
+            {
+                UpdateProposed();
+                if (!(base.Number == "-"))
+                {
+                    return proposed.Number;
+                }
+                return string.Empty;
+            }
+        }
+
+        public int ProposedCount
+        {
+            get
+            {
+                UpdateProposed();
+                return proposed.Count;
+            }
+        }
+
+        public int ProposedYear
+        {
+            get
+            {
+                UpdateProposed();
+                return proposed.Year;
+            }
+        }
+
+        public string ProposedYearAsText => FormatYear(ProposedYear);
+
+        public string ProposedNumberAsText => FormatNumber(ProposedNumber, ProposedCount);
+
+        public string ProposedVolumeAsText => FormatVolume(ProposedVolume);
+
+        public string ProposedNakedVolumeAsText
+        {
+            get
+            {
+                if (ProposedVolume != -1)
+                {
+                    return ProposedVolume.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public string ProposedCountAsText
+        {
+            get
+            {
+                if (ProposedCount != -1)
+                {
+                    return ProposedCount.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public string ShadowSeries
+        {
+            get
+            {
+                if (!EnableProposed || !string.IsNullOrEmpty(base.Series))
+                {
+                    return base.Series;
+                }
+                return ProposedSeries;
+            }
+        }
+
+        public string ShadowTitle
+        {
+            get
+            {
+                if (!EnableProposed || !string.IsNullOrEmpty(base.Title))
+                {
+                    return base.Title;
+                }
+                return ProposedTitle;
+            }
+        }
+
+        public string ShadowFormat
+        {
+            get
+            {
+                if (!EnableProposed || !string.IsNullOrEmpty(base.Format))
+                {
+                    return base.Format;
+                }
+                return ProposedFormat;
+            }
+        }
+
+        public int ShadowVolume
+        {
+            get
+            {
+                if (!EnableProposed || base.Volume != -1)
+                {
+                    return base.Volume;
+                }
+                return ProposedVolume;
+            }
+        }
+
+        public string ShadowNumber
+        {
+            get
+            {
+                if (!EnableProposed || !string.IsNullOrEmpty(base.Number))
+                {
+                    return base.Number;
+                }
+                return ProposedNumber;
+            }
+        }
+
+        public int ShadowCount
+        {
+            get
+            {
+                if (!EnableProposed || base.Count != -1)
+                {
+                    return base.Count;
+                }
+                return ProposedCount;
+            }
+        }
+
+        public int ShadowYear
+        {
+            get
+            {
+                if (!EnableProposed || base.Year != -1)
+                {
+                    return base.Year;
+                }
+                return ProposedYear;
+            }
+        }
+
         [Browsable(true)]
-        public string VirtualTag10 { get; set; }
+        public string ShadowYearAsText => FormatYear(ShadowYear);
+
+        public string ShadowNumberAsText => FormatNumber(ShadowNumber, ShadowCount);
+
+        public string ShadowVolumeAsText => FormatVolume(ShadowVolume);
+
+        public string ShadowCountAsText
+        {
+            get
+            {
+                if (ShadowCount != -1)
+                {
+                    return ShadowCount.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public TextNumberFloat CompareNumber => compareNumber ?? (compareNumber = new ComicTextNumberFloat(ShadowNumber));
+
+        public TextNumberFloat CompareAlternateNumber => compareAlternateNumber ?? (compareAlternateNumber = new ComicTextNumberFloat(base.AlternateNumber));
+
+        [DefaultValue(null)]
+        public ExtraSyncInformation ExtraSyncInformation
+        {
+            get
+            {
+                using (ItemMonitor.Lock(syncInfo))
+                {
+                    ExtraSyncInformation value;
+                    return syncInfo.TryGetValue(this, out value) ? value : null;
+                }
+            }
+            set
+            {
+                using (ItemMonitor.Lock(syncInfo))
+                {
+                    syncInfo[this] = value;
+                }
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string CustomValuesStore
+        {
+            get
+            {
+                return customValuesStore;
+            }
+            set
+            {
+                SetProperty("CustomValuesStore", ref customValuesStore, value);
+            }
+        }
+
+        public static ImagePackage PublisherIcons => publisherIcons;
+
+        public static ImagePackage AgeRatingIcons => ageRatingIcons;
+
+        public static ImagePackage FormatIcons => formatIcons;
+
+        public static ImagePackage SpecialIcons => specialIcons;
+
+        public static bool NewBooksChecked
+        {
+            get;
+            set;
+        }
+
+        [field: NonSerialized]
+        public event EventHandler<ComicBookFileRenameEventArgs> FileRenamed;
+
+        [field: NonSerialized]
+        public event EventHandler<CreateComicProviderEventArgs> CreateComicProvider;
+
+        [field: NonSerialized]
+        public event EventHandler<CreateComicProviderEventArgs> ComicProviderCreated;
+
+        public static event EventHandler<ParseFilePathEventArgs> ParseFilePath;
+
+        private string GetVirtualTagValue(int id)
+        {
+            string captionFormat = VirtualTagsCollection.Tags.GetValue(id).CaptionFormat;
+
+            if (!string.IsNullOrEmpty(captionFormat))
+                return GetFullTitle(captionFormat);
+            else
+                return string.Empty;
+        }
+
+        [Browsable(true)]
+        public string VirtualTag01 => GetVirtualTagValue(1);
+
+        [Browsable(true)]
+        public string VirtualTag02 => GetVirtualTagValue(2);
+
+        [Browsable(true)]
+        public string VirtualTag03 => GetVirtualTagValue(3);
+
+        [Browsable(true)]
+        public string VirtualTag04 => GetVirtualTagValue(4);
+
+        [Browsable(true)]
+        public string VirtualTag05 => GetVirtualTagValue(5);
+
+        [Browsable(true)]
+        public string VirtualTag06 => GetVirtualTagValue(6);
+
+        [Browsable(true)]
+        public string VirtualTag07 => GetVirtualTagValue(7);
+
+        [Browsable(true)]
+        public string VirtualTag08 => GetVirtualTagValue(8);
+
+        [Browsable(true)]
+        public string VirtualTag09 => GetVirtualTagValue(9);
+
+        [Browsable(true)]
+        public string VirtualTag10 => GetVirtualTagValue(10);
 
         static ComicBook()
-		{
-			GuidEquality = new Equality<ComicBook>((ComicBook a, ComicBook b) => a.Id == b.Id, (ComicBook a) => a.Id.GetHashCode());
-			EnableGroupNameCompression = false;
-			unkownText = new Lazy<string>(() => TR["Unknown"]);
-			pagesText = new Lazy<string>(() => TR["Pages", "{0} Page(s)"]);
-			lastTimeOpenedAtText = new Lazy<string>(() => TR["LastTimeOpenedAt", "Last time opened at {0}"]);
-			readingAtPageText = new Lazy<string>(() => TR["ReadingAtPage", "Reading at page {0}"]);
-			lastPageReadIsText = new Lazy<string>(() => TR["LastPageReadIs", "Last page read is {0}"]);
-			noneText = new Lazy<string>(() => TR["None", "None"]);
-			notFoundText = new Lazy<string>(() => TR["NotFound", "not found"]);
-			neverText = new Lazy<string>(() => TR["Never", "never"]);
-			volumeFormat = new Lazy<string>(() => TR["Volume", "V{0}"]);
-			ofText = new Lazy<string>(() => TR["Of", "of"]);
-			weekCalendar = new GregorianCalendar();
-			syncInfo = new Dictionary<ComicBook, ExtraSyncInformation>();
-			rxField = new Regex("{(?<name>[a-z]+)}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-			Default = new ComicBook();
-			hasAsText = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-			publisherIcons = new ImagePackage
-			{
-				EnableWidthCropping = true
-			};
-			ageRatingIcons = new ImagePackage
-			{
-				EnableWidthCropping = true
-			};
-			formatIcons = new ImagePackage
-			{
-				EnableWidthCropping = true
-			};
-			specialIcons = new ImagePackage
-			{
-				EnableWidthCropping = true
-			};
-			NewBooksChecked = true;
-		}
+        {
+            GuidEquality = new Equality<ComicBook>((ComicBook a, ComicBook b) => a.Id == b.Id, (ComicBook a) => a.Id.GetHashCode());
+            EnableGroupNameCompression = false;
+            unkownText = new Lazy<string>(() => TR["Unknown"]);
+            pagesText = new Lazy<string>(() => TR["Pages", "{0} Page(s)"]);
+            lastTimeOpenedAtText = new Lazy<string>(() => TR["LastTimeOpenedAt", "Last time opened at {0}"]);
+            readingAtPageText = new Lazy<string>(() => TR["ReadingAtPage", "Reading at page {0}"]);
+            lastPageReadIsText = new Lazy<string>(() => TR["LastPageReadIs", "Last page read is {0}"]);
+            noneText = new Lazy<string>(() => TR["None", "None"]);
+            notFoundText = new Lazy<string>(() => TR["NotFound", "not found"]);
+            neverText = new Lazy<string>(() => TR["Never", "never"]);
+            volumeFormat = new Lazy<string>(() => TR["Volume", "V{0}"]);
+            ofText = new Lazy<string>(() => TR["Of", "of"]);
+            weekCalendar = new GregorianCalendar();
+            syncInfo = new Dictionary<ComicBook, ExtraSyncInformation>();
+            rxField = new Regex("{(?<name>[a-z]+)}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            Default = new ComicBook();
+            hasAsText = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            publisherIcons = new ImagePackage
+            {
+                EnableWidthCropping = true
+            };
+            ageRatingIcons = new ImagePackage
+            {
+                EnableWidthCropping = true
+            };
+            formatIcons = new ImagePackage
+            {
+                EnableWidthCropping = true
+            };
+            specialIcons = new ImagePackage
+            {
+                EnableWidthCropping = true
+            };
+            NewBooksChecked = true;
+        }
 
-		public ComicBook()
-		{
-			VirtualTagsCollection.TagsRefresh += (sender, e) => UpdateVirtualTags();
+        public ComicBook()
+        {
         }
 
         public ComicBook(ComicBook cb)
-		{
-			CopyFrom(cb);
-			if (cb.CreateComicProvider != null)
-			{
-				CreateComicProvider += cb.CreateComicProvider;
-			}
-			if (cb.ComicProviderCreated != null)
-			{
-				ComicProviderCreated += cb.ComicProviderCreated;
-			}
-            VirtualTagsCollection.TagsRefresh += (sender, e) => UpdateVirtualTags();
+        {
+            CopyFrom(cb);
+            if (cb.CreateComicProvider != null)
+            {
+                CreateComicProvider += cb.CreateComicProvider;
+            }
+            if (cb.ComicProviderCreated != null)
+            {
+                ComicProviderCreated += cb.ComicProviderCreated;
+            }
         }
 
         public static ComicBook Create(string file, RefreshInfoOptions options)
-		{
-			ComicBook comicBook = new ComicBook
-			{
-				FilePath = file
-			};
-			comicBook.RefreshInfoFromFile(options);
-			return comicBook;
-		}
-
-		private void ResetOptimizedNumbers()
-		{
-			compareNumber = (compareAlternateNumber = null);
-		}
-
-		public static void ClearExtraSyncInformation()
-		{
-			using (ItemMonitor.Lock(syncInfo))
-			{
-				syncInfo.Clear();
-			}
-		}
-
-		public IEnumerable<StringPair> GetCustomValues()
-		{
-			return ValuesStore.GetValues(CustomValuesStore);
-		}
-
-		public void SetCustomValue(string key, string value)
-		{
-			if (!string.IsNullOrEmpty(key))
-			{
-				if (string.IsNullOrEmpty(value))
-				{
-					DeleteCustomValue(key);
-				}
-				else
-				{
-					CustomValuesStore = new ValuesStore(CustomValuesStore).Add(key, value).ToString();
-				}
-			}
-		}
-
-		public string GetCustomValue(string key)
-		{
-			return ValuesStore.GetValue(CustomValuesStore, key);
-		}
-
-		public void DeleteCustomValue(string key)
-		{
-			CustomValuesStore = new ValuesStore(CustomValuesStore).Remove(key).ToString();
-		}
-
-		public ThumbnailKey GetThumbnailKey(int page)
-		{
-			string locationKey = ((!IsLinked) ? (string.IsNullOrEmpty(CustomThumbnailKey) ? ThumbnailKey.GetResource(ThumbnailKey.ResourceKey, "Unknown") : ThumbnailKey.GetResource(ThumbnailKey.CustomKey, CustomThumbnailKey)) : FileLocation);
-			return GetThumbnailKey(page, locationKey);
-		}
-
-		public ThumbnailKey GetThumbnailKey(int page, string locationKey)
-		{
-			return new ThumbnailKey(this, locationKey, FileSize, FileModifiedTime, TranslatePageToImageIndex(page), GetPage(page).Rotation);
-		}
-
-		public ThumbnailKey GetFrontCoverThumbnailKey()
-		{
-			return GetThumbnailKey(base.FrontCoverPageIndex);
-		}
-
-		public PageKey GetFrontCoverKey(BitmapAdjustment bitmapAdjustment)
-		{
-			return GetPageKey(base.FrontCoverPageIndex, bitmapAdjustment);
-		}
-
-		public PageKey GetPageKey(int page, BitmapAdjustment bitmapAdjustment)
-		{
-			return new PageKey(this, FileLocation, FileSize, FileModifiedTime, TranslatePageToImageIndex(page), GetPage(page).Rotation, bitmapAdjustment);
-		}
-
-		public ImageKey GetImageKey(int image)
-		{
-			return new PageKey(this, FileLocation, FileSize, FileModifiedTime, image, ImageRotation.None, BitmapAdjustment.Empty);
-		}
-
-		public ImageProvider CreateImageProvider()
-		{
-			CreateComicProviderEventArgs createComicProviderEventArgs = new CreateComicProviderEventArgs();
-			OnCreateComicProvider(createComicProviderEventArgs);
-			createComicProviderEventArgs.Provider = createComicProviderEventArgs.Provider ?? Providers.Readers.CreateSourceProvider(FilePath);
-			OnComicProviderCreated(createComicProviderEventArgs);
-			return createComicProviderEventArgs.Provider;
-		}
-
-		public ImageProvider OpenProvider(int lastPageIndexToRead = -1)
-		{
-			ImageProvider imageProvider = CreateImageProvider();
-			try
-			{
-				if (lastPageIndexToRead != -1)
-				{
-					int imageIndex = TranslatePageToImageIndex(lastPageIndexToRead);
-					imageProvider.ImageReady += delegate(object s, ImageIndexReadyEventArgs e)
-					{
-						e.Cancel = e.ImageNumber == imageIndex;
-					};
-				}
-				imageProvider.Open(async: false);
-				return imageProvider;
-			}
-			catch
-			{
-				imageProvider?.Dispose();
-				return null;
-			}
-		}
-
-		public string GetPublisherIconKey()
-		{
-			string text = base.Publisher;
-			if (base.Year >= 0)
-			{
-				text = text + "(" + YearAsText + ")";
-			}
-			return text;
-		}
-
-		public string GetImprintIconKey()
-		{
-			string text = base.Imprint;
-			if (base.Year >= 0)
-			{
-				text = text + "(" + YearAsText + ")";
-			}
-			return text;
-		}
-
-		private IEnumerable<Image> GetIconsInternal()
-		{
-			Image img2 = PublisherIcons.GetImage(GetPublisherIconKey());
-			Image image;
-			if (img2 != null)
-			{
-				yield return img2;
-			}
-			else
-			{
-				img2 = (image = PublisherIcons.GetImage(Publisher));
-				if (image != null)
-				{
-					yield return img2;
-				}
-			}
-			img2 = (image = PublisherIcons.GetImage(GetImprintIconKey()));
-			if (image != null)
-			{
-				yield return img2;
-			}
-			else
-			{
-				img2 = (image = PublisherIcons.GetImage(Imprint));
-				if (image != null)
-				{
-					yield return img2;
-				}
-			}
-			img2 = (image = AgeRatingIcons.GetImage(AgeRating));
-			if (image != null)
-			{
-				yield return img2;
-			}
-			img2 = (image = FormatIcons.GetImage(ShadowFormat));
-			if (image != null)
-			{
-				yield return img2;
-			}
-			if (!string.IsNullOrEmpty(Tags))
-			{
-				foreach (string item in Tags.ListStringToSet(','))
-				{
-					img2 = (image = SpecialIcons.GetImage(item));
-					if (image != null)
-					{
-						yield return img2;
-					}
-				}
-			}
-			if (SeriesComplete == YesNo.Yes)
-			{
-				img2 = (image = SpecialIcons.GetImage("SeriesComplete"));
-				if (image != null)
-				{
-					yield return img2;
-				}
-			}
-			if (BlackAndWhite == YesNo.Yes)
-			{
-				img2 = (image = SpecialIcons.GetImage("BlackAndWhite"));
-				if (image != null)
-				{
-					yield return img2;
-				}
-			}
-			if (Manga == MangaYesNo.Yes)
-			{
-				img2 = (image = SpecialIcons.GetImage("Manga"));
-				if (image != null)
-				{
-					yield return img2;
-				}
-			}
-			if (Manga == MangaYesNo.YesAndRightToLeft)
-			{
-				img2 = (image = SpecialIcons.GetImage("MangaRightToLeft"));
-				if (image != null)
-				{
-					yield return img2;
-				}
-			}
-		}
-
-		public IEnumerable<Image> GetIcons()
-		{
-			return GetIconsInternal();
-		}
-
-		public void CopyFrom(ComicBook cb)
-		{
-			SetInfo(cb, onlyUpdateEmpty: false);
-			Id = cb.Id;
-			AddedTime = cb.AddedTime;
-			ReleasedTime = cb.ReleasedTime;
-			OpenedTime = cb.OpenedTime;
-			OpenedCount = cb.OpenedCount;
-			CurrentPage = cb.CurrentPage;
-			LastPageRead = cb.LastPageRead;
-			Rating = cb.Rating;
-			ColorAdjustment = cb.ColorAdjustment;
-			EnableDynamicUpdate = cb.EnableDynamicUpdate;
-			EnableProposed = cb.EnableProposed;
-			SeriesComplete = cb.SeriesComplete;
-			Checked = cb.Checked;
-			FilePath = cb.FilePath;
-			FileSize = cb.FileSize;
-			FileModifiedTime = cb.FileModifiedTime;
-			FileCreationTime = cb.FileCreationTime;
-			fileLocation = cb.FileLocation;
-			customThumbnailKey = cb.CustomThumbnailKey;
-			LastOpenedFromListId = cb.LastOpenedFromListId;
-			CustomValuesStore = cb.CustomValuesStore;
-		}
-
-		public void CopyTo(ComicBook cb)
-		{
-			cb.CopyFrom(this);
-		}
-
-		public string GetFullTitle(string textFormat, params string[] ignore)
-		{
-			try
-			{
-				return ExtendedStringFormater.Format(textFormat, delegate(string s)
-				{
-					try
-					{
-						if (ignore != null && ignore.Length != 0 && ignore.Contains(s, StringComparer.OrdinalIgnoreCase))
-						{
-							return null;
-						}
-						MapPropertyNameToAsText(s, out var newName);
-						return GetPropertyValue<string>(newName, ComicValueType.Shadow);
-					}
-					catch
-					{
-						return null;
-					}
-				});
-			}
-			catch
-			{
-				return string.Empty;
-			}
-		}
-
-		public void SetShadowValues(ComicInfo ci)
-		{
-			ci.Series = ShadowSeries;
-			ci.Count = ShadowCount;
-			ci.Title = ShadowTitle;
-			ci.Year = ShadowYear;
-			ci.Number = ShadowNumber;
-			ci.Format = ShadowFormat;
-			ci.Volume = ShadowVolume;
-		}
-
-		public void SetFileLocation(string fileLocation)
-		{
-			this.fileLocation = fileLocation;
-		}
-
-		public void MarkAsNotRead()
-		{
-			OpenedTime = DateTime.MinValue;
-			int num2 = (CurrentPage = 0);
-			int num5 = (OpenedCount = (LastPageRead = num2));
-		}
-
-		public void MarkAsRead()
-		{
-			if (OpenedCount == 0)
-			{
-				OpenedCount = 1;
-			}
-			OpenedTime = DateTime.Now;
-			if (base.PageCount > 0)
-			{
-				int num3 = (CurrentPage = (LastPageRead = base.PageCount - 1));
-			}
-		}
-
-		public void ResetProperties(int level = 0)
-		{
-			ResetValueAttribute.ResetProperties(this, level);
-			UpdateVirtualTags();
-		}
-
-		public bool RemoveFromContainer()
-		{
-			return Container?.Books.Remove(this) ?? false;
-		}
-
-		public bool IsSearchable(string propName)
-		{
-			if (searchableProperties == null)
-			{
-				searchableProperties = new HashSet<string>(from pi in GetType().GetProperties().Where(SearchableAttribute.IsSearchable)
-					select pi.Name);
-			}
-			return searchableProperties.Contains(propName);
-		}
-
-		public object GetUntypedPropertyValue(string propName)
-		{
-			return GetType().GetProperty(propName).GetValue(this, null);
-		}
-
-		public T GetPropertyValue<T>(string propName, ComicValueType cvt = ComicValueType.Standard)
-		{
-			MapPropertyName(propName, out propName, cvt);
-			try
-			{
-				if (!propName.StartsWith("{"))
-				{
-					return PropertyCaller.CreateGetMethod<ComicBook, T>(propName)(this);
-				}
-				propName = propName.Substring(1, propName.Length - 2);
-				return (T)(object)GetCustomValue(propName);
-			}
-			catch (Exception)
-			{
-				return default(T);
-			}
-		}
-
-		public string GetStringPropertyValue(string propName, ComicValueType cvt = ComicValueType.Standard)
-		{
-			return GetPropertyValue<string>(propName, cvt) ?? string.Empty;
-		}
-
-		public T GetPropertyValue<T>(string propName, bool proposed)
-		{
-			T propertyValue = GetPropertyValue<T>(propName);
-			if (!proposed || !EnableProposed || !IsDefaultPropertyValue(propertyValue) || !MapPropertyName(propName, out propName, ComicValueType.Proposed))
-			{
-				return propertyValue;
-			}
-			return GetPropertyValue<T>(propName);
-		}
-
-		public string FormatString(string format)
-		{
-			return rxField.Replace(format, delegate(Match m)
-			{
-				try
-				{
-					return PropertyCaller.CreateGetMethod<ComicBook, string>(m.Groups[1].Value)(this) ?? string.Empty;
-				}
-				catch (Exception)
-				{
-					return m.Value;
-				}
-			});
-		}
-
-		public void WriteProposedValues(bool overwriteAll)
-		{
-			if (overwriteAll || string.IsNullOrEmpty(base.Series))
-			{
-				base.Series = ProposedSeries;
-			}
-			if (overwriteAll || string.IsNullOrEmpty(base.Title))
-			{
-				base.Title = ProposedTitle;
-			}
-			if (overwriteAll || base.Year == -1)
-			{
-				base.Year = ProposedYear;
-			}
-			if (overwriteAll || string.IsNullOrEmpty(base.Number))
-			{
-				base.Number = ProposedNumber;
-			}
-			if (overwriteAll || base.Volume == -1)
-			{
-				base.Volume = ProposedVolume;
-			}
-			if (overwriteAll || base.Count == -1)
-			{
-				base.Count = ProposedCount;
-			}
-			if (overwriteAll || string.IsNullOrEmpty(base.Format))
-			{
-				base.Format = ProposedFormat;
-			}
-			EnableProposed = false;
-		}
-
-		public bool RenameFile(string newName)
-		{
-			if (!IsLinked || !EditMode.IsLocalComic())
-			{
-				return false;
-			}
-			try
-			{
-				newName = FileUtility.MakeValidFilename(newName);
-				string text = Path.Combine(FileDirectory, newName + Path.GetExtension(FilePath));
-				if (string.Equals(FilePath, text, StringComparison.OrdinalIgnoreCase))
-				{
-					return true;
-				}
-				File.Move(FilePath, text);
-				FilePath = text;
-				return true;
-			}
-			catch
-			{
-				return false;
-			}
-		}
-
-		public ComicBookNavigator CreateNavigator()
-		{
-			try
-			{
-				ComicBookNavigator comicBookNavigator = new ComicBookNavigator(this);
-				switch (base.Manga)
-				{
-				case MangaYesNo.Unknown:
-					comicBookNavigator.RightToLeftReading = YesNo.Unknown;
-					break;
-				case MangaYesNo.No:
-				case MangaYesNo.Yes:
-					comicBookNavigator.RightToLeftReading = YesNo.No;
-					break;
-				case MangaYesNo.YesAndRightToLeft:
-					comicBookNavigator.RightToLeftReading = YesNo.Yes;
-					break;
-				}
-				return comicBookNavigator;
-			}
-			catch
-			{
-				return null;
-			}
-		}
-
-		public void SetValue(string propertyName, object value, bool skipUpdateTags = false)
-		{
-			try
-			{
-				GetType().GetProperty(propertyName).SetValue(this, value, null);
-
-                //Skip is used to prevent a recursive loop, because updating the SetValue would call Update, which calls SetValue and so forth.
-				if (skipUpdateTags == false)
-					UpdateVirtualTags(skipUpdateTags);
-			}
-			catch (Exception)
-			{
-			}
-		}
-
-		public string Hash()
-		{
-			try
-			{
-				if (EditMode.IsLocalComic() && !string.IsNullOrEmpty(FilePath) && File.Exists(FilePath))
-				{
-					return CreateFileHash();
-				}
-			}
-			catch
-			{
-			}
-			return null;
-		}
-
-		public void CopyDataFrom(ComicBook data, IEnumerable<string> properties)
-		{
-			Type type = data.GetType();
-			foreach (string property2 in properties)
-			{
-				try
-				{
-					if (property2.StartsWith("{"))
-					{
-						string key = property2.Substring(1, property2.Length - 2);
-						SetCustomValue(key, data.GetCustomValue(key));
-					}
-					else
-					{
-						PropertyInfo property = type.GetProperty(property2);
-						property.SetValue(this, property.GetValue(data, null), null);
-					}
-				}
-				catch
-				{
-				}
-			}
-		}
-
-		public void ToClipboard()
-		{
-			ComicBook comicBook = CloneUtility.Clone(this);
-			comicBook.Id = Guid.NewGuid();
-			DataObject dataObject = new DataObject();
-			dataObject.SetData(DataFormats.UnicodeText, GetInfo().ToXml());
-			dataObject.SetData(ClipboardFormat, comicBook);
-			Clipboard.SetDataObject(dataObject);
-		}
-
-		public bool IsDefaultValue(string property)
-		{
-			PropertyInfo property2 = GetType().GetProperty(property);
-			return object.Equals(property2.GetValue(Default, null), property2.GetValue(this, null));
-		}
-
-		public void ValidateData()
-		{
-			TrimExcessPageInfo();
-			if (!FileIsMissing && FileCreationTime == DateTime.MinValue)
-			{
-				try
-				{
-					FileCreationTime = File.GetCreationTimeUtc(FilePath);
-				}
-				catch (Exception)
-				{
-				}
-			}
-		}
-
-		public void UpdateDynamicPageCount(bool refresh, IProgressState ps = null)
-		{
-			try
-			{
-				using (ImageProvider imageProvider = Providers.Readers.CreateSourceProvider(FilePath))
-				{
-					IDynamicImages dynamicImages = imageProvider as IDynamicImages;
-					if (dynamicImages != null)
-					{
-						dynamicImages.RefreshMode = refresh;
-					}
-					if (ps != null)
-					{
-						imageProvider.ImageReady += delegate(object s, ImageIndexReadyEventArgs e)
-						{
-							ps.ProgressAvailable = base.PageCount > 0;
-							if (ps.ProgressAvailable)
-							{
-								ps.ProgressPercentage = 100 * e.ImageNumber / base.PageCount;
-							}
-						};
-					}
-					imageProvider.Open(async: false);
-					NewPages = Math.Max(imageProvider.Count - base.PageCount, 0);
-				}
-			}
-			catch (Exception)
-			{
-			}
-		}
-
-		public bool WriteInfoToFile(bool withRefreshFileProperties = true)
-		{
-			if (!EditMode.IsLocalComic())
-			{
-				return false;
-			}
-			FileInfo fileInfo = new FileInfo(FilePath);
-			if (!fileInfo.Exists || fileInfo.IsReadOnly)
-			{
-				return false;
-			}
-			using (ImageProvider imageProvider = CreateImageProvider())
-			{
-				IInfoStorage infoStorage = imageProvider as IInfoStorage;
-				if (infoStorage == null)
-				{
-					return false;
-				}
-				infoStorage.StoreInfo(GetInfo());
-				FileInfoRetrieved = true;
-			}
-			if (withRefreshFileProperties)
-			{
-				RefreshFileProperties();
-			}
-			return true;
-		}
-
-		public void ResetInfoRetrieved()
-		{
-			FileInfoRetrieved = false;
-		}
-
-		public void RefreshInfoFromFile(RefreshInfoOptions options)
-		{
-			if ((options & RefreshInfoOptions.DontReadInformation) != 0 || !EditMode.IsLocalComic() || !IsLinked)
-			{
-				return;
-			}
-			DateTime d = FileModifiedTime;
-			long num = FileSize;
-			RefreshFileProperties();
-			if (FileIsMissing)
-			{
-				return;
-			}
-			bool flag = FileModifiedTime != d;
-			try
-			{
-				IsDynamicSource = Providers.Readers.GetSourceProviderInfo(FilePath).Formats.All((FileFormat f) => f.Dynamic);
-			}
-			catch (Exception)
-			{
-				IsDynamicSource = false;
-			}
-			if (!(!FileInfoRetrieved || flag) && (options & RefreshInfoOptions.ForceRefresh) == 0 && ((options & (RefreshInfoOptions.GetFastPageCount | RefreshInfoOptions.GetPageCount)) == 0 || base.PageCount != 0))
-			{
-				return;
-			}
-			using (ImageProvider imageProvider = CreateImageProvider())
-			{
-				IInfoStorage infoStorage = imageProvider as IInfoStorage;
-				if (infoStorage == null)
-				{
-					return;
-				}
-				if (!ComicInfoIsDirty)
-				{
-					SetInfo(infoStorage.LoadInfo((flag || !FileInfoRetrieved) ? InfoLoadingMethod.Complete : InfoLoadingMethod.Fast));
-				}
-				if (!imageProvider.IsSlow && (base.PageCount == 0 || num != FileSize) && (((options & RefreshInfoOptions.GetFastPageCount) != 0 && (imageProvider.Capabilities & ImageProviderCapabilities.FastPageInfo) != 0) || (options & RefreshInfoOptions.GetPageCount) != 0))
-				{
-					try
-					{
-						imageProvider.Open(async: false);
-						if (imageProvider.Count > 0)
-						{
-							base.PageCount = imageProvider.Count;
-						}
-					}
-					catch
-					{
-					}
-				}
-			}
-			FileInfoRetrieved = true;
-		}
-
-		public void RefreshInfoFromFile()
-		{
-			RefreshInfoFromFile(RefreshInfoOptions.GetFastPageCount);
-		}
-
-		public string CreateFileHash()
-		{
-			using (ImageProvider imageProvider = CreateImageProvider())
-			{
-				imageProvider.Open(async: false);
-				return imageProvider.CreateHash();
-			}
-		}
-
-		public void RefreshFileProperties()
-		{
-			if (!EditMode.IsLocalComic())
-			{
-				return;
-			}
-			try
-			{
-				FileInfo fileInfo = new FileInfo(FilePath);
-				FileIsMissing = !fileInfo.Exists;
-				if (fileInfo.Exists)
-				{
-					bool flag = fileSize != fileInfo.Length;
-					bool flag2 = fileModifiedTime != fileInfo.LastWriteTimeUtc;
-					fileSize = fileInfo.Length;
-					fileModifiedTime = fileInfo.LastWriteTimeUtc;
-					if (flag)
-					{
-						FireBookChanged("FileSize");
-					}
-					if (flag2)
-					{
-						FireBookChanged("FileModifiedTime");
-					}
-					FileCreationTime = fileInfo.CreationTimeUtc;
-				}
-			}
-			catch
-			{
-				FileIsMissing = true;
-			}
-		}
-
-		private bool SetProperty<T>(string name, ref T property, T value, bool lockItem = false, bool addUndo = true)
-		{
-			if (object.Equals(property, value))
-			{
-				return false;
-			}
-			T val = property;
-			using (lockItem ? ItemMonitor.Lock(this) : null)
-			{
-				property = value;
-			}
-			if (addUndo)
-			{
-				FireBookChanged(name, val, value);
-			}
-			else
-			{
-				FireBookChanged(name);
-			}
-			return true;
-		}
-
-		private void FireBookChanged(string name)
-		{
-			OnBookChanged(new BookChangedEventArgs(name, isComicInfo: false));
-		}
-
-		private void FireBookChanged(string name, object oldValue, object newValue)
-		{
-			OnBookChanged(new BookChangedEventArgs(name, isComicInfo: false, oldValue, newValue));
-		}
-
-		private void UpdateProposed()
-		{
-			if (proposed == null)
-			{
-				OnParseFilePath();
-			}
-		}
-
-		protected virtual void OnFileRenamed(ComicBookFileRenameEventArgs e)
-		{
-			if (this.FileRenamed != null)
-			{
-				this.FileRenamed(this, e);
-			}
-		}
-
-		protected virtual void OnCreateComicProvider(CreateComicProviderEventArgs cpea)
-		{
-			if (this.CreateComicProvider != null)
-			{
-				this.CreateComicProvider(this, cpea);
-			}
-		}
-
-		protected virtual void OnComicProviderCreated(CreateComicProviderEventArgs cpea)
-		{
-			if (this.ComicProviderCreated != null)
-			{
-				this.ComicProviderCreated(this, cpea);
-			}
-		}
-
-		protected override void OnBookChanged(BookChangedEventArgs e)
-		{
-			base.OnBookChanged(e);
-			if (e.PropertyName == "FilePath" || e.PropertyName == "Number" || e.PropertyName == "EnableProposed")
-			{
-				compareNumber = null;
-			}
-			else if (e.PropertyName == "AlternateNumber")
-			{
-				compareAlternateNumber = null;
-			}
-		}
-
-		public override void SetInfo(ComicInfo ci, bool onlyUpdateEmpty = true, bool updatePages = true)
-		{
-			base.SetInfo(ci, onlyUpdateEmpty, updatePages);
-			LastPageRead = Math.Min(base.PageCount - 1, LastPageRead);
-			CurrentPage = Math.Min(base.PageCount - 1, CurrentPage);
-		}
-
-		protected override ComicPageInfo OnNewComicPageAdded(ComicPageInfo info)
-		{
-			if (proposed != null && info.ImageIndex < proposed.CoverCount)
-			{
-				info.PageType = ComicPageType.FrontCover;
-			}
-			return info;
-		}
-
-		public static ComicBook DeserializeFull(Stream stream)
-		{
-			return XmlUtility.Load<ComicBook>(stream, compressed: false);
-		}
-
-		public static ComicBook DeserializeFull(string file)
-		{
-			return XmlUtility.Load<ComicBook>(file, compressed: false);
-		}
-
-		public void SerializeFull(Stream stream)
-		{
-			XmlUtility.Store(stream, this, compressed: false);
-		}
-
-		public void SerializeFull(string file)
-		{
-			XmlUtility.Store(file, this, compressed: false);
-		}
-
-		public static string FormatPages(int pages)
-		{
-			if (pages <= 0)
-			{
-				return unkownText.Value;
-			}
-			return StringUtility.Format(pagesText.Value, pages);
-		}
-
-		public static string FormatRating(float rating)
-		{
-			if (!(rating <= 0f))
-			{
-				return rating.ToString("0.0");
-			}
-			return noneText.Value;
-		}
-
-		public static string FormatYear(int year)
-		{
-			if (year != -1)
-			{
-				return year.ToString();
-			}
-			return string.Empty;
-		}
-
-		public static string FormatNumber(string number, int count)
-		{
-			if (string.IsNullOrEmpty(number))
-			{
-				return string.Empty;
-			}
-			string text = ((number == "-") ? string.Empty : number);
-			if (count >= 0)
-			{
-				text += StringUtility.Format(" ({0} {1})", ofText.Value, count);
-			}
-			return text;
-		}
-
-		public static string FormatVolume(int volume)
-		{
-			if (volume != -1)
-			{
-				return StringUtility.Format(volumeFormat.Value, volume);
-			}
-			return string.Empty;
-		}
-
-		public static string FormatTitle(string textFormat, string series, string title = null, string volumeText = null, string numberText = null, string yearText = null, string monthText = null, string dayText = null, string format = null, string fileName = null)
-		{
-			if (!string.IsNullOrEmpty(series))
-			{
-				try
-				{
-					return ExtendedStringFormater.Format(textFormat, delegate(string s)
-					{
-						switch (s)
-						{
-						case "filename":
-							return fileName;
-						case "series":
-							return series;
-						case "title":
-							return title;
-						case "volume":
-							return volumeText;
-						case "number":
-							return numberText;
-						case "year":
-							return yearText;
-						case "month":
-							return monthText;
-						case "day":
-							return dayText;
-						case "format":
-							if (!series.Contains(format, StringComparison.OrdinalIgnoreCase))
-							{
-								return format;
-							}
-							return string.Empty;
-						default:
-							return null;
-						}
-					}).Trim();
-				}
-				catch
-				{
-				}
-			}
-			return fileName ?? string.Empty;
-		}
-
-		private static void AppendString(StringBuilder s, string delimiter, string text)
-		{
-			if (!string.IsNullOrEmpty(text))
-			{
-				if (s.Length != 0)
-				{
-					s.Append(delimiter);
-				}
-				s.Append(text);
-			}
-		}
-
-		public static string FormatDate(DateTime date, ComicDateFormat dateFormat = ComicDateFormat.Long, bool toLocal = false, string missingText = null)
-		{
-			if (date == DateTime.MinValue)
-			{
-				return missingText ?? neverText.Value;
-			}
-			if (toLocal)
-			{
-				date = date.ToLocalTime();
-			}
-			switch (dateFormat)
-			{
-			default:
-				if (!date.IsDateOnly())
-				{
-					return date.ToString();
-				}
-				return date.ToShortDateString();
-			case ComicDateFormat.Short:
-				return date.ToShortDateString();
-			case ComicDateFormat.Relative:
-				return date.ToRelativeDateString(DateTime.Now);
-			}
-		}
-
-		public static string FormatFileDate(DateTime date, ComicDateFormat dateFormat = ComicDateFormat.Long)
-		{
-			return FormatDate(date, dateFormat, toLocal: true, notFoundText.Value);
-		}
-
-		public static string GetLanguageName(string iso)
-		{
-			try
-			{
-				return GetIsoCulture(iso).DisplayName;
-			}
-			catch
-			{
-				return string.Empty;
-			}
-		}
-
-		public static CultureInfo GetIsoCulture(string iso)
-		{
-			iso = iso.ToLower();
-			if (languages == null)
-			{
-				languages = new Dictionary<string, CultureInfo>();
-			}
-			new Dictionary<string, CultureInfo>();
-			if (languages.TryGetValue(iso, out var value))
-			{
-				return value;
-			}
-			CultureInfo cultureInfo = CultureInfo.GetCultures(CultureTypes.NeutralCultures).FirstOrDefault((CultureInfo info) => info.TwoLetterISOLanguageName == iso);
-			if (cultureInfo != null)
-			{
-				return languages[iso] = cultureInfo;
-			}
-			return new CultureInfo(string.Empty);
-		}
-
-		public static IEnumerable<string> GetProperties(bool onlyWritable, Type t = null)
-		{
+        {
+            ComicBook comicBook = new ComicBook
+            {
+                FilePath = file
+            };
+            comicBook.RefreshInfoFromFile(options);
+            return comicBook;
+        }
+
+        private void ResetOptimizedNumbers()
+        {
+            compareNumber = (compareAlternateNumber = null);
+        }
+
+        public static void ClearExtraSyncInformation()
+        {
+            using (ItemMonitor.Lock(syncInfo))
+            {
+                syncInfo.Clear();
+            }
+        }
+
+        public IEnumerable<StringPair> GetCustomValues()
+        {
+            return ValuesStore.GetValues(CustomValuesStore);
+        }
+
+        public void SetCustomValue(string key, string value)
+        {
+            if (!string.IsNullOrEmpty(key))
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    DeleteCustomValue(key);
+                }
+                else
+                {
+                    CustomValuesStore = new ValuesStore(CustomValuesStore).Add(key, value).ToString();
+                }
+            }
+        }
+
+        public string GetCustomValue(string key)
+        {
+            return ValuesStore.GetValue(CustomValuesStore, key);
+        }
+
+        public void DeleteCustomValue(string key)
+        {
+            CustomValuesStore = new ValuesStore(CustomValuesStore).Remove(key).ToString();
+        }
+
+        public ThumbnailKey GetThumbnailKey(int page)
+        {
+            string locationKey = ((!IsLinked) ? (string.IsNullOrEmpty(CustomThumbnailKey) ? ThumbnailKey.GetResource(ThumbnailKey.ResourceKey, "Unknown") : ThumbnailKey.GetResource(ThumbnailKey.CustomKey, CustomThumbnailKey)) : FileLocation);
+            return GetThumbnailKey(page, locationKey);
+        }
+
+        public ThumbnailKey GetThumbnailKey(int page, string locationKey)
+        {
+            return new ThumbnailKey(this, locationKey, FileSize, FileModifiedTime, TranslatePageToImageIndex(page), GetPage(page).Rotation);
+        }
+
+        public ThumbnailKey GetFrontCoverThumbnailKey()
+        {
+            return GetThumbnailKey(base.FrontCoverPageIndex);
+        }
+
+        public PageKey GetFrontCoverKey(BitmapAdjustment bitmapAdjustment)
+        {
+            return GetPageKey(base.FrontCoverPageIndex, bitmapAdjustment);
+        }
+
+        public PageKey GetPageKey(int page, BitmapAdjustment bitmapAdjustment)
+        {
+            return new PageKey(this, FileLocation, FileSize, FileModifiedTime, TranslatePageToImageIndex(page), GetPage(page).Rotation, bitmapAdjustment);
+        }
+
+        public ImageKey GetImageKey(int image)
+        {
+            return new PageKey(this, FileLocation, FileSize, FileModifiedTime, image, ImageRotation.None, BitmapAdjustment.Empty);
+        }
+
+        public ImageProvider CreateImageProvider()
+        {
+            CreateComicProviderEventArgs createComicProviderEventArgs = new CreateComicProviderEventArgs();
+            OnCreateComicProvider(createComicProviderEventArgs);
+            createComicProviderEventArgs.Provider = createComicProviderEventArgs.Provider ?? Providers.Readers.CreateSourceProvider(FilePath);
+            OnComicProviderCreated(createComicProviderEventArgs);
+            return createComicProviderEventArgs.Provider;
+        }
+
+        public ImageProvider OpenProvider(int lastPageIndexToRead = -1)
+        {
+            ImageProvider imageProvider = CreateImageProvider();
+            try
+            {
+                if (lastPageIndexToRead != -1)
+                {
+                    int imageIndex = TranslatePageToImageIndex(lastPageIndexToRead);
+                    imageProvider.ImageReady += delegate(object s, ImageIndexReadyEventArgs e)
+                    {
+                        e.Cancel = e.ImageNumber == imageIndex;
+                    };
+                }
+                imageProvider.Open(async: false);
+                return imageProvider;
+            }
+            catch
+            {
+                imageProvider?.Dispose();
+                return null;
+            }
+        }
+
+        public string GetPublisherIconKey()
+        {
+            string text = base.Publisher;
+            if (base.Year >= 0)
+            {
+                text = text + "(" + YearAsText + ")";
+            }
+            return text;
+        }
+
+        public string GetImprintIconKey()
+        {
+            string text = base.Imprint;
+            if (base.Year >= 0)
+            {
+                text = text + "(" + YearAsText + ")";
+            }
+            return text;
+        }
+
+        private IEnumerable<Image> GetIconsInternal()
+        {
+            Image img2 = PublisherIcons.GetImage(GetPublisherIconKey());
+            Image image;
+            if (img2 != null)
+            {
+                yield return img2;
+            }
+            else
+            {
+                img2 = (image = PublisherIcons.GetImage(Publisher));
+                if (image != null)
+                {
+                    yield return img2;
+                }
+            }
+            img2 = (image = PublisherIcons.GetImage(GetImprintIconKey()));
+            if (image != null)
+            {
+                yield return img2;
+            }
+            else
+            {
+                img2 = (image = PublisherIcons.GetImage(Imprint));
+                if (image != null)
+                {
+                    yield return img2;
+                }
+            }
+            img2 = (image = AgeRatingIcons.GetImage(AgeRating));
+            if (image != null)
+            {
+                yield return img2;
+            }
+            img2 = (image = FormatIcons.GetImage(ShadowFormat));
+            if (image != null)
+            {
+                yield return img2;
+            }
+            if (!string.IsNullOrEmpty(Tags))
+            {
+                foreach (string item in Tags.ListStringToSet(','))
+                {
+                    img2 = (image = SpecialIcons.GetImage(item));
+                    if (image != null)
+                    {
+                        yield return img2;
+                    }
+                }
+            }
+            if (SeriesComplete == YesNo.Yes)
+            {
+                img2 = (image = SpecialIcons.GetImage("SeriesComplete"));
+                if (image != null)
+                {
+                    yield return img2;
+                }
+            }
+            if (BlackAndWhite == YesNo.Yes)
+            {
+                img2 = (image = SpecialIcons.GetImage("BlackAndWhite"));
+                if (image != null)
+                {
+                    yield return img2;
+                }
+            }
+            if (Manga == MangaYesNo.Yes)
+            {
+                img2 = (image = SpecialIcons.GetImage("Manga"));
+                if (image != null)
+                {
+                    yield return img2;
+                }
+            }
+            if (Manga == MangaYesNo.YesAndRightToLeft)
+            {
+                img2 = (image = SpecialIcons.GetImage("MangaRightToLeft"));
+                if (image != null)
+                {
+                    yield return img2;
+                }
+            }
+        }
+
+        public IEnumerable<Image> GetIcons()
+        {
+            return GetIconsInternal();
+        }
+
+        public void CopyFrom(ComicBook cb)
+        {
+            SetInfo(cb, onlyUpdateEmpty: false);
+            Id = cb.Id;
+            AddedTime = cb.AddedTime;
+            ReleasedTime = cb.ReleasedTime;
+            OpenedTime = cb.OpenedTime;
+            OpenedCount = cb.OpenedCount;
+            CurrentPage = cb.CurrentPage;
+            LastPageRead = cb.LastPageRead;
+            Rating = cb.Rating;
+            ColorAdjustment = cb.ColorAdjustment;
+            EnableDynamicUpdate = cb.EnableDynamicUpdate;
+            EnableProposed = cb.EnableProposed;
+            SeriesComplete = cb.SeriesComplete;
+            Checked = cb.Checked;
+            FilePath = cb.FilePath;
+            FileSize = cb.FileSize;
+            FileModifiedTime = cb.FileModifiedTime;
+            FileCreationTime = cb.FileCreationTime;
+            fileLocation = cb.FileLocation;
+            customThumbnailKey = cb.CustomThumbnailKey;
+            LastOpenedFromListId = cb.LastOpenedFromListId;
+            CustomValuesStore = cb.CustomValuesStore;
+        }
+
+        public void CopyTo(ComicBook cb)
+        {
+            cb.CopyFrom(this);
+        }
+
+        public string GetFullTitle(string textFormat, params string[] ignore)
+        {
+            try
+            {
+                return ExtendedStringFormater.Format(textFormat, delegate(string s)
+                {
+                    try
+                    {
+                        if (ignore != null && ignore.Length != 0 && ignore.Contains(s, StringComparer.OrdinalIgnoreCase))
+                        {
+                            return null;
+                        }
+                        MapPropertyNameToAsText(s, out var newName);
+                        return GetPropertyValue<string>(newName, ComicValueType.Shadow);
+                    }
+                    catch
+                    {
+                        return null;
+                    }
+                });
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        public void SetShadowValues(ComicInfo ci)
+        {
+            ci.Series = ShadowSeries;
+            ci.Count = ShadowCount;
+            ci.Title = ShadowTitle;
+            ci.Year = ShadowYear;
+            ci.Number = ShadowNumber;
+            ci.Format = ShadowFormat;
+            ci.Volume = ShadowVolume;
+        }
+
+        public void SetFileLocation(string fileLocation)
+        {
+            this.fileLocation = fileLocation;
+        }
+
+        public void MarkAsNotRead()
+        {
+            OpenedTime = DateTime.MinValue;
+            int num2 = (CurrentPage = 0);
+            int num5 = (OpenedCount = (LastPageRead = num2));
+        }
+
+        public void MarkAsRead()
+        {
+            if (OpenedCount == 0)
+            {
+                OpenedCount = 1;
+            }
+            OpenedTime = DateTime.Now;
+            if (base.PageCount > 0)
+            {
+                int num3 = (CurrentPage = (LastPageRead = base.PageCount - 1));
+            }
+        }
+
+        public void ResetProperties(int level = 0)
+        {
+            ResetValueAttribute.ResetProperties(this, level);
+        }
+
+        public bool RemoveFromContainer()
+        {
+            return Container?.Books.Remove(this) ?? false;
+        }
+
+        public bool IsSearchable(string propName)
+        {
+            if (searchableProperties == null)
+            {
+                searchableProperties = new HashSet<string>(from pi in GetType().GetProperties().Where(SearchableAttribute.IsSearchable)
+                                                           select pi.Name);
+            }
+            return searchableProperties.Contains(propName);
+        }
+
+        public object GetUntypedPropertyValue(string propName)
+        {
+            return GetType().GetProperty(propName).GetValue(this, null);
+        }
+
+        public T GetPropertyValue<T>(string propName, ComicValueType cvt = ComicValueType.Standard)
+        {
+            MapPropertyName(propName, out propName, cvt);
+            try
+            {
+                if (!propName.StartsWith("{"))
+                {
+                    return PropertyCaller.CreateGetMethod<ComicBook, T>(propName)(this);
+                }
+                propName = propName.Substring(1, propName.Length - 2);
+                return (T)(object)GetCustomValue(propName);
+            }
+            catch (Exception)
+            {
+                return default(T);
+            }
+        }
+
+        public string GetStringPropertyValue(string propName, ComicValueType cvt = ComicValueType.Standard)
+        {
+            return GetPropertyValue<string>(propName, cvt) ?? string.Empty;
+        }
+
+        public T GetPropertyValue<T>(string propName, bool proposed)
+        {
+            T propertyValue = GetPropertyValue<T>(propName);
+            if (!proposed || !EnableProposed || !IsDefaultPropertyValue(propertyValue) || !MapPropertyName(propName, out propName, ComicValueType.Proposed))
+            {
+                return propertyValue;
+            }
+            return GetPropertyValue<T>(propName);
+        }
+
+        public string FormatString(string format)
+        {
+            return rxField.Replace(format, delegate(Match m)
+            {
+                try
+                {
+                    return PropertyCaller.CreateGetMethod<ComicBook, string>(m.Groups[1].Value)(this) ?? string.Empty;
+                }
+                catch (Exception)
+                {
+                    return m.Value;
+                }
+            });
+        }
+
+        public void WriteProposedValues(bool overwriteAll)
+        {
+            if (overwriteAll || string.IsNullOrEmpty(base.Series))
+            {
+                base.Series = ProposedSeries;
+            }
+            if (overwriteAll || string.IsNullOrEmpty(base.Title))
+            {
+                base.Title = ProposedTitle;
+            }
+            if (overwriteAll || base.Year == -1)
+            {
+                base.Year = ProposedYear;
+            }
+            if (overwriteAll || string.IsNullOrEmpty(base.Number))
+            {
+                base.Number = ProposedNumber;
+            }
+            if (overwriteAll || base.Volume == -1)
+            {
+                base.Volume = ProposedVolume;
+            }
+            if (overwriteAll || base.Count == -1)
+            {
+                base.Count = ProposedCount;
+            }
+            if (overwriteAll || string.IsNullOrEmpty(base.Format))
+            {
+                base.Format = ProposedFormat;
+            }
+            EnableProposed = false;
+        }
+
+        public bool RenameFile(string newName)
+        {
+            if (!IsLinked || !EditMode.IsLocalComic())
+            {
+                return false;
+            }
+            try
+            {
+                newName = FileUtility.MakeValidFilename(newName);
+                string text = Path.Combine(FileDirectory, newName + Path.GetExtension(FilePath));
+                if (string.Equals(FilePath, text, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+                File.Move(FilePath, text);
+                FilePath = text;
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public ComicBookNavigator CreateNavigator()
+        {
+            try
+            {
+                ComicBookNavigator comicBookNavigator = new ComicBookNavigator(this);
+                switch (base.Manga)
+                {
+                    case MangaYesNo.Unknown:
+                        comicBookNavigator.RightToLeftReading = YesNo.Unknown;
+                        break;
+                    case MangaYesNo.No:
+                    case MangaYesNo.Yes:
+                        comicBookNavigator.RightToLeftReading = YesNo.No;
+                        break;
+                    case MangaYesNo.YesAndRightToLeft:
+                        comicBookNavigator.RightToLeftReading = YesNo.Yes;
+                        break;
+                }
+                return comicBookNavigator;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public void SetValue(string propertyName, object value)
+        {
+            try
+            {
+                GetType().GetProperty(propertyName).SetValue(this, value, null);
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        public string Hash()
+        {
+            try
+            {
+                if (EditMode.IsLocalComic() && !string.IsNullOrEmpty(FilePath) && File.Exists(FilePath))
+                {
+                    return CreateFileHash();
+                }
+            }
+            catch
+            {
+            }
+            return null;
+        }
+
+        public void CopyDataFrom(ComicBook data, IEnumerable<string> properties)
+        {
+            Type type = data.GetType();
+            foreach (string property2 in properties)
+            {
+                try
+                {
+                    if (property2.StartsWith("{"))
+                    {
+                        string key = property2.Substring(1, property2.Length - 2);
+                        SetCustomValue(key, data.GetCustomValue(key));
+                    }
+                    else
+                    {
+                        PropertyInfo property = type.GetProperty(property2);
+                        property.SetValue(this, property.GetValue(data, null), null);
+                    }
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        public void ToClipboard()
+        {
+            ComicBook comicBook = CloneUtility.Clone(this);
+            comicBook.Id = Guid.NewGuid();
+            DataObject dataObject = new DataObject();
+            dataObject.SetData(DataFormats.UnicodeText, GetInfo().ToXml());
+            dataObject.SetData(ClipboardFormat, comicBook);
+            Clipboard.SetDataObject(dataObject);
+        }
+
+        public bool IsDefaultValue(string property)
+        {
+            PropertyInfo property2 = GetType().GetProperty(property);
+            return object.Equals(property2.GetValue(Default, null), property2.GetValue(this, null));
+        }
+
+        public void ValidateData()
+        {
+            TrimExcessPageInfo();
+            if (!FileIsMissing && FileCreationTime == DateTime.MinValue)
+            {
+                try
+                {
+                    FileCreationTime = File.GetCreationTimeUtc(FilePath);
+                }
+                catch (Exception)
+                {
+                }
+            }
+        }
+
+        public void UpdateDynamicPageCount(bool refresh, IProgressState ps = null)
+        {
+            try
+            {
+                using (ImageProvider imageProvider = Providers.Readers.CreateSourceProvider(FilePath))
+                {
+                    IDynamicImages dynamicImages = imageProvider as IDynamicImages;
+                    if (dynamicImages != null)
+                    {
+                        dynamicImages.RefreshMode = refresh;
+                    }
+                    if (ps != null)
+                    {
+                        imageProvider.ImageReady += delegate(object s, ImageIndexReadyEventArgs e)
+                        {
+                            ps.ProgressAvailable = base.PageCount > 0;
+                            if (ps.ProgressAvailable)
+                            {
+                                ps.ProgressPercentage = 100 * e.ImageNumber / base.PageCount;
+                            }
+                        };
+                    }
+                    imageProvider.Open(async: false);
+                    NewPages = Math.Max(imageProvider.Count - base.PageCount, 0);
+                }
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        public bool WriteInfoToFile(bool withRefreshFileProperties = true)
+        {
+            if (!EditMode.IsLocalComic())
+            {
+                return false;
+            }
+            FileInfo fileInfo = new FileInfo(FilePath);
+            if (!fileInfo.Exists || fileInfo.IsReadOnly)
+            {
+                return false;
+            }
+            using (ImageProvider imageProvider = CreateImageProvider())
+            {
+                IInfoStorage infoStorage = imageProvider as IInfoStorage;
+                if (infoStorage == null)
+                {
+                    return false;
+                }
+                infoStorage.StoreInfo(GetInfo());
+                FileInfoRetrieved = true;
+            }
+            if (withRefreshFileProperties)
+            {
+                RefreshFileProperties();
+            }
+            return true;
+        }
+
+        public void ResetInfoRetrieved()
+        {
+            FileInfoRetrieved = false;
+        }
+
+        public void RefreshInfoFromFile(RefreshInfoOptions options)
+        {
+            if ((options & RefreshInfoOptions.DontReadInformation) != 0 || !EditMode.IsLocalComic() || !IsLinked)
+            {
+                return;
+            }
+            DateTime d = FileModifiedTime;
+            long num = FileSize;
+            RefreshFileProperties();
+            if (FileIsMissing)
+            {
+                return;
+            }
+            bool flag = FileModifiedTime != d;
+            try
+            {
+                IsDynamicSource = Providers.Readers.GetSourceProviderInfo(FilePath).Formats.All((FileFormat f) => f.Dynamic);
+            }
+            catch (Exception)
+            {
+                IsDynamicSource = false;
+            }
+            if (!(!FileInfoRetrieved || flag) && (options & RefreshInfoOptions.ForceRefresh) == 0 && ((options & (RefreshInfoOptions.GetFastPageCount | RefreshInfoOptions.GetPageCount)) == 0 || base.PageCount != 0))
+            {
+                return;
+            }
+            using (ImageProvider imageProvider = CreateImageProvider())
+            {
+                IInfoStorage infoStorage = imageProvider as IInfoStorage;
+                if (infoStorage == null)
+                {
+                    return;
+                }
+                if (!ComicInfoIsDirty)
+                {
+                    SetInfo(infoStorage.LoadInfo((flag || !FileInfoRetrieved) ? InfoLoadingMethod.Complete : InfoLoadingMethod.Fast));
+                }
+                if (!imageProvider.IsSlow && (base.PageCount == 0 || num != FileSize) && (((options & RefreshInfoOptions.GetFastPageCount) != 0 && (imageProvider.Capabilities & ImageProviderCapabilities.FastPageInfo) != 0) || (options & RefreshInfoOptions.GetPageCount) != 0))
+                {
+                    try
+                    {
+                        imageProvider.Open(async: false);
+                        if (imageProvider.Count > 0)
+                        {
+                            base.PageCount = imageProvider.Count;
+                        }
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+            FileInfoRetrieved = true;
+        }
+
+        public void RefreshInfoFromFile()
+        {
+            RefreshInfoFromFile(RefreshInfoOptions.GetFastPageCount);
+        }
+
+        public string CreateFileHash()
+        {
+            using (ImageProvider imageProvider = CreateImageProvider())
+            {
+                imageProvider.Open(async: false);
+                return imageProvider.CreateHash();
+            }
+        }
+
+        public void RefreshFileProperties()
+        {
+            if (!EditMode.IsLocalComic())
+            {
+                return;
+            }
+            try
+            {
+                FileInfo fileInfo = new FileInfo(FilePath);
+                FileIsMissing = !fileInfo.Exists;
+                if (fileInfo.Exists)
+                {
+                    bool flag = fileSize != fileInfo.Length;
+                    bool flag2 = fileModifiedTime != fileInfo.LastWriteTimeUtc;
+                    fileSize = fileInfo.Length;
+                    fileModifiedTime = fileInfo.LastWriteTimeUtc;
+                    if (flag)
+                    {
+                        FireBookChanged("FileSize");
+                    }
+                    if (flag2)
+                    {
+                        FireBookChanged("FileModifiedTime");
+                    }
+                    FileCreationTime = fileInfo.CreationTimeUtc;
+                }
+            }
+            catch
+            {
+                FileIsMissing = true;
+            }
+        }
+
+        private bool SetProperty<T>(string name, ref T property, T value, bool lockItem = false, bool addUndo = true)
+        {
+            if (object.Equals(property, value))
+            {
+                return false;
+            }
+            T val = property;
+            using (lockItem ? ItemMonitor.Lock(this) : null)
+            {
+                property = value;
+            }
+            if (addUndo)
+            {
+                FireBookChanged(name, val, value);
+            }
+            else
+            {
+                FireBookChanged(name);
+            }
+            return true;
+        }
+
+        private void FireBookChanged(string name)
+        {
+            OnBookChanged(new BookChangedEventArgs(name, isComicInfo: false));
+        }
+
+        private void FireBookChanged(string name, object oldValue, object newValue)
+        {
+            OnBookChanged(new BookChangedEventArgs(name, isComicInfo: false, oldValue, newValue));
+        }
+
+        private void UpdateProposed()
+        {
+            if (proposed == null)
+            {
+                OnParseFilePath();
+            }
+        }
+
+        protected virtual void OnFileRenamed(ComicBookFileRenameEventArgs e)
+        {
+            if (this.FileRenamed != null)
+            {
+                this.FileRenamed(this, e);
+            }
+        }
+
+        protected virtual void OnCreateComicProvider(CreateComicProviderEventArgs cpea)
+        {
+            if (this.CreateComicProvider != null)
+            {
+                this.CreateComicProvider(this, cpea);
+            }
+        }
+
+        protected virtual void OnComicProviderCreated(CreateComicProviderEventArgs cpea)
+        {
+            if (this.ComicProviderCreated != null)
+            {
+                this.ComicProviderCreated(this, cpea);
+            }
+        }
+
+        protected override void OnBookChanged(BookChangedEventArgs e)
+        {
+            base.OnBookChanged(e);
+            if (e.PropertyName == "FilePath" || e.PropertyName == "Number" || e.PropertyName == "EnableProposed")
+            {
+                compareNumber = null;
+            }
+            else if (e.PropertyName == "AlternateNumber")
+            {
+                compareAlternateNumber = null;
+            }
+        }
+
+        public override void SetInfo(ComicInfo ci, bool onlyUpdateEmpty = true, bool updatePages = true)
+        {
+            base.SetInfo(ci, onlyUpdateEmpty, updatePages);
+            LastPageRead = Math.Min(base.PageCount - 1, LastPageRead);
+            CurrentPage = Math.Min(base.PageCount - 1, CurrentPage);
+        }
+
+        protected override ComicPageInfo OnNewComicPageAdded(ComicPageInfo info)
+        {
+            if (proposed != null && info.ImageIndex < proposed.CoverCount)
+            {
+                info.PageType = ComicPageType.FrontCover;
+            }
+            return info;
+        }
+
+        public static ComicBook DeserializeFull(Stream stream)
+        {
+            return XmlUtility.Load<ComicBook>(stream, compressed: false);
+        }
+
+        public static ComicBook DeserializeFull(string file)
+        {
+            return XmlUtility.Load<ComicBook>(file, compressed: false);
+        }
+
+        public void SerializeFull(Stream stream)
+        {
+            XmlUtility.Store(stream, this, compressed: false);
+        }
+
+        public void SerializeFull(string file)
+        {
+            XmlUtility.Store(file, this, compressed: false);
+        }
+
+        public static string FormatPages(int pages)
+        {
+            if (pages <= 0)
+            {
+                return unkownText.Value;
+            }
+            return StringUtility.Format(pagesText.Value, pages);
+        }
+
+        public static string FormatRating(float rating)
+        {
+            if (!(rating <= 0f))
+            {
+                return rating.ToString("0.0");
+            }
+            return noneText.Value;
+        }
+
+        public static string FormatYear(int year)
+        {
+            if (year != -1)
+            {
+                return year.ToString();
+            }
+            return string.Empty;
+        }
+
+        public static string FormatNumber(string number, int count)
+        {
+            if (string.IsNullOrEmpty(number))
+            {
+                return string.Empty;
+            }
+            string text = ((number == "-") ? string.Empty : number);
+            if (count >= 0)
+            {
+                text += StringUtility.Format(" ({0} {1})", ofText.Value, count);
+            }
+            return text;
+        }
+
+        public static string FormatVolume(int volume)
+        {
+            if (volume != -1)
+            {
+                return StringUtility.Format(volumeFormat.Value, volume);
+            }
+            return string.Empty;
+        }
+
+        public static string FormatTitle(string textFormat, string series, string title = null, string volumeText = null, string numberText = null, string yearText = null, string monthText = null, string dayText = null, string format = null, string fileName = null)
+        {
+            if (!string.IsNullOrEmpty(series))
+            {
+                try
+                {
+                    return ExtendedStringFormater.Format(textFormat, delegate(string s)
+                    {
+                        switch (s)
+                        {
+                            case "filename":
+                                return fileName;
+                            case "series":
+                                return series;
+                            case "title":
+                                return title;
+                            case "volume":
+                                return volumeText;
+                            case "number":
+                                return numberText;
+                            case "year":
+                                return yearText;
+                            case "month":
+                                return monthText;
+                            case "day":
+                                return dayText;
+                            case "format":
+                                if (!series.Contains(format, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    return format;
+                                }
+                                return string.Empty;
+                            default:
+                                return null;
+                        }
+                    }).Trim();
+                }
+                catch
+                {
+                }
+            }
+            return fileName ?? string.Empty;
+        }
+
+        private static void AppendString(StringBuilder s, string delimiter, string text)
+        {
+            if (!string.IsNullOrEmpty(text))
+            {
+                if (s.Length != 0)
+                {
+                    s.Append(delimiter);
+                }
+                s.Append(text);
+            }
+        }
+
+        public static string FormatDate(DateTime date, ComicDateFormat dateFormat = ComicDateFormat.Long, bool toLocal = false, string missingText = null)
+        {
+            if (date == DateTime.MinValue)
+            {
+                return missingText ?? neverText.Value;
+            }
+            if (toLocal)
+            {
+                date = date.ToLocalTime();
+            }
+            switch (dateFormat)
+            {
+                default:
+                    if (!date.IsDateOnly())
+                    {
+                        return date.ToString();
+                    }
+                    return date.ToShortDateString();
+                case ComicDateFormat.Short:
+                    return date.ToShortDateString();
+                case ComicDateFormat.Relative:
+                    return date.ToRelativeDateString(DateTime.Now);
+            }
+        }
+
+        public static string FormatFileDate(DateTime date, ComicDateFormat dateFormat = ComicDateFormat.Long)
+        {
+            return FormatDate(date, dateFormat, toLocal: true, notFoundText.Value);
+        }
+
+        public static string GetLanguageName(string iso)
+        {
+            try
+            {
+                return GetIsoCulture(iso).DisplayName;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        public static CultureInfo GetIsoCulture(string iso)
+        {
+            iso = iso.ToLower();
+            if (languages == null)
+            {
+                languages = new Dictionary<string, CultureInfo>();
+            }
+            new Dictionary<string, CultureInfo>();
+            if (languages.TryGetValue(iso, out var value))
+            {
+                return value;
+            }
+            CultureInfo cultureInfo = CultureInfo.GetCultures(CultureTypes.NeutralCultures).FirstOrDefault((CultureInfo info) => info.TwoLetterISOLanguageName == iso);
+            if (cultureInfo != null)
+            {
+                return languages[iso] = cultureInfo;
+            }
+            return new CultureInfo(string.Empty);
+        }
+
+        public static IEnumerable<string> GetProperties(bool onlyWritable, Type t = null)
+        {
             return from pi in typeof(ComicBook).GetProperties(BindingFlags.Instance | BindingFlags.Public)
-				where pi.CanRead && (pi.CanWrite || !onlyWritable) && (t == null || pi.PropertyType == t) && pi.Browsable(forced: true)
-				select pi.Name;
-		}
+                   where pi.CanRead && (pi.CanWrite || !onlyWritable) && (t == null || pi.PropertyType == t) && pi.Browsable(forced: true)
+                   select pi.Name;
+        }
 
-		public static IEnumerable<string> GetWritableStringProperties()
-		{
-			return GetProperties(onlyWritable: true, typeof(string));
-		}
+        public static IEnumerable<string> GetWritableStringProperties()
+        {
+            return GetProperties(onlyWritable: true, typeof(string));
+        }
 
-		public static IDictionary<string, string> GetTranslatedWritableStringProperties()
-		{
-			TR tr = TR.Load("Columns");
-			return GetWritableStringProperties().ToDictionary((string s) => tr[s].PascalToSpaced());
-		}
+        public static IDictionary<string, string> GetTranslatedWritableStringProperties()
+        {
+            TR tr = TR.Load("Columns");
+            return GetWritableStringProperties().ToDictionary((string s) => tr[s].PascalToSpaced());
+        }
 
-		public static bool MapPropertyName(string propName, out string newName, ComicValueType cvt)
-		{
-			string text = propName.ToLower();
-			if (text == "cover" || text == "rating")
-			{
-				propName += "AsText";
-			}
-			if (cvt != 0)
-			{
-				switch (text)
-				{
-				case "series":
-				case "title":
-				case "format":
-				case "count":
-				case "year":
-				case "number":
-				case "yearastext":
-				case "numberastext":
-				case "volumeastext":
-				case "countastext":
-					newName = ((cvt == ComicValueType.Proposed) ? "Proposed" : "Shadow") + propName;
-					return true;
-				}
-			}
-			newName = propName;
-			return false;
-		}
+        public static bool MapPropertyName(string propName, out string newName, ComicValueType cvt)
+        {
+            string text = propName.ToLower();
+            if (text == "cover" || text == "rating")
+            {
+                propName += "AsText";
+            }
+            if (cvt != 0)
+            {
+                switch (text)
+                {
+                    case "series":
+                    case "title":
+                    case "format":
+                    case "count":
+                    case "year":
+                    case "number":
+                    case "yearastext":
+                    case "numberastext":
+                    case "volumeastext":
+                    case "countastext":
+                        newName = ((cvt == ComicValueType.Proposed) ? "Proposed" : "Shadow") + propName;
+                        return true;
+                }
+            }
+            newName = propName;
+            return false;
+        }
 
-		public static bool MapPropertyNameToAsText(string propName, out string newName)
-		{
-			if (hasAsText.TryGetValue(propName, out newName))
-			{
-				return true;
-			}
-			string text = propName + "AsText";
-			if (typeof(ComicBook).GetProperty(text, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Public) != null)
-			{
-				propName = text;
-			}
-			hasAsText[propName] = propName;
-			newName = propName;
-			return true;
-		}
+        public static bool MapPropertyNameToAsText(string propName, out string newName)
+        {
+            if (hasAsText.TryGetValue(propName, out newName))
+            {
+                return true;
+            }
+            string text = propName + "AsText";
+            if (typeof(ComicBook).GetProperty(text, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Public) != null)
+            {
+                propName = text;
+            }
+            hasAsText[propName] = propName;
+            newName = propName;
+            return true;
+        }
 
-		public static bool IsDefaultPropertyValue(object value)
-		{
-			if (value == null)
-			{
-				return true;
-			}
-			if (value is string)
-			{
-				return string.IsNullOrEmpty((string)value);
-			}
-			if (value is int || value is double || value is float)
-			{
-				return (int)value == -1;
-			}
-			if (value is DateTime)
-			{
-				return (DateTime)value == DateTime.MinValue;
-			}
-			return false;
-		}
+        public static bool IsDefaultPropertyValue(object value)
+        {
+            if (value == null)
+            {
+                return true;
+            }
+            if (value is string)
+            {
+                return string.IsNullOrEmpty((string)value);
+            }
+            if (value is int || value is double || value is float)
+            {
+                return (int)value == -1;
+            }
+            if (value is DateTime)
+            {
+                return (DateTime)value == DateTime.MinValue;
+            }
+            return false;
+        }
 
-		protected virtual void OnParseFilePath()
-		{
-			ParseFilePathEventArgs parseFilePathEventArgs = new ParseFilePathEventArgs(FilePath);
-			if (ComicBook.ParseFilePath != null)
-			{
-				ComicBook.ParseFilePath(this, parseFilePathEventArgs);
-			}
-			proposed = parseFilePathEventArgs.NameInfo;
-		}
+        protected virtual void OnParseFilePath()
+        {
+            ParseFilePathEventArgs parseFilePathEventArgs = new ParseFilePathEventArgs(FilePath);
+            if (ComicBook.ParseFilePath != null)
+            {
+                ComicBook.ParseFilePath(this, parseFilePathEventArgs);
+            }
+            proposed = parseFilePathEventArgs.NameInfo;
+        }
 
-		public object Clone()
-		{
-			return new ComicBook(this);
-		}
-	}
+        public object Clone()
+        {
+            return new ComicBook(this);
+        }
+    }
 }

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -1598,7 +1598,7 @@ namespace cYo.Projects.ComicRack.Engine
 
 		public static event EventHandler<ParseFilePathEventArgs> ParseFilePath;
 
-        private void UpdateVirtualTags(object sender, EventArgs e)
+        private void UpdateVirtualTags()
         {
 			for (int i = 1; i <= 10; i++)
 			{
@@ -1609,52 +1609,42 @@ namespace cYo.Projects.ComicRack.Engine
 
         [XmlIgnore]
         [Browsable(true)]
-		[DefaultValue("")]
-		public string VirtualTag01 { get; set; }
+        public string VirtualTag01 { get; set; }
 
         [XmlIgnore]
         [Browsable(true)]
-        [DefaultValue("")]
         public string VirtualTag02 { get; set; }
 
         [XmlIgnore]
         [Browsable(true)]
-        [DefaultValue("")]
         public string VirtualTag03 { get; set; }
 
         [XmlIgnore]
         [Browsable(true)]
-        [DefaultValue("")]
         public string VirtualTag04 { get; set; }
 
         [XmlIgnore]
         [Browsable(true)]
-        [DefaultValue("")]
         public string VirtualTag05 { get; set; }
 
         [XmlIgnore]
         [Browsable(true)]
-        [DefaultValue("")]
         public string VirtualTag06 { get; set; }
 
         [XmlIgnore]
         [Browsable(true)]
-        [DefaultValue("")]
         public string VirtualTag07 { get; set; }
 
         [XmlIgnore]
         [Browsable(true)]
-        [DefaultValue("")]
         public string VirtualTag08 { get; set; }
 
         [XmlIgnore]
         [Browsable(true)]
-        [DefaultValue("")]
         public string VirtualTag09 { get; set; }
 
         [XmlIgnore]
         [Browsable(true)]
-        [DefaultValue("")]
         public string VirtualTag10 { get; set; }
 
         static ComicBook()
@@ -1697,7 +1687,7 @@ namespace cYo.Projects.ComicRack.Engine
 
 		public ComicBook()
 		{
-            VirtualTagsCollection.TagsRefresh += UpdateVirtualTags;
+			VirtualTagsCollection.TagsRefresh += (sender, e) => UpdateVirtualTags();
         }
 
         public ComicBook(ComicBook cb)
@@ -1711,7 +1701,7 @@ namespace cYo.Projects.ComicRack.Engine
 			{
 				ComicProviderCreated += cb.ComicProviderCreated;
 			}
-            VirtualTagsCollection.TagsRefresh += UpdateVirtualTags;
+            VirtualTagsCollection.TagsRefresh += (sender, e) => UpdateVirtualTags();
         }
 
         public static ComicBook Create(string file, RefreshInfoOptions options)
@@ -2036,6 +2026,7 @@ namespace cYo.Projects.ComicRack.Engine
 		public void ResetProperties(int level = 0)
 		{
 			ResetValueAttribute.ResetProperties(this, level);
+			UpdateVirtualTags();
 		}
 
 		public bool RemoveFromContainer()

--- a/ComicRack.Engine/ComicBookValueMatcher.cs
+++ b/ComicRack.Engine/ComicBookValueMatcher.cs
@@ -42,8 +42,9 @@ namespace cYo.Projects.ComicRack.Engine
 			{
 				if (descriptionNeutral == null)
 				{
-					DescriptionAttribute descriptionAttribute = (DescriptionAttribute)Attribute.GetCustomAttribute(GetType(), typeof(DescriptionAttribute));
-					descriptionNeutral = descriptionAttribute.Description ?? string.Empty;
+                    DescriptionAttribute descriptionAttribute = (DescriptionAttribute)Attribute.GetCustomAttribute(GetType(), typeof(DescriptionAttribute));
+                    descriptionNeutral = descriptionAttribute.Description ?? string.Empty;
+                    descriptionNeutral = this is IVirtualDescription ? (this as IVirtualDescription)?.VirtualDescription : descriptionNeutral;
 				}
 				return descriptionNeutral;
 			}

--- a/ComicRack.Engine/ComicRack.Engine.csproj
+++ b/ComicRack.Engine/ComicRack.Engine.csproj
@@ -574,6 +574,12 @@
     <Compile Include="ISharesSettings.cs" />
     <Compile Include="ItemGroupCount.cs" />
     <Compile Include="MangaYesNo.cs" />
+    <Compile Include="Metadata\VirtualTags\ComicBookVirtualTagMatcher.cs" />
+    <Compile Include="Metadata\VirtualTags\VirtualTagsCollection.cs" />
+    <Compile Include="Metadata\VirtualTags\IVirtualTagSettings.cs" />
+    <Compile Include="Metadata\VirtualTags\IVirtualDescription.cs" />
+    <Compile Include="Metadata\VirtualTags\IVirtualTag.cs" />
+    <Compile Include="Metadata\VirtualTags\VirtualTag.cs" />
     <Compile Include="NetworkManager.cs" />
     <Compile Include="PackageManager.cs" />
     <Compile Include="PackedLocalize.cs" />
@@ -651,7 +657,6 @@
   <ItemGroup>
     <Content Include="DLL\sharpPDF.dll" />
   </ItemGroup>
-  <ItemGroup />
   <!-- <ItemGroup> -->
   <!-- <EmbeddedResource Include="Controls\ComicPageContainerControl.resources" /> -->
   <!-- <EmbeddedResource Include="Controls\MagnifySetupControl.resources" /> -->

--- a/ComicRack.Engine/Metadata/VirtualTags/ComicBookVirtualTagMatcher.cs
+++ b/ComicRack.Engine/Metadata/VirtualTags/ComicBookVirtualTagMatcher.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reflection.Emit;
+using System.Reflection;
+using static cYo.Common.Win32.ExecuteProcess;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace cYo.Projects.ComicRack.Engine
+{
+    public abstract class ComicBookVirtualTagMatcher : ComicBookStringMatcher, IVirtualDescription
+    {
+        /// <summary>
+        /// Finds the IVirtualTag based on the Hint Attribute & the corresponding IVirtualTag.
+        /// Returns an alternate string for the Description used in SmartLists
+        /// </summary>
+        public string VirtualDescription
+        {
+            get
+            {
+                var matcherHintAttribute = Attribute.GetCustomAttribute(GetType(), typeof(ComicBookMatcherHintAttribute)) as ComicBookMatcherHintAttribute;
+                IVirtualTag vtag = VirtualTagsCollection.Tags.Values.FirstOrDefault(x => x.IsEnabled && x.PropertyName == matcherHintAttribute?.Properties.First());
+                return vtag?.Name ?? string.Empty;
+            }
+        }
+    }
+
+    [Serializable]
+    [Description("Virtual Tags #01")]
+    [ComicBookMatcherHint("VirtualTag01")]
+    public class ComicBookVirtualTag1Matcher : ComicBookVirtualTagMatcher
+    {
+        protected override string GetValue(ComicBook comicBook)
+        {
+            return comicBook.VirtualTag01;
+        }
+    }
+
+    [Serializable]
+    [Description("Virtual Tags #02")]
+    [ComicBookMatcherHint("VirtualTag02")]
+    public class ComicBookVirtualTag2Matcher : ComicBookVirtualTagMatcher
+    {
+        protected override string GetValue(ComicBook comicBook)
+        {
+            return comicBook.VirtualTag02;
+        }
+    }
+
+    [Serializable]
+    [Description("Virtual Tags #03")]
+    [ComicBookMatcherHint("VirtualTag03")]
+    public class ComicBookVirtualTag3Matcher : ComicBookVirtualTagMatcher
+    {
+        protected override string GetValue(ComicBook comicBook)
+        {
+            return comicBook.VirtualTag03;
+        }
+    }
+
+    [Serializable]
+    [Description("Virtual Tags #04")]
+    [ComicBookMatcherHint("VirtualTag04")]
+    public class ComicBookVirtualTag4Matcher : ComicBookVirtualTagMatcher
+    {
+        protected override string GetValue(ComicBook comicBook)
+        {
+            return comicBook.VirtualTag04;
+        }
+    }
+
+    [Serializable]
+    [Description("Virtual Tags #05")]
+    [ComicBookMatcherHint("VirtualTag05")]
+    public class ComicBookVirtualTag5Matcher : ComicBookVirtualTagMatcher
+    {
+        protected override string GetValue(ComicBook comicBook)
+        {
+            return comicBook.VirtualTag05;
+        }
+    }
+
+    [Serializable]
+    [Description("Virtual Tags #06")]
+    [ComicBookMatcherHint("VirtualTag06")]
+    public class ComicBookVirtualTag6Matcher : ComicBookVirtualTagMatcher
+    {
+        protected override string GetValue(ComicBook comicBook)
+        {
+            return comicBook.VirtualTag06;
+        }
+    }
+
+    [Serializable]
+    [Description("Virtual Tags #07")]
+    [ComicBookMatcherHint("VirtualTag07")]
+    public class ComicBookVirtualTag7Matcher : ComicBookVirtualTagMatcher
+    {
+        protected override string GetValue(ComicBook comicBook)
+        {
+            return comicBook.VirtualTag07;
+        }
+    }
+
+    [Serializable]
+    [Description("Virtual Tags #08")]
+    [ComicBookMatcherHint("VirtualTag08")]
+    public class ComicBookVirtualTag8Matcher : ComicBookVirtualTagMatcher
+    {
+        protected override string GetValue(ComicBook comicBook)
+        {
+            return comicBook.VirtualTag08;
+        }
+    }
+
+    [Serializable]
+    [Description("Virtual Tags #09")]
+    [ComicBookMatcherHint("VirtualTag09")]
+    public class ComicBookVirtualTag9Matcher : ComicBookVirtualTagMatcher
+    {
+        protected override string GetValue(ComicBook comicBook)
+        {
+            return comicBook.VirtualTag09;
+        }
+    }
+
+    [Serializable]
+    [Description("Virtual Tags #10")]
+    [ComicBookMatcherHint("VirtualTag10")]
+    public class ComicBookVirtualTag10Matcher : ComicBookVirtualTagMatcher
+    {
+        protected override string GetValue(ComicBook comicBook)
+        {
+            return comicBook.VirtualTag10;
+        }
+    }
+}

--- a/ComicRack.Engine/Metadata/VirtualTags/IVirtualDescription.cs
+++ b/ComicRack.Engine/Metadata/VirtualTags/IVirtualDescription.cs
@@ -1,0 +1,7 @@
+﻿namespace cYo.Projects.ComicRack.Engine
+{
+    public interface IVirtualDescription
+    {
+        string VirtualDescription { get; }
+    }
+}

--- a/ComicRack.Engine/Metadata/VirtualTags/IVirtualTag.cs
+++ b/ComicRack.Engine/Metadata/VirtualTags/IVirtualTag.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Xml.Serialization;
+
+namespace cYo.Projects.ComicRack.Engine
+{
+    public interface IVirtualTag
+    {
+        int ID { get; }
+        string Name { get; set; }
+        string Description { get; set; }
+        string CaptionFormat { get; set; }
+        bool IsEnabled { get; set; }
+        string PropertyName { get; }
+    }
+}

--- a/ComicRack.Engine/Metadata/VirtualTags/IVirtualTagSettings.cs
+++ b/ComicRack.Engine/Metadata/VirtualTags/IVirtualTagSettings.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace cYo.Projects.ComicRack.Engine
+{
+    public interface IVirtualTagSettings
+    {
+        List<VirtualTag> VirtualTags { get; }
+    }
+}

--- a/ComicRack.Engine/Metadata/VirtualTags/VirtualTag.cs
+++ b/ComicRack.Engine/Metadata/VirtualTags/VirtualTag.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Xml.Serialization;
+
+namespace cYo.Projects.ComicRack.Engine
+{
+    public class VirtualTag : IVirtualTag
+    {
+        public VirtualTag()
+        {
+        }
+
+        public VirtualTag(int id, string name, string description, string captionFormat, bool isEnabled = false, bool isDefault = false)
+        {
+            ID = id;
+            Name = name;
+            Description = description;
+            CaptionFormat = captionFormat;
+            IsEnabled = isEnabled;
+            IsDefault = isDefault;
+        }
+
+        [DefaultValue(0)]
+        public int ID { get; set; }
+
+        [DefaultValue("")]
+        public string Name { get; set; }
+
+        [DefaultValue("")]
+        public string Description { get; set; }
+
+        [DefaultValue("")]
+        public string CaptionFormat { get; set; }
+
+        [DefaultValue(false)]
+        public bool IsEnabled { get; set; }
+
+        [XmlIgnore]
+        [DefaultValue(false)]
+        public bool IsDefault { get; set; }
+
+        [XmlIgnore]
+        public string PropertyName => $"VirtualTag{ID:00}";
+
+        [XmlIgnore]
+        public string DisplayMember => $"{Name}{(IsEnabled ? " (Enabled)" : "")}";
+
+        public override bool Equals(object obj)
+        {
+            VirtualTag vtag = obj as VirtualTag;
+            if (vtag != null)
+            {
+                return Equals(vtag);
+            }
+            return false;
+        }
+
+        public bool Equals(VirtualTag vtag)
+        {
+            if (vtag != null)
+            {
+                return vtag.ID == ID && vtag.Name == Name && vtag.Description == Description
+                    && vtag.CaptionFormat == CaptionFormat && vtag.IsEnabled == IsEnabled && vtag.IsDefault == IsDefault;
+            }
+            return false;
+        }
+    }
+}
+
+

--- a/ComicRack.Engine/Metadata/VirtualTags/VirtualTagsCollection.cs
+++ b/ComicRack.Engine/Metadata/VirtualTags/VirtualTagsCollection.cs
@@ -52,7 +52,7 @@ namespace cYo.Projects.ComicRack.Engine
         private static IEnumerable<IVirtualTag> Init()
         {
             return Settings?.VirtualTags
-                .Where(x => x.IsEnabled && !string.IsNullOrEmpty(x.CaptionFormat) && !string.IsNullOrEmpty(x.Name))
+                .Where(x => x != null && x.IsEnabled && !string.IsNullOrEmpty(x.CaptionFormat) && !string.IsNullOrEmpty(x.Name))
                 .ToList() ?? Enumerable.Empty<IVirtualTag>();
         }
 

--- a/ComicRack.Engine/Metadata/VirtualTags/VirtualTagsCollection.cs
+++ b/ComicRack.Engine/Metadata/VirtualTags/VirtualTagsCollection.cs
@@ -36,6 +36,7 @@ namespace cYo.Projects.ComicRack.Engine
             if (instance.IsValueCreated)
                 instance.Value.Refresh();
 
+            //TODO: Refresh only when settings have changed
             OnTagsRefresh();
         }
 

--- a/ComicRack.Engine/Metadata/VirtualTags/VirtualTagsCollection.cs
+++ b/ComicRack.Engine/Metadata/VirtualTags/VirtualTagsCollection.cs
@@ -1,0 +1,74 @@
+﻿using cYo.Common.Collections;
+using cYo.Projects.ComicRack.Engine.IO.Provider;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.IdentityModel.Tokens;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace cYo.Projects.ComicRack.Engine
+{
+    public class VirtualTagsCollection : Dictionary<int, IVirtualTag>
+    {
+        private static readonly Lazy<VirtualTagsCollection> instance = new Lazy<VirtualTagsCollection>(() => new VirtualTagsCollection(Init()));
+        private static IVirtualTagSettings Settings;
+
+        public static event EventHandler TagsRefresh;
+
+        private VirtualTagsCollection(IEnumerable<IVirtualTag> list)
+            : base(InitDictionary(list))
+        {
+
+        }
+
+        public static VirtualTagsCollection Tags => instance.Value;
+
+        public static void RegisterSettings(IVirtualTagSettings settings)
+        {
+            Settings = settings;
+
+            if (instance.IsValueCreated)
+                instance.Value.Refresh();
+
+            OnTagsRefresh();
+        }
+
+        public IVirtualTag GetValue(int i)
+        {
+            if (Tags.TryGetValue(i, out var tag))
+                return tag;
+
+            return new VirtualTag();
+        }
+
+        private static Dictionary<int, IVirtualTag> InitDictionary(IEnumerable<IVirtualTag> list) => list.ToDictionary(v => v.ID, v => v);
+
+        private static IEnumerable<IVirtualTag> Init()
+        {
+            return Settings?.VirtualTags
+                .Where(x => x.IsEnabled && !string.IsNullOrEmpty(x.CaptionFormat) && !string.IsNullOrEmpty(x.Name))
+                .ToList() ?? Enumerable.Empty<IVirtualTag>();
+        }
+
+        private void Refresh()
+        {
+            Clear();
+            foreach (var v in Init())
+            {
+                if (!ContainsKey(v.ID))
+                    Add(v.ID, v);
+            }
+        }
+
+        private static void OnTagsRefresh()
+        {
+            TagsRefresh?.Invoke(null, EventArgs.Empty);
+        }
+    }
+}

--- a/ComicRack/Changes.txt
+++ b/ComicRack/Changes.txt
@@ -4,6 +4,7 @@ Community Edition Build 0.9.180:
 * NEW: Added the Git version to the Splash Screen, to more easily identify bugs in specific releases.
 * NEW: Added the "-local" command line switch, to have the program load on portable mode.
 * NEW: Added links to The Organizer guide to the online manual help system
+* NEW: Added the possibility for unknown elements that may have been added my other software to the ComicInfo.xml to be kept.
 
 * CHANGE: Updated to .NET Framework v4.8
 * CHANGE: Updated the Splash Screen and Renamed the Program to Community Edition, this means that a new config folder will be used %appdata%\cYo\ComicRack Community Edition. 
@@ -34,6 +35,7 @@ Community Edition Build 0.9.180:
 * BUGFIX: Fixed smartlist "in range" for dates, the second field wasn't taken into account.
 * BUGFIX: Fixed possible crash if window size is less than 0 (Usually when using high DPI scaling).
 * BUGFIX: Fixed a bug where clicking a folder that didn't exists anymore, would show the files from the program installation directory.
+* BUGFIX: Fixed missing entry (MainCharacterOrTeam, Review & CommunityRating) in ComicInfo.xml.
 
 ^^^^^^^^^^ Community Edition ^^^^^^^^^^
 

--- a/ComicRack/Config/Settings.cs
+++ b/ComicRack/Config/Settings.cs
@@ -26,8 +26,8 @@ using cYo.Projects.ComicRack.Viewer.Views;
 namespace cYo.Projects.ComicRack.Viewer.Config
 {
 	[Serializable]
-	public class Settings : ICacheSettings, IComicUpdateSettings, ISharesSettings
-	{
+	public class Settings : ICacheSettings, IComicUpdateSettings, ISharesSettings, IVirtualTagSettings
+    {
 		[Serializable]
 		public class PasswordCacheEntry
 		{
@@ -2359,7 +2359,10 @@ namespace cYo.Projects.ComicRack.Viewer.Config
 			set;
 		}
 
-		[field: NonSerialized]
+		private List<VirtualTag> virtualTags = new List<VirtualTag>();
+		public List<VirtualTag> VirtualTags => virtualTags;
+
+        [field: NonSerialized]
 		public event EventHandler SettingsChanged;
 
 		[field: NonSerialized]

--- a/ComicRack/Dialogs/PreferencesDialog.Designer.cs
+++ b/ComicRack/Dialogs/PreferencesDialog.Designer.cs
@@ -16,6 +16,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
         private void InitializeComponent()
 		{
             this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PreferencesDialog));
             System.Windows.Forms.ListViewGroup listViewGroup1 = new System.Windows.Forms.ListViewGroup("Installed", System.Windows.Forms.HorizontalAlignment.Left);
             System.Windows.Forms.ListViewGroup listViewGroup2 = new System.Windows.Forms.ListViewGroup("To be removed (requires restart)", System.Windows.Forms.HorizontalAlignment.Left);
             System.Windows.Forms.ListViewGroup listViewGroup3 = new System.Windows.Forms.ListViewGroup("To be installed (requires restart)", System.Windows.Forms.HorizontalAlignment.Left);
@@ -129,6 +130,26 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             this.labelLanguage = new System.Windows.Forms.Label();
             this.lbLanguages = new System.Windows.Forms.ListBox();
             this.pageLibrary = new System.Windows.Forms.Panel();
+            this.grpVirtualTags = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.grpVtagConfig = new System.Windows.Forms.GroupBox();
+            this.lblCaptionFormat = new System.Windows.Forms.Label();
+            this.txtCaptionFormat = new System.Windows.Forms.TextBox();
+            this.btInsertValue = new System.Windows.Forms.Button();
+            this.lblVirtualTagDescription = new System.Windows.Forms.Label();
+            this.lblVirtualTagName = new System.Windows.Forms.Label();
+            this.txtVirtualTagDescription = new System.Windows.Forms.TextBox();
+            this.txtVirtualTagName = new System.Windows.Forms.TextBox();
+            this.chkVirtualTagEnable = new System.Windows.Forms.CheckBox();
+            this.lblCaptionText = new System.Windows.Forms.Label();
+            this.lblCaptionSuffix = new System.Windows.Forms.Label();
+            this.rtfVirtualTagCaption = new System.Windows.Forms.RichTextBox();
+            this.lblFieldConfig = new System.Windows.Forms.Label();
+            this.txtCaptionPrefix = new System.Windows.Forms.TextBox();
+            this.lblCaptionPrefix = new System.Windows.Forms.Label();
+            this.btnCaptionInsert = new System.Windows.Forms.Button();
+            this.txtCaptionSuffix = new System.Windows.Forms.TextBox();
+            this.lblVirtualTags = new System.Windows.Forms.Label();
+            this.cbVirtualTags = new System.Windows.Forms.ComboBox();
             this.grpServerSettings = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
             this.txPrivateListingPassword = new cYo.Common.Windows.Forms.PasswordTextBox();
             this.labelPrivateListPassword = new System.Windows.Forms.Label();
@@ -209,6 +230,8 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             this.groupOtherComics.SuspendLayout();
             this.grpLanguages.SuspendLayout();
             this.pageLibrary.SuspendLayout();
+            this.grpVirtualTags.SuspendLayout();
+            this.grpVtagConfig.SuspendLayout();
             this.grpServerSettings.SuspendLayout();
             this.grpSharing.SuspendLayout();
             this.groupLibraryDisplay.SuspendLayout();
@@ -1492,6 +1515,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             | System.Windows.Forms.AnchorStyles.Right)));
             this.pageLibrary.AutoScroll = true;
             this.pageLibrary.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.pageLibrary.Controls.Add(this.grpVirtualTags);
             this.pageLibrary.Controls.Add(this.grpServerSettings);
             this.pageLibrary.Controls.Add(this.grpSharing);
             this.pageLibrary.Controls.Add(this.groupLibraryDisplay);
@@ -1501,6 +1525,214 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             this.pageLibrary.Name = "pageLibrary";
             this.pageLibrary.Size = new System.Drawing.Size(517, 408);
             this.pageLibrary.TabIndex = 10;
+            // 
+            // grpVirtualTags
+            // 
+            this.grpVirtualTags.Controls.Add(this.grpVtagConfig);
+            this.grpVirtualTags.Controls.Add(this.lblVirtualTags);
+            this.grpVirtualTags.Controls.Add(this.cbVirtualTags);
+            this.grpVirtualTags.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpVirtualTags.Location = new System.Drawing.Point(0, 1058);
+            this.grpVirtualTags.Name = "grpVirtualTags";
+            this.grpVirtualTags.Size = new System.Drawing.Size(498, 279);
+            this.grpVirtualTags.TabIndex = 0;
+            this.grpVirtualTags.Text = "Virtual Tags";
+            // 
+            // grpVtagConfig
+            // 
+            this.grpVtagConfig.Controls.Add(this.lblCaptionFormat);
+            this.grpVtagConfig.Controls.Add(this.txtCaptionFormat);
+            this.grpVtagConfig.Controls.Add(this.btInsertValue);
+            this.grpVtagConfig.Controls.Add(this.lblVirtualTagDescription);
+            this.grpVtagConfig.Controls.Add(this.lblVirtualTagName);
+            this.grpVtagConfig.Controls.Add(this.txtVirtualTagDescription);
+            this.grpVtagConfig.Controls.Add(this.txtVirtualTagName);
+            this.grpVtagConfig.Controls.Add(this.chkVirtualTagEnable);
+            this.grpVtagConfig.Controls.Add(this.lblCaptionText);
+            this.grpVtagConfig.Controls.Add(this.lblCaptionSuffix);
+            this.grpVtagConfig.Controls.Add(this.rtfVirtualTagCaption);
+            this.grpVtagConfig.Controls.Add(this.lblFieldConfig);
+            this.grpVtagConfig.Controls.Add(this.txtCaptionPrefix);
+            this.grpVtagConfig.Controls.Add(this.lblCaptionPrefix);
+            this.grpVtagConfig.Controls.Add(this.btnCaptionInsert);
+            this.grpVtagConfig.Controls.Add(this.txtCaptionSuffix);
+            this.grpVtagConfig.Location = new System.Drawing.Point(14, 63);
+            this.grpVtagConfig.Name = "grpVtagConfig";
+            this.grpVtagConfig.Size = new System.Drawing.Size(472, 199);
+            this.grpVtagConfig.TabIndex = 5;
+            this.grpVtagConfig.TabStop = false;
+            this.grpVtagConfig.Text = "Config";
+            // 
+            // lblCaptionFormat
+            // 
+            this.lblCaptionFormat.AutoSize = true;
+            this.lblCaptionFormat.Location = new System.Drawing.Point(275, 151);
+            this.lblCaptionFormat.Name = "lblCaptionFormat";
+            this.lblCaptionFormat.Size = new System.Drawing.Size(39, 13);
+            this.lblCaptionFormat.TabIndex = 28;
+            this.lblCaptionFormat.Text = "Format";
+            this.lblCaptionFormat.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // txtCaptionFormat
+            // 
+            this.txtCaptionFormat.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtCaptionFormat.Location = new System.Drawing.Point(269, 167);
+            this.txtCaptionFormat.Name = "txtCaptionFormat";
+            this.txtCaptionFormat.Size = new System.Drawing.Size(50, 20);
+            this.txtCaptionFormat.TabIndex = 27;
+            this.toolTip.SetToolTip(this.txtCaptionFormat, resources.GetString("txtCaptionFormat.ToolTip"));
+            this.txtCaptionFormat.WordWrap = false;
+            // 
+            // btInsertValue
+            // 
+            this.btInsertValue.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.SmallArrowDown;
+            this.btInsertValue.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.btInsertValue.Location = new System.Drawing.Point(96, 164);
+            this.btInsertValue.Name = "btInsertValue";
+            this.btInsertValue.Size = new System.Drawing.Size(167, 23);
+            this.btInsertValue.TabIndex = 26;
+            this.btInsertValue.Text = "Choose Value";
+            this.btInsertValue.UseVisualStyleBackColor = true;
+            // 
+            // lblVirtualTagDescription
+            // 
+            this.lblVirtualTagDescription.AutoSize = true;
+            this.lblVirtualTagDescription.Location = new System.Drawing.Point(72, 49);
+            this.lblVirtualTagDescription.Name = "lblVirtualTagDescription";
+            this.lblVirtualTagDescription.Size = new System.Drawing.Size(69, 13);
+            this.lblVirtualTagDescription.TabIndex = 25;
+            this.lblVirtualTagDescription.Text = "Description : ";
+            // 
+            // lblVirtualTagName
+            // 
+            this.lblVirtualTagName.AutoSize = true;
+            this.lblVirtualTagName.Location = new System.Drawing.Point(72, 23);
+            this.lblVirtualTagName.Name = "lblVirtualTagName";
+            this.lblVirtualTagName.Size = new System.Drawing.Size(44, 13);
+            this.lblVirtualTagName.TabIndex = 24;
+            this.lblVirtualTagName.Text = "Name : ";
+            // 
+            // txtVirtualTagDescription
+            // 
+            this.txtVirtualTagDescription.Location = new System.Drawing.Point(147, 46);
+            this.txtVirtualTagDescription.Name = "txtVirtualTagDescription";
+            this.txtVirtualTagDescription.Size = new System.Drawing.Size(308, 20);
+            this.txtVirtualTagDescription.TabIndex = 2;
+            this.txtVirtualTagDescription.Validated += new System.EventHandler(this.VirtualTag_Validated);
+            // 
+            // txtVirtualTagName
+            // 
+            this.txtVirtualTagName.Location = new System.Drawing.Point(122, 20);
+            this.txtVirtualTagName.Name = "txtVirtualTagName";
+            this.txtVirtualTagName.Size = new System.Drawing.Size(333, 20);
+            this.txtVirtualTagName.TabIndex = 1;
+            this.txtVirtualTagName.Validated += new System.EventHandler(this.UpdateVirtualTagsComboBox);
+            // 
+            // chkVirtualTagEnable
+            // 
+            this.chkVirtualTagEnable.AutoSize = true;
+            this.chkVirtualTagEnable.Location = new System.Drawing.Point(10, 34);
+            this.chkVirtualTagEnable.Name = "chkVirtualTagEnable";
+            this.chkVirtualTagEnable.Size = new System.Drawing.Size(59, 17);
+            this.chkVirtualTagEnable.TabIndex = 3;
+            this.chkVirtualTagEnable.Text = "Enable";
+            this.chkVirtualTagEnable.UseVisualStyleBackColor = true;
+            this.chkVirtualTagEnable.Validated += new System.EventHandler(this.UpdateVirtualTagsComboBox);
+            // 
+            // lblCaptionText
+            // 
+            this.lblCaptionText.AutoSize = true;
+            this.lblCaptionText.Location = new System.Drawing.Point(7, 82);
+            this.lblCaptionText.Name = "lblCaptionText";
+            this.lblCaptionText.Size = new System.Drawing.Size(52, 13);
+            this.lblCaptionText.TabIndex = 3;
+            this.lblCaptionText.Text = "Caption : ";
+            // 
+            // lblCaptionSuffix
+            // 
+            this.lblCaptionSuffix.AutoSize = true;
+            this.lblCaptionSuffix.Location = new System.Drawing.Point(349, 151);
+            this.lblCaptionSuffix.Name = "lblCaptionSuffix";
+            this.lblCaptionSuffix.Size = new System.Drawing.Size(33, 13);
+            this.lblCaptionSuffix.TabIndex = 20;
+            this.lblCaptionSuffix.Text = "Suffix";
+            // 
+            // rtfVirtualTagCaption
+            // 
+            this.rtfVirtualTagCaption.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.rtfVirtualTagCaption.DetectUrls = false;
+            this.rtfVirtualTagCaption.Font = new System.Drawing.Font("Courier New", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.rtfVirtualTagCaption.Location = new System.Drawing.Point(64, 79);
+            this.rtfVirtualTagCaption.Name = "rtfVirtualTagCaption";
+            this.rtfVirtualTagCaption.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
+            this.rtfVirtualTagCaption.Size = new System.Drawing.Size(391, 62);
+            this.rtfVirtualTagCaption.TabIndex = 4;
+            this.rtfVirtualTagCaption.Text = "";
+            this.rtfVirtualTagCaption.Validated += new System.EventHandler(this.VirtualTag_Validated);
+            // 
+            // lblFieldConfig
+            // 
+            this.lblFieldConfig.AutoSize = true;
+            this.lblFieldConfig.Location = new System.Drawing.Point(165, 151);
+            this.lblFieldConfig.Name = "lblFieldConfig";
+            this.lblFieldConfig.Size = new System.Drawing.Size(29, 13);
+            this.lblFieldConfig.TabIndex = 19;
+            this.lblFieldConfig.Text = "Field";
+            this.lblFieldConfig.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // txtCaptionPrefix
+            // 
+            this.txtCaptionPrefix.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtCaptionPrefix.Location = new System.Drawing.Point(10, 167);
+            this.txtCaptionPrefix.Name = "txtCaptionPrefix";
+            this.txtCaptionPrefix.Size = new System.Drawing.Size(80, 20);
+            this.txtCaptionPrefix.TabIndex = 5;
+            // 
+            // lblCaptionPrefix
+            // 
+            this.lblCaptionPrefix.AutoSize = true;
+            this.lblCaptionPrefix.Location = new System.Drawing.Point(34, 151);
+            this.lblCaptionPrefix.Name = "lblCaptionPrefix";
+            this.lblCaptionPrefix.Size = new System.Drawing.Size(33, 13);
+            this.lblCaptionPrefix.TabIndex = 18;
+            this.lblCaptionPrefix.Text = "Prefix";
+            // 
+            // btnCaptionInsert
+            // 
+            this.btnCaptionInsert.Location = new System.Drawing.Point(410, 164);
+            this.btnCaptionInsert.Name = "btnCaptionInsert";
+            this.btnCaptionInsert.Size = new System.Drawing.Size(51, 23);
+            this.btnCaptionInsert.TabIndex = 8;
+            this.btnCaptionInsert.Text = "Insert";
+            this.btnCaptionInsert.UseVisualStyleBackColor = true;
+            this.btnCaptionInsert.Click += new System.EventHandler(this.btnCaptionInsert_Click);
+            // 
+            // txtCaptionSuffix
+            // 
+            this.txtCaptionSuffix.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtCaptionSuffix.Location = new System.Drawing.Point(325, 167);
+            this.txtCaptionSuffix.Name = "txtCaptionSuffix";
+            this.txtCaptionSuffix.Size = new System.Drawing.Size(80, 20);
+            this.txtCaptionSuffix.TabIndex = 7;
+            // 
+            // lblVirtualTags
+            // 
+            this.lblVirtualTags.AutoSize = true;
+            this.lblVirtualTags.Location = new System.Drawing.Point(10, 39);
+            this.lblVirtualTags.Name = "lblVirtualTags";
+            this.lblVirtualTags.Size = new System.Drawing.Size(45, 13);
+            this.lblVirtualTags.TabIndex = 1;
+            this.lblVirtualTags.Text = "Tag # : ";
+            // 
+            // cbVirtualTags
+            // 
+            this.cbVirtualTags.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbVirtualTags.FormattingEnabled = true;
+            this.cbVirtualTags.Location = new System.Drawing.Point(61, 36);
+            this.cbVirtualTags.Name = "cbVirtualTags";
+            this.cbVirtualTags.Size = new System.Drawing.Size(424, 21);
+            this.cbVirtualTags.TabIndex = 0;
+            this.cbVirtualTags.SelectedIndexChanged += new System.EventHandler(this.cbVirtualTags_SelectedIndexChanged);
             // 
             // grpServerSettings
             // 
@@ -2183,6 +2415,10 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             this.groupOtherComics.PerformLayout();
             this.grpLanguages.ResumeLayout(false);
             this.pageLibrary.ResumeLayout(false);
+            this.grpVirtualTags.ResumeLayout(false);
+            this.grpVirtualTags.PerformLayout();
+            this.grpVtagConfig.ResumeLayout(false);
+            this.grpVtagConfig.PerformLayout();
             this.grpServerSettings.ResumeLayout(false);
             this.grpServerSettings.PerformLayout();
             this.grpSharing.ResumeLayout(false);
@@ -2387,5 +2623,25 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 		private Button btTestWifi;
 		private static int activeTab = -1;
 		private readonly List<CheckBox> tabButtons = new List<CheckBox>();
-	}
+        private CollapsibleGroupBox grpVirtualTags;
+        private Label lblVirtualTags;
+        private ComboBox cbVirtualTags;
+        private GroupBox grpVtagConfig;
+        private Label lblCaptionText;
+        private Label lblCaptionSuffix;
+        private RichTextBox rtfVirtualTagCaption;
+        private Label lblFieldConfig;
+        private TextBox txtCaptionPrefix;
+        private Label lblCaptionPrefix;
+        private Button btnCaptionInsert;
+        private TextBox txtCaptionSuffix;
+        private CheckBox chkVirtualTagEnable;
+        private Label lblVirtualTagDescription;
+        private Label lblVirtualTagName;
+        private TextBox txtVirtualTagDescription;
+        private TextBox txtVirtualTagName;
+        private Button btInsertValue;
+        private TextBox txtCaptionFormat;
+        private Label lblCaptionFormat;
+    }
 }

--- a/ComicRack/Dialogs/PreferencesDialog.cs
+++ b/ComicRack/Dialogs/PreferencesDialog.cs
@@ -1264,7 +1264,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
         {
             components = new Container();
             ContextMenuBuilder contextMenuBuilder = new ContextMenuBuilder();
-            foreach (string item in ComicBookMatcher.ComicProperties)
+            foreach (string item in ComicBook.GetProperties(false))
             {
                 contextMenuBuilder.Add(item, topLevel: false, chk: false, SetCaptionField, item, DateTime.MinValue);
             }

--- a/ComicRack/Dialogs/PreferencesDialog.cs
+++ b/ComicRack/Dialogs/PreferencesDialog.cs
@@ -1238,7 +1238,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 
             for (int id = 1; id <= 10; id++)
             {
-                VirtualTag vtag = Program.Settings.VirtualTags.ElementAtOrDefault(i);
+                VirtualTag vtag = Program.Settings.VirtualTags.FirstOrDefault(x => x.ID == id);
 
                 //If the data doesn't already exists, create a default tag for the settings
                 if (vtag is null || vtag.ID != id)

--- a/ComicRack/Dialogs/PreferencesDialog.cs
+++ b/ComicRack/Dialogs/PreferencesDialog.cs
@@ -31,1201 +31,1359 @@ using cYo.Projects.ComicRack.Viewer.Properties;
 
 namespace cYo.Projects.ComicRack.Viewer.Dialogs
 {
-	public partial class PreferencesDialog : Form
-	{
-		private const int MaximumMemoryStepSize = 32;
-
-		private static readonly string DuplicatePackageText = TR.Messages["ScriptPackageExists", "A Script Package with the same name already exists! Do you want to overwrite this Package?"];
-
-		private PluginEngine pluginEngine;
-
-		private bool blockSetTab;
-
-		public string AutoInstallPlugin
-		{
-			get;
-			set;
-		}
-
-		public bool NeedsRestart
-		{
-			get;
-			set;
-		}
-
-		public string BackupFile
-		{
-			get;
-			set;
-		}
-
-		public PluginEngine Plugins
-		{
-			get
-			{
-				return pluginEngine;
-			}
-			set
-			{
-				pluginEngine = value;
-				FillScriptsList();
-			}
-		}
-
-		public PreferencesDialog()
-		{
-			LocalizeUtility.UpdateRightToLeft(this);
-			InitializeComponent();
-			lvPackages.Columns.ScaleDpi();
-			lvScripts.Columns.ScaleDpi();
-			this.RestorePosition();
-			this.RestorePanelStates();
-			tabReader.Tag = pageReader;
-			tabBehavior.Tag = pageBehavior;
-			tabLibraries.Tag = pageLibrary;
-			tabScripts.Tag = pageScripts;
-			tabAdvanced.Tag = pageAdvanced;
-			tabButtons.AddRange(new CheckBox[5]
-			{
-				tabReader,
-				tabBehavior,
-				tabLibraries,
-				tabScripts,
-				tabAdvanced
-			});
-			lbLanguages.ItemHeight = FormUtility.ScaleDpiY(lbLanguages.ItemHeight);
-			tabReader.Image = ((Bitmap)tabReader.Image).ScaleDpi();
-			tabAdvanced.Image = ((Bitmap)tabAdvanced.Image).ScaleDpi();
-			tabBehavior.Image = ((Bitmap)tabBehavior.Image).ScaleDpi();
-			tabLibraries.Image = ((Bitmap)tabLibraries.Image).ScaleDpi();
-			tabScripts.Image = ((Bitmap)tabScripts.Image).ScaleDpi();
-			FormUtility.FillPanelWithOptions(pageBehavior, Program.Settings, TR.Load("Settings"));
-			packageImageList.Images.Add(Resources.Package);
-			LocalizeUtility.Localize(this, components);
-			LocalizeUtility.Localize(TR.Load(base.Name), cbNavigationOverlayPosition);
-			FormUtility.RegisterPanelToTabToggle(pageReader, PropertyCaller.CreateFlagsValueStore(Program.Settings, "TabLayouts", TabLayouts.ReaderSettings));
-			FormUtility.RegisterPanelToTabToggle(pageBehavior, PropertyCaller.CreateFlagsValueStore(Program.Settings, "TabLayouts", TabLayouts.BehaviorSettings));
-			FormUtility.RegisterPanelToTabToggle(pageLibrary, PropertyCaller.CreateFlagsValueStore(Program.Settings, "TabLayouts", TabLayouts.LibrarySettings));
-			FormUtility.RegisterPanelToTabToggle(pageScripts, PropertyCaller.CreateFlagsValueStore(Program.Settings, "TabLayouts", TabLayouts.ScriptSettings));
-			FormUtility.RegisterPanelToTabToggle(pageAdvanced, PropertyCaller.CreateFlagsValueStore(Program.Settings, "TabLayouts", TabLayouts.AdvancedSettings));
-			Program.Scanner.ScanNotify += DatabaseScanNotify;
-			IdleProcess.Idle += ApplicationIdle;
-			numMemPageCount.Minimum = 20m;
-			numMemPageCount.Maximum = 100m;
-			numMemThumbSize.Minimum = 5m;
-			numMemThumbSize.Maximum = 100m;
-			lbLanguages.Items.Add(new TRInfo());
-			lbLanguages.Items.Add(new TRInfo("en"));
-			TRInfo[] installedLanguages = Program.InstalledLanguages;
-			foreach (TRInfo item in installedLanguages)
-			{
-				lbLanguages.Items.Add(item);
-			}
-			SetSettings();
-			foreach (WatchFolder watchFolder in Program.Database.WatchFolders)
-			{
-				lbPaths.Items.Add(watchFolder.Folder, watchFolder.Watch);
-			}
-			lbPaths_SelectedIndexChanged(lbPaths, EventArgs.Empty);
-			SetScanButtonText();
-			btResetMessages.Enabled = Program.Settings.HiddenMessageBoxes != HiddenMessageBoxes.None;
-			FillExtensionsList();
-			chkOverwriteAssociations.Checked = Program.Settings.OverwriteAssociations;
-			if (!FileFormat.CanRegisterShell)
-			{
-				Win7.ShowShield(btAssociateExtensions);
-			}
-			else
-			{
-				btAssociateExtensions.Visible = false;
-				lbFormats.Width = btAssociateExtensions.Right - lbFormats.Left;
-			}
-			Program.InternetCache.SizeChanged += UpdateDiskCacheStatus;
-			Program.ImagePool.Pages.DiskCache.SizeChanged += UpdateDiskCacheStatus;
-			Program.ImagePool.Thumbs.DiskCache.SizeChanged += UpdateDiskCacheStatus;
-			UpdateDiskCacheStatus(this, null);
-			UpdateMemoryCacheStatus();
-			RefreshPackageList();
-		}
-
-		protected override void OnLoad(EventArgs e)
-		{
-			base.OnLoad(e);
-			SetTab((activeTab != -1) ? tabButtons[activeTab] : tabReader);
-		}
-
-		protected override void OnShown(EventArgs e)
-		{
-			base.OnShown(e);
-			if (!string.IsNullOrEmpty(AutoInstallPlugin))
-			{
-				SetTab(tabScripts);
-				if (InstallPlugin(AutoInstallPlugin))
-				{
-					RefreshPackageList();
-				}
-			}
-		}
-
-		private void btTestWifi_Click(object sender, EventArgs e)
-		{
-			string text = string.Empty;
-			using (new WaitCursor(this))
-			{
-				foreach (ISyncProvider item in DeviceSyncFactory.Discover(DeviceSyncFactory.ParseWifiAddressList(txWifiAddresses.Text)))
-				{
-					text = text.AppendWithSeparator(", ", item.Device.Model);
-				}
-			}
-			lblWifiStatus.Text = (string.IsNullOrEmpty(text) ? TR.Load(base.Name)["msgNoDevicesFound", "No devices found!"] : TR.Load(base.Name)["msgDevicesFound", "{0} found!"].SafeFormat(text));
-		}
-
-		private void chkAdvanced_CheckedChanged(object sender, EventArgs e)
-		{
-			CheckBox checkBox = sender as CheckBox;
-			if (checkBox.Checked)
-			{
-				SetTab(checkBox);
-			}
-		}
-
-		private void chkLibraryGauges_CheckedChanged(object sender, EventArgs e)
-		{
-			CheckBox checkBox = chkLibraryGaugesNew;
-			CheckBox checkBox2 = chkLibraryGaugesUnread;
-			CheckBox checkBox3 = chkLibraryGaugesTotal;
-			bool flag = (chkLibraryGaugesNumeric.Enabled = chkLibraryGauges.Checked);
-			bool flag3 = (checkBox3.Enabled = flag);
-			bool enabled = (checkBox2.Enabled = flag3);
-			checkBox.Enabled = enabled;
-		}
-
-		private void tbSystemMemory_ValueChanged(object sender, EventArgs e)
-		{
-			int num = tbMaximumMemoryUsage.Value * MaximumMemoryStepSize;
-			if (num == Settings.UnlimitedSystemMemory)
-			{
-				lblMaximumMemoryUsageValue.Text = TR.Default["Unlimited"];
-			}
-			else
-			{
-				lblMaximumMemoryUsageValue.Text = $"{num} MB";
-			}
-		}
-
-		private void lbPaths_DragDrop(object sender, DragEventArgs e)
-		{
-			(from d in (e.Data.GetData(DataFormats.FileDrop) as string[])?.Select((string d) => (!Directory.Exists(d)) ? Path.GetDirectoryName(d) : d)
-			 where !lbPaths.Items.Contains(d)
-			 select d).ForEach(delegate (string d)
-			 {
-				 lbPaths.Items.Add(d);
-			 });
-		}
-
-		private void lbPaths_DragOver(object sender, DragEventArgs e)
-		{
-			e.Effect = (e.Data.GetDataPresent(DataFormats.FileDrop) ? DragDropEffects.Copy : DragDropEffects.None);
-		}
-
-		private void lvScripts_ItemChecked(object sender, ItemCheckedEventArgs e)
-		{
-			Command command = e.Item.Tag as Command;
-			if (command != null)
-			{
-				command.Enabled = e.Item.Checked;
-			}
-		}
-
-		private void lvScripts_SelectedIndexChanged(object sender, EventArgs e)
-		{
-			Command command = (from lvi in lvScripts.SelectedItems.OfType<ListViewItem>()
-							   select lvi.Tag as Command).FirstOrDefault();
-			btConfigScript.Enabled = command != null && command.Configure != null;
-			if (btConfigScript.Enabled)
-			{
-				btConfigScript.Tag = command.Configure;
-			}
-		}
-
-		private void btConfigScript_Click(object sender, EventArgs e)
-		{
-			(btConfigScript.Tag as Command)?.Invoke(new object[0], catchErrors: true);
-		}
-
-		private void lbPaths_DrawItemText(object sender, DrawItemEventArgs e)
-		{
-			CheckedListBoxEx checkedListBoxEx = (CheckedListBoxEx)sender;
-			using (StringFormat format = new StringFormat
-			{
-				LineAlignment = StringAlignment.Center,
-				Trimming = StringTrimming.EllipsisPath
-			})
-			{
-				checkedListBoxEx.DrawDefaultItemText(e, format);
-			}
-		}
-
-		private void DatabaseScanNotify(object sender, ComicScanNotifyEventArgs e)
-		{
-			try
-			{
-				if (!this.BeginInvokeIfRequired(delegate
-				{
-					DatabaseScanNotify(sender, e);
-				}))
-				{
-					if (string.IsNullOrEmpty(e.File))
-					{
-						lblScan.Text = string.Empty;
-					}
-					else
-					{
-						lblScan.Text = StringUtility.Format(LocalizeUtility.GetText(this, "Scanning", "Scanning '{0}' ..."), e.File);
-					}
-					SetScanButtonText();
-				}
-			}
-			catch (Exception)
-			{
-			}
-		}
-
-		private void btClearThumbnailCache_Click(object sender, EventArgs e)
-		{
-			using (new WaitCursor())
-			{
-				Program.ImagePool.Thumbs.DiskCache.Clear();
-			}
-		}
-
-		private void btClearPageCache_Click(object sender, EventArgs e)
-		{
-			using (new WaitCursor())
-			{
-				Program.ImagePool.Pages.DiskCache.Clear();
-			}
-		}
-
-		private void btClearInternetCache_Click(object sender, EventArgs e)
-		{
-			using (new WaitCursor())
-			{
-				Program.InternetCache.Clear();
-			}
-		}
-
-		private void btAddFolder_Click(object sender, EventArgs e)
-		{
-			using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
-			{
-				folderBrowserDialog.Description = LocalizeUtility.GetText(this, "SelectComicFolder", "Please select a folder containing Books");
-				folderBrowserDialog.ShowNewFolderButton = true;
-				if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
-				{
-					lbPaths.Items.Add(folderBrowserDialog.SelectedPath);
-					if (lbPaths.SelectedIndex == -1)
-					{
-						lbPaths.SelectedIndex = 0;
-					}
-				}
-			}
-		}
-
-		private void btChangeFolder_Click(object sender, EventArgs e)
-		{
-			string text = lbPaths.SelectedItem as string;
-			if (text == null)
-			{
-				return;
-			}
-			using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
-			{
-				folderBrowserDialog.Description = LocalizeUtility.GetText(this, "SelectComicFolder", "Please select a folder containing Books");
-				folderBrowserDialog.ShowNewFolderButton = true;
-				folderBrowserDialog.SelectedPath = text;
-				if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
-				{
-					lbPaths.Items[lbPaths.SelectedIndex] = folderBrowserDialog.SelectedPath;
-				}
-			}
-		}
-
-		private void btAddLibraryFolder_Click(object sender, EventArgs e)
-		{
-			using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
-			{
-				folderBrowserDialog.Description = LocalizeUtility.GetText(this, "SelectScriptFolder", "Please select a script library folder");
-				folderBrowserDialog.ShowNewFolderButton = false;
-				if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
-				{
-					if (txLibraries.Text.Trim().Length > 0)
-					{
-						txLibraries.Text += ";";
-					}
-					txLibraries.Text += folderBrowserDialog.SelectedPath;
-				}
-			}
-		}
-
-		private void btRemoveFolder_Click(object sender, EventArgs e)
-		{
-			int selectedIndex = lbPaths.SelectedIndex;
-			if (selectedIndex != -1)
-			{
-				lbPaths.Items.RemoveAt(selectedIndex);
-			}
-		}
-
-		private void btOpenFolder_Click(object sender, EventArgs e)
-		{
-			Program.ShowExplorer(lbPaths.SelectedItem as string);
-		}
-
-		private void btScan_Click(object sender, EventArgs e)
-		{
-			if (Program.Scanner.IsScanning)
-			{
-				Program.Scanner.Stop(clearQueue: true);
-				return;
-			}
-			foreach (string item in lbPaths.Items)
-			{
-				Program.Scanner.ScanFileOrFolder(item, all: true, chkAutoRemoveMissing.Checked);
-			}
-		}
-
-		private void lbPaths_DrawItem(object sender, DrawItemEventArgs e)
-		{
-			e.DrawBackground();
-			string s = lbPaths.Items[e.Index] as string;
-			using (StringFormat format = new StringFormat
-			{
-				Trimming = StringTrimming.EllipsisPath
-			})
-			{
-				using (Brush brush = new SolidBrush(e.ForeColor))
-				{
-					e.Graphics.DrawString(s, e.Font, brush, e.Bounds, format);
-				}
-			}
-			e.DrawFocusRectangle();
-		}
-
-		private void lbPaths_SelectedIndexChanged(object sender, EventArgs e)
-		{
-			Button button = btOpenFolder;
-			bool enabled = (btRemoveFolder.Enabled = lbPaths.SelectedIndex != -1);
-			button.Enabled = enabled;
-			btScan.Enabled = lbPaths.Items.Count > 0;
-		}
-
-		private void btResetMessages_Click(object sender, EventArgs e)
-		{
-			Program.Settings.HiddenMessageBoxes = HiddenMessageBoxes.None;
-			btResetMessages.Enabled = false;
-		}
-
-		private void ApplicationIdle(object sender, EventArgs e)
-		{
-			CheckBox checkBox = chkEnableDisplayChangeAnimation;
-			CheckBox checkBox2 = chkEnableHardwareFiltering;
-			CheckBox checkBox3 = chkEnableSoftwareFiltering;
-			bool flag = (chkEnableInertialMouseScrolling.Enabled = chkEnableHardware.Checked);
-			bool flag3 = (checkBox3.Enabled = flag);
-			bool enabled = (checkBox2.Enabled = flag3);
-			checkBox.Enabled = enabled;
-			chkAutoConnectShares.Enabled = chkLookForShared.Checked;
-			btRemovePackage.Enabled = lvPackages.SelectedItems.Count > 0;
-			labelPageOverlay.Enabled = chkShowCurrentPageOverlay.Checked;
-			labelVisiblePartOverlay.Enabled = chkShowVisiblePartOverlay.Checked;
-			labelStatusOverlay.Enabled = chkShowStatusOverlay.Checked;
-			labelNavigationOverlay.Top = ((cbNavigationOverlayPosition.SelectedIndex != 0) ? labelPageOverlay.Top : (labelVisiblePartOverlay.Bottom - labelNavigationOverlay.Height));
-			labelPageOverlay.Text = (chkShowPageNames.Checked ? LocalizeUtility.GetText(this, "PageNumberAndName", "Page\nName") : LocalizeUtility.GetText(this, "PageNumberOnly", "Page"));
-		}
-
-		private void btApply_Click(object sender, EventArgs e)
-		{
-			Apply();
-		}
-
-		private void tbSaturation_DoubleClick(object sender, EventArgs e)
-		{
-			tbSaturation.Value = 0;
-		}
-
-		private void tbBrightness_DoubleClick(object sender, EventArgs e)
-		{
-			tbBrightness.Value = 0;
-		}
-
-		private void tbContrast_DoubleClick(object sender, EventArgs e)
-		{
-			tbContrast.Value = 0;
-		}
-
-		private void tbSharpening_DoubleClick(object sender, EventArgs e)
-		{
-			tbSharpening.Value = 0;
-		}
-
-		private void tbGamma_DoubleClick(object sender, EventArgs e)
-		{
-			tbGamma.Value = 0;
-		}
-
-		private void btReset_Click(object sender, EventArgs e)
-		{
-			TrackBarLite trackBarLite = tbSaturation;
-			TrackBarLite trackBarLite2 = tbBrightness;
-			TrackBarLite trackBarLite3 = tbContrast;
-			int num2 = (tbGamma.Value = 0);
-			int num4 = (trackBarLite3.Value = num2);
-			int num7 = (trackBarLite.Value = (trackBarLite2.Value = num4));
-		}
-
-		private void tbOverlayScalingChanged(object sender, EventArgs e)
-		{
-			toolTip.SetToolTip(tbOverlayScaling, $"{tbOverlayScaling.Value}%");
-		}
-
-		private void tbColorAdjustmentChanged(object sender, EventArgs e)
-		{
-			TrackBarLite trackBarLite = (TrackBarLite)sender;
-			toolTip.SetToolTip(trackBarLite, string.Format("{1}{0}%", trackBarLite.Value, (trackBarLite.Value > 0) ? "+" : string.Empty));
-		}
-
-		private void lbLanguages_DrawItem(object sender, DrawItemEventArgs e)
-		{
-			if (e.Index == -1)
-			{
-				return;
-			}
-			TRInfo tRInfo = (TRInfo)lbLanguages.Items[e.Index];
-			e.DrawBackground();
-			using (Brush brush = new SolidBrush((tRInfo.CompletionPercent > 95f) ? ForeColor : Color.Red))
-			{
-				Rectangle bounds = e.Bounds;
-				string cultureCode = tRInfo.CultureName ?? CultureInfo.InstalledUICulture.Name;
-				using (Image image = Flags.GetFlagFromCulture(cultureCode))
-				{
-					if (image != null)
-					{
-						float scale = image.Size.GetScale(bounds.Pad(2).Size);
-						e.Graphics.DrawImage(image, bounds.X + 1, bounds.Y + 2, (float)image.Width * scale, (float)image.Height * scale);
-					}
-				}
-				bounds.X += FormUtility.ScaleDpiX(20);
-				bounds.Width -= FormUtility.ScaleDpiX(20);
-				string[] array = tRInfo.ToString().Split('\t');
-				using (StringFormat stringFormat = new StringFormat(StringFormatFlags.NoWrap)
-				{
-					Trimming = StringTrimming.Character,
-					LineAlignment = StringAlignment.Center
-				})
-				{
-					e.Graphics.DrawString(array[0], e.Font, brush, bounds, stringFormat);
-					if (array.Length > 1)
-					{
-						stringFormat.Alignment = StringAlignment.Far;
-						e.Graphics.DrawString(array[1], e.Font, brush, bounds, stringFormat);
-					}
-				}
-			}
-			if ((e.State & DrawItemState.Focus) != 0)
-			{
-				ControlPaint.DrawFocusRectangle(e.Graphics, e.Bounds);
-			}
-		}
-
-		private void btBackupDatabase_Click(object sender, EventArgs e)
-		{
-			SaveFileDialog dlg = new SaveFileDialog();
-			try
-			{
-				dlg.Title = btBackupDatabase.Text.Replace(".", string.Empty);
-				dlg.FileName = string.Format("ComicDB Backup {0}.zip", DateTime.Now.ToString("yyyy-MM-dd"));
-				dlg.Filter = TR.Load("FileFilter")["ComicRackBackup", "ComicRack Database|*.zip"];
-				dlg.DefaultExt = ".zip";
-				if (dlg.ShowDialog(this) != DialogResult.OK)
-				{
-					return;
-				}
-				try
-				{
-					AutomaticProgressDialog.Process(this, TR.Messages["DatabaseBackup", "Database Backup"], TR.Messages["DatabaseBackupText", "Creating and saving the Backup File"], 1000, delegate
-					{
-						Program.DatabaseManager.BackupTo(dlg.FileName, Program.Paths.CustomThumbnailPath);
-					}, AutomaticProgressDialogOptions.None);
-				}
-				catch
-				{
-					MessageBox.Show(this, TR.Messages["DatabaseBackupError", "There was an error saving the Database backup"], TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-				}
-			}
-			finally
-			{
-				if (dlg != null)
-				{
-					((IDisposable)dlg).Dispose();
-				}
-			}
-		}
-
-		private void btRestoreDatabase_Click(object sender, EventArgs e)
-		{
-			using (OpenFileDialog openFileDialog = new OpenFileDialog())
-			{
-				openFileDialog.Title = btRestoreDatabase.Text.Replace(".", string.Empty);
-				openFileDialog.Filter = TR.Load("FileFilter")["ComicRackBackup", "ComicRack Backup|*.zip"];
-				openFileDialog.CheckFileExists = true;
-				if (openFileDialog.ShowDialog(this) == DialogResult.OK)
-				{
-					BackupFile = openFileDialog.FileName;
-				}
-			}
-		}
-
-		private void btTranslate_Click(object sender, EventArgs e)
-		{
-			Program.StartDocument(Program.DefaultLocalizePage);
-		}
-
-		private void memCacheUpate_Tick(object sender, EventArgs e)
-		{
-			UpdateMemoryCacheStatus();
-		}
-
-		private void btInstallPackage_Click(object sender, EventArgs e)
-		{
-			using (OpenFileDialog openFileDialog = new OpenFileDialog())
-			{
-				openFileDialog.Title = btInstallPackage.Text.Replace(".", string.Empty);
-				openFileDialog.Filter = TR.Load("FileFilter")["ScriptPackageOpen", "ComicRack Plugin|*.crplugin|Script Archive|*.zip"];
-				openFileDialog.CheckFileExists = true;
-				if (openFileDialog.ShowDialog(this) == DialogResult.OK && InstallPlugin(openFileDialog.FileName))
-				{
-					RefreshPackageList();
-				}
-			}
-		}
-
-		private void btRemovePackage_Click(object sender, EventArgs e)
-		{
-			foreach (ListViewItem selectedItem in lvPackages.SelectedItems)
-			{
-				NeedsRestart = true;
-				if (!Program.ScriptPackages.Uninstall(selectedItem.Tag as PackageManager.Package))
-				{
-					MessageBox.Show(this, TR.Messages["FailedRemovePackage", "Failed to uninstall package. Please restart ComicRack and try again!"], TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-				}
-			}
-			RefreshPackageList();
-		}
-
-		private void lvPackages_DoubleClick(object sender, EventArgs e)
-		{
-			ListViewItem listViewItem = lvPackages.SelectedItems.OfType<ListViewItem>().FirstOrDefault();
-			if (listViewItem != null)
-			{
-				PackageManager.Package package = listViewItem.Tag as PackageManager.Package;
-				if (package.PackageType == PackageManager.PackageType.Installed)
-				{
-					Program.ShowExplorer(package.PackagePath);
-				}
-			}
-		}
-
-		private void lvPackages_DragDrop(object sender, DragEventArgs e)
-		{
-			try
-			{
-				string[] array = e.Data.GetData(DataFormats.FileDrop) as string[];
-				string[] array2 = array;
-				foreach (string f in array2)
-				{
-					if (!InstallPlugin(f))
-					{
-						break;
-					}
-				}
-				RefreshPackageList();
-			}
-			catch (Exception)
-			{
-			}
-		}
-
-		private void lvPackages_DragOver(object sender, DragEventArgs e)
-		{
-			e.Effect = (e.Data.GetDataPresent(DataFormats.FileDrop) ? DragDropEffects.Copy : DragDropEffects.None);
-		}
-
-		private void keyboardShortcutEditor_DragOver(object sender, DragEventArgs e)
-		{
-			e.Effect = (e.Data.GetDataPresent(DataFormats.FileDrop) ? DragDropEffects.Copy : DragDropEffects.None);
-		}
-
-		private void keyboardShortcutEditor_DragDrop(object sender, DragEventArgs e)
-		{
-			try
-			{
-				LoadKeyboard(((string[])e.Data.GetData(DataFormats.FileDrop))[0]);
-			}
-			catch (Exception)
-			{
-			}
-		}
-
-		private void btExportKeyboard_Click(object sender, EventArgs e)
-		{
-			using (SaveFileDialog saveFileDialog = new SaveFileDialog())
-			{
-				saveFileDialog.Title = btExportKeyboard.Text.Replace("&", string.Empty);
-				saveFileDialog.FileName = TR.Load("FileFilter")["KeyboardLayout", "Keyboard Layout"] + ".xml";
-				saveFileDialog.Filter = TR.Load("FileFilter")["KeyboardLayoutFilter", "Keyboard Layout|*.xml"];
-				saveFileDialog.DefaultExt = ".xml";
-				saveFileDialog.CheckPathExists = true;
-				saveFileDialog.OverwritePrompt = true;
-				if (saveFileDialog.ShowDialog(this) != DialogResult.Cancel)
-				{
-					try
-					{
-						List<StringPair> data = keyboardShortcutEditor.Shortcuts.GetKeyMapping().ToList();
-						XmlUtility.Store(saveFileDialog.FileName, data);
-						Program.Settings.KeyboardLayouts.UpdateMostRecent(saveFileDialog.FileName);
-					}
-					catch (Exception ex)
-					{
-						MessageBox.Show(this, string.Format(TR.Messages["CouldNotExportKeyboardLayout", "Could not export Keyboard Layout!\nReason: {0}"], ex.Message), TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-					}
-				}
-			}
-		}
-
-		private void btLoadKeyboard_Click(object sender, EventArgs e)
-		{
-			using (OpenFileDialog openFileDialog = new OpenFileDialog())
-			{
-				openFileDialog.Title = btImportKeyboard.Text.Replace("&", string.Empty);
-				openFileDialog.Filter = TR.Load("FileFilter")["KeyboardLayoutFilter", "Keyboard Layout|*.xml"];
-				openFileDialog.DefaultExt = ".xml";
-				openFileDialog.CheckFileExists = true;
-				if (openFileDialog.ShowDialog(this) != DialogResult.Cancel)
-				{
-					LoadKeyboard(openFileDialog.FileName);
-				}
-			}
-		}
-
-		private void btImportKeyboard_ShowContextMenu(object sender, EventArgs e)
-		{
-			FormUtility.SafeToolStripClear(cmKeyboardLayout.Items, 2);
-			foreach (string keyboardLayout in Program.Settings.KeyboardLayouts)
-			{
-				string file = keyboardLayout;
-				cmKeyboardLayout.Items.Add(keyboardLayout, null, delegate
-				{
-					LoadKeyboard(file);
-				});
-			}
-			cmKeyboardLayout.Items[1].Visible = cmKeyboardLayout.Items.Count > 2;
-		}
-
-		private void miDefaultKeyboardLayout_Click(object sender, EventArgs e)
-		{
-			keyboardShortcutEditor.Shortcuts.SetKeyMapping(Program.DefaultKeyboardMapping);
-			keyboardShortcutEditor.RefreshList();
-		}
-
-		private void chkHideSampleScripts_CheckedChanged(object sender, EventArgs e)
-		{
-			FillScriptsList();
-		}
-
-		private void FillScriptsList()
-		{
-			lvScripts.BeginUpdate();
-			try
-			{
-				lvScripts.Items.Clear();
-				if (pluginEngine == null)
-				{
-					return;
-				}
-				foreach (Command allCommand in pluginEngine.GetAllCommands())
-				{
-					if (!lvScripts.Items.ContainsKey(allCommand.Key) && (!allCommand.Name.Contains("[Code Sample]") || !chkHideSampleScripts.Checked))
-					{
-						string value = IniFile.GetValue(Path.Combine(allCommand.Environment.CommandPath, "package.ini"), "Name", "Other");
-						string hookDescription = PluginEngine.GetHookDescription(allCommand.Hook);
-						ListViewGroup group = lvScripts.Groups[hookDescription] ?? lvScripts.Groups.Add(hookDescription, hookDescription);
-						ListViewItem listViewItem = lvScripts.Items.Add(allCommand.Key, allCommand.GetLocalizedName(), allCommand.Key);
-						listViewItem.SubItems.Add(value);
-						listViewItem.Tag = allCommand;
-						listViewItem.Checked = allCommand.Enabled;
-						listViewItem.ToolTipText = allCommand.GetLocalizedDescription();
-						listViewItem.Group = group;
-						Image commandImage = allCommand.CommandImage;
-						if (commandImage != null)
-						{
-							imageList.Images.Add(allCommand.Key, commandImage);
-						}
-					}
-				}
-				lvScripts.SortGroups();
-			}
-			finally
-			{
-				lvScripts.EndUpdate();
-			}
-		}
-
-		private void LoadKeyboard(string f)
-		{
-			try
-			{
-				keyboardShortcutEditor.Shortcuts.SetKeyMapping(XmlUtility.Load<List<StringPair>>(f));
-				keyboardShortcutEditor.RefreshList();
-				Program.Settings.KeyboardLayouts.UpdateMostRecent(f);
-			}
-			catch (Exception ex)
-			{
-				Program.Settings.KeyboardLayouts.Remove(f);
-				MessageBox.Show(this, string.Format(TR.Messages["CouldNotImportKeyboardLayout", "Could not import Keyboard Layout!\nReason: {0}"], ex.Message), TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-			}
-		}
-
-		private bool InstallPlugin(string f)
-		{
-			if (Program.ScriptPackages.PackageFileExists(f) && !QuestionDialog.Ask(this, DuplicatePackageText, TR.Default["Yes", "Yes"]))
-			{
-				return false;
-			}
-			bool flag = Program.ScriptPackages.Install(f);
-			NeedsRestart |= flag;
-			return flag;
-		}
-
-		private void FillExtensionsList()
-		{
-			lbFormats.Items.Clear();
-			foreach (FileFormat item in from f in Providers.Readers.GetSourceFormats()
-										orderby f
-										select f)
-			{
-				int index = lbFormats.Items.Add(item);
-				lbFormats.SetItemChecked(index, item.IsShellRegistered(Program.ComicRackTypeId));
-			}
-		}
-
-		public void Apply()
-		{
-			string cultureName = ((TRInfo)lbLanguages.SelectedItem).CultureName;
-			if (cultureName != Program.Settings.CultureName)
-			{
-				NeedsRestart = true;
-				Program.Settings.CultureName = cultureName;
-			}
-			NeedsRestart |= Plugins != null && !string.IsNullOrEmpty(Program.Settings.PluginsStates) && Plugins.CommandStates != Program.Settings.PluginsStates;
-			FormUtility.RetrieveOptionsFromPanel(pageBehavior, Program.Settings);
-			Program.Settings.MouseWheelSpeed = (float)tbMouseWheel.Value / 10f;
-			Program.Settings.LibraryGaugesFormat = LibraryGauges.None.SetMask(LibraryGauges.Unread, chkLibraryGaugesUnread.Checked).SetMask(LibraryGauges.New, chkLibraryGaugesNew.Checked).SetMask(LibraryGauges.Total, chkLibraryGaugesTotal.Checked)
-				.SetMask(LibraryGauges.Numeric, chkLibraryGaugesNumeric.Checked);
-			Program.Settings.DisplayLibraryGauges = chkLibraryGauges.Checked;
-			Program.Settings.PageImageDisplayOptions = Program.Settings.PageImageDisplayOptions.SetMask(ImageDisplayOptions.AnamorphicScaling, chkAnamorphicScaling.Checked);
-			Program.Settings.PageImageDisplayOptions = Program.Settings.PageImageDisplayOptions.SetMask(ImageDisplayOptions.HighQuality, chkHighQualityDisplay.Checked);
-			Program.Settings.InternetCacheEnabled = chkEnableInternetCache.Checked;
-			Program.Settings.InternetCacheSizeMB = (int)numInternetCacheSize.Value;
-			Program.Settings.ThumbCacheEnabled = chkEnableThumbnailCache.Checked;
-			Program.Settings.ThumbCacheSizeMB = (int)numThumbnailCacheSize.Value;
-			Program.Settings.PageCacheEnabled = chkEnablePageCache.Checked;
-			Program.Settings.PageCacheSizeMB = (int)numPageCacheSize.Value;
-			Program.Settings.MaximumMemoryMB = tbMaximumMemoryUsage.Value * MaximumMemoryStepSize;
-			Program.Settings.MemoryPageCacheOptimized = chkMemPageOptimized.Checked;
-			Program.Settings.MemoryPageCacheCount = (int)numMemPageCount.Value;
-			Program.Settings.MemoryThumbCacheOptimized = chkMemThumbOptimized.Checked;
-			Program.Settings.MemoryThumbCacheSizeMB = (int)numMemThumbSize.Value;
-			BitmapAdjustmentOptions options = (chkAutoContrast.Checked ? BitmapAdjustmentOptions.AutoContrast : BitmapAdjustmentOptions.None);
-			Program.Settings.GlobalColorAdjustment = new BitmapAdjustment((float)tbSaturation.Value / 100f, (float)tbBrightness.Value / 100f, (float)tbContrast.Value / 100f, (float)tbGamma.Value / 100f, options, tbSharpening.Value);
-			Program.Settings.ShowCurrentPageOverlay = chkShowCurrentPageOverlay.Checked;
-			Program.Settings.ShowVisiblePagePartOverlay = chkShowVisiblePartOverlay.Checked;
-			Program.Settings.ShowStatusOverlay = chkShowStatusOverlay.Checked;
-			Program.Settings.ShowNavigationOverlay = chkShowNavigationOverlay.Checked;
-			Program.Settings.NavigationOverlayOnTop = cbNavigationOverlayPosition.SelectedIndex == 1;
-			Program.Settings.CurrentPageShowsName = chkShowPageNames.Checked;
-			Program.Settings.HardwareAcceleration = chkEnableHardware.Checked;
-			Program.Settings.SmoothScrolling = chkSmoothAutoScrolling.Checked;
-			Program.Settings.DisplayChangeAnimation = chkEnableDisplayChangeAnimation.Checked;
-			Program.Settings.SoftwareFiltering = chkEnableSoftwareFiltering.Checked;
-			Program.Settings.HardwareFiltering = chkEnableHardwareFiltering.Checked;
-			Program.Settings.FlowingMouseScrolling = chkEnableInertialMouseScrolling.Checked;
-			Program.Settings.OverlayScaling = tbOverlayScaling.Value;
-			Program.Settings.RemoveMissingFilesOnFullScan = chkAutoRemoveMissing.Checked;
-			Program.Settings.DontAddRemoveFiles = chkDontAddRemovedFiles.Checked;
-			if (!Program.Settings.DontAddRemoveFiles)
-			{
-				Program.Database.ClearBlackList();
-			}
-			Program.Settings.OverwriteAssociations = chkOverwriteAssociations.Checked;
-			Program.Settings.LookForShared = chkLookForShared.Checked;
-			Program.Settings.AutoConnectShares = chkAutoConnectShares.Checked;
-			CopyWatchFoldersToDatabase();
-			RegisterFileTypes();
-			Program.Settings.UpdateComicFiles = chkUpdateComicFiles.Checked;
-			Program.Settings.AutoUpdateComicsFiles = chkAutoUpdateComicFiles.Checked;
-			Program.Settings.IgnoredCoverImages = (string.IsNullOrEmpty(txCoverFilter.Text) ? null : txCoverFilter.Text);
-			Program.Settings.ScriptingLibraries = txLibraries.Text;
-			Program.Settings.Scripting = !chkDisableScripting.Checked;
-			Program.Settings.HideSampleScripts = chkHideSampleScripts.Checked;
-			if (!string.IsNullOrEmpty(BackupFile))
-			{
-				try
-				{
-					try
-					{
-						AutomaticProgressDialog.Process(this, TR.Messages["DatabaseRestore", "Database Restore"], TR.Messages["DatabaseRestoreText", "Restoring database from Backup file"], 1000, delegate
-						{
-							Program.DatabaseManager.RestoreFrom(BackupFile, Program.Paths.CustomThumbnailPath);
-						}, AutomaticProgressDialogOptions.None);
-					}
-					catch (Exception)
-					{
-						MessageBox.Show(this, TR.Messages["DatabaseRestoreError", "There was an error restoring the Database Backup"], TR.Messages["Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-					}
-					BackupFile = null;
-					NeedsRestart = true;
-				}
-				catch
-				{
-				}
-			}
-			List<ComicLibraryServerConfig> list = (from p in tabShares.TabPages.OfType<Control>()
-												   select p.Controls[0] as ServerEditControl into se
-												   select se.Config).ToList();
-			if (!list.SequenceEqual(Program.Settings.Shares, new ComicLibraryServerConfig.EqualityComparer()))
-			{
-				NeedsRestart = true;
-				Program.Settings.Shares.Clear();
-				Program.Settings.Shares.AddRange(list);
-			}
-			string text = txPublicServerAddress.Text.Trim();
-			if (text != Program.Settings.ExternalServerAddress)
-			{
-				NeedsRestart = true;
-				Program.Settings.ExternalServerAddress = text;
-			}
-			if (txPrivateListingPassword.Password != Program.Settings.PrivateListingPassword)
-			{
-				NeedsRestart = true;
-				Program.Settings.PrivateListingPassword = txPrivateListingPassword.Password;
-			}
-			Program.Settings.ExtraWifiDeviceAddresses = txWifiAddresses.Text;
-			Program.RefreshAllWindows();
-			Program.ForAllForms(delegate (Form f)
-			{
-				f.FindServices<ISettingsChanged>().ForEach(delegate (ISettingsChanged s)
-				{
-					s.SettingsChanged();
-				});
-			});
-		}
-
-		private void SetScanButtonText()
-		{
-			btScan.Text = (Program.Scanner.IsScanning ? LocalizeUtility.GetText(this, "Stop", "Stop") : LocalizeUtility.GetText(this, "Scan", "Scan"));
-		}
-
-		private void SetSettings()
-		{
-			FormUtility.FillPanelWithOptions(pageBehavior, Program.Settings, TR.Load("Settings"));
-			chkLibraryGauges.Checked = Program.Settings.DisplayLibraryGauges;
-			chkLibraryGaugesUnread.Checked = Program.Settings.LibraryGaugesFormat.IsSet(LibraryGauges.Unread);
-			chkLibraryGaugesNew.Checked = Program.Settings.LibraryGaugesFormat.IsSet(LibraryGauges.New);
-			chkLibraryGaugesTotal.Checked = Program.Settings.LibraryGaugesFormat.IsSet(LibraryGauges.Total);
-			chkLibraryGaugesNumeric.Checked = Program.Settings.LibraryGaugesFormat.IsSet(LibraryGauges.Numeric);
-			tbMouseWheel.Value = (int)(Program.Settings.MouseWheelSpeed * 10f);
-			chkHighQualityDisplay.Checked = Program.Settings.PageImageDisplayOptions.IsSet(ImageDisplayOptions.HighQuality);
-			chkAnamorphicScaling.Checked = Program.Settings.PageImageDisplayOptions.IsSet(ImageDisplayOptions.AnamorphicScaling);
-			chkAutoRemoveMissing.Checked = Program.Settings.RemoveMissingFilesOnFullScan;
-			chkDontAddRemovedFiles.Checked = Program.Settings.DontAddRemoveFiles;
-			tbSaturation.Value = (int)(Program.Settings.GlobalColorAdjustment.Saturation * 100f);
-			tbBrightness.Value = (int)(Program.Settings.GlobalColorAdjustment.Brightness * 100f);
-			tbContrast.Value = (int)(Program.Settings.GlobalColorAdjustment.Contrast * 100f);
-			tbGamma.Value = (int)(Program.Settings.GlobalColorAdjustment.Gamma * 100f);
-			tbSharpening.Value = Program.Settings.GlobalColorAdjustment.Sharpen;
-			chkAutoContrast.Checked = Program.Settings.GlobalColorAdjustment.Options.IsSet(BitmapAdjustmentOptions.AutoContrast);
-			chkShowCurrentPageOverlay.Checked = Program.Settings.ShowCurrentPageOverlay;
-			chkShowVisiblePartOverlay.Checked = Program.Settings.ShowVisiblePagePartOverlay;
-			chkShowStatusOverlay.Checked = Program.Settings.ShowStatusOverlay;
-			chkShowNavigationOverlay.Checked = Program.Settings.ShowNavigationOverlay;
-			cbNavigationOverlayPosition.SelectedIndex = (Program.Settings.NavigationOverlayOnTop ? 1 : 0);
-			chkShowPageNames.Checked = Program.Settings.CurrentPageShowsName;
-			chkEnableHardware.Checked = Program.Settings.HardwareAcceleration;
-			chkSmoothAutoScrolling.Checked = Program.Settings.SmoothScrolling;
-			chkEnableDisplayChangeAnimation.Checked = Program.Settings.DisplayChangeAnimation;
-			chkEnableSoftwareFiltering.Checked = Program.Settings.SoftwareFiltering;
-			chkEnableHardwareFiltering.Checked = Program.Settings.HardwareFiltering;
-			chkEnableInertialMouseScrolling.Checked = Program.Settings.FlowingMouseScrolling;
-			chkEnableInternetCache.Checked = Program.Settings.InternetCacheEnabled;
-			numInternetCacheSize.Value = numInternetCacheSize.Clamp(Program.Settings.InternetCacheSizeMB);
-			chkEnableThumbnailCache.Checked = Program.Settings.ThumbCacheEnabled;
-			numThumbnailCacheSize.Value = numThumbnailCacheSize.Clamp(Program.Settings.ThumbCacheSizeMB);
-			chkEnablePageCache.Checked = Program.Settings.PageCacheEnabled;
-			numPageCacheSize.Value = numPageCacheSize.Clamp(Program.Settings.PageCacheSizeMB);
-			chkMemPageOptimized.Checked = Program.Settings.MemoryPageCacheOptimized;
-			numMemPageCount.Value = numMemPageCount.Clamp(Program.Settings.MemoryPageCacheCount);
-			chkMemThumbOptimized.Checked = Program.Settings.MemoryThumbCacheOptimized;
-			numMemThumbSize.Value = numMemThumbSize.Clamp(Program.Settings.MemoryThumbCacheSizeMB);
-			tbMaximumMemoryUsage.SetRange(2, MaximumMemoryStepSize);
-			tbMaximumMemoryUsage.Value = Program.Settings.MaximumMemoryMB / MaximumMemoryStepSize;
-			tbOverlayScaling.Value = Program.Settings.OverlayScaling;
-			chkOverwriteAssociations.Checked = Program.Settings.OverwriteAssociations;
-			chkUpdateComicFiles.Checked = Program.Settings.UpdateComicFiles;
-			chkAutoUpdateComicFiles.Checked = Program.Settings.AutoUpdateComicsFiles;
-			txCoverFilter.Text = Program.Settings.IgnoredCoverImages;
-			txLibraries.Text = Program.Settings.ScriptingLibraries;
-			chkDisableScripting.Checked = !Program.Settings.Scripting;
-			chkHideSampleScripts.Checked = Program.Settings.HideSampleScripts;
-			lbLanguages.SelectedIndex = 0;
-			foreach (TRInfo item in lbLanguages.Items)
-			{
-				if (item.CultureName == Program.Settings.CultureName)
-				{
-					lbLanguages.SelectedItem = item;
-					break;
-				}
-			}
-			txPublicServerAddress.Text = Program.Settings.ExternalServerAddress;
-			txPrivateListingPassword.Password = Program.Settings.PrivateListingPassword;
-			chkLookForShared.Checked = Program.Settings.LookForShared;
-			chkAutoConnectShares.Checked = Program.Settings.AutoConnectShares;
-			foreach (ComicLibraryServerConfig share in Program.Settings.Shares)
-			{
-				AddSharePage(share);
-			}
-			txWifiAddresses.Text = Program.Settings.ExtraWifiDeviceAddresses;
-		}
-
-		private void AddSharePage(ComicLibraryServerConfig cfg)
-		{
-			TabPage tab = new TabPage(cfg.Name)
-			{
-				UseVisualStyleBackColor = true
-			};
-			ServerEditControl sc = new ServerEditControl
-			{
-				Dock = DockStyle.Fill,
-				Config = cfg,
-				BackColor = Color.Transparent
-			};
-			sc.ShareNameChanged += delegate
-			{
-				tab.Text = sc.ShareName;
-			};
-			tab.Controls.Add(sc);
-			tabShares.TabPages.Add(tab);
-		}
-
-		private void RemoveSharePage(TabPage tab)
-		{
-			Control control = tab.Controls[0];
-			tab.Controls.Remove(control);
-			control.Dispose();
-			tabShares.TabPages.Remove(tab);
-			tab.Dispose();
-		}
-
-		private void CopyWatchFoldersToDatabase()
-		{
-			Program.Database.WatchFolders.Clear();
-			for (int i = 0; i < lbPaths.Items.Count; i++)
-			{
-				Program.Database.WatchFolders.Add(new WatchFolder(lbPaths.Items[i].ToString(), lbPaths.GetItemChecked(i)));
-			}
-		}
-
-		private void RegisterFileTypes()
-		{
-			for (int i = 0; i < lbFormats.Items.Count; i++)
-			{
-				FileFormat fileFormat = (FileFormat)lbFormats.Items[i];
-				if (lbFormats.GetItemChecked(i))
-				{
-					fileFormat.RegisterShell(Program.ComicRackTypeId, Program.ComicRackDocumentName, Program.Settings.OverwriteAssociations);
-				}
-				else
-				{
-					fileFormat.UnregisterShell(Program.ComicRackTypeId);
-				}
-			}
-		}
-
-		private void SetTab(CheckBox cb)
-		{
-			if (blockSetTab)
-			{
-				return;
-			}
-			blockSetTab = true;
-			try
-			{
-				foreach (CheckBox tabButton in tabButtons)
-				{
-					tabButton.Checked = tabButton == cb;
-					Control control = tabButton.Tag as Control;
-					if (control.Tag is Control)
-					{
-						control = control.Tag as Control;
-					}
-					control.Visible = tabButton.Checked;
-				}
-			}
-			finally
-			{
-				blockSetTab = false;
-			}
-		}
-
-		private void UpdateDiskCacheStatus(object sender, EventArgs e)
-		{
-			if (!this.BeginInvokeIfRequired(delegate
-			{
-				UpdateDiskCacheStatus(sender, e);
-			}))
-			{
-				lblInternetCacheUsage.Text = string.Format("({0}/{1})", Program.InternetCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
-				{
-					Program.InternetCache.Size
-				}));
-				lblPageCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Pages.DiskCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
-				{
-					Program.ImagePool.Pages.DiskCache.Size
-				}));
-				lblThumbCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Thumbs.DiskCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
-				{
-					Program.ImagePool.Thumbs.DiskCache.Size
-				}));
-			}
-		}
-
-		private void UpdateMemoryCacheStatus()
-		{
-			if (!this.BeginInvokeIfRequired(UpdateMemoryCacheStatus))
-			{
-				lblPageMemCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Pages.MemoryCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
-				{
-					Program.ImagePool.Pages.MemoryCache.Size
-				}));
-				lblThumbMemCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Thumbs.MemoryCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
-				{
-					Program.ImagePool.Thumbs.MemoryCache.Size
-				}));
-			}
-		}
-
-		private void RefreshPackageList()
-		{
-			lvPackages.Items.Clear();
-			foreach (PackageManager.Package item in (from p in Program.ScriptPackages.GetPackages()
-													 orderby p.PackageType
-													 select p).Reverse())
-			{
-				ListViewItem listViewItem = lvPackages.Items.Add(item.Name, item.Name, 0);
-				if (item.Image != null)
-				{
-					packageImageList.Images.Add(item.Image);
-					listViewItem.ImageIndex = packageImageList.Images.Count - 1;
-				}
-				listViewItem.Tag = item;
-				if (!string.IsNullOrEmpty(item.Version))
-				{
-					listViewItem.Text = listViewItem.Text + " V" + item.Version;
-				}
-				listViewItem.SubItems.Add(item.Author);
-				listViewItem.SubItems.Add(item.Description);
-				switch (item.PackageType)
-				{
-					default:
-						listViewItem.Group = lvPackages.Groups["packageGroupInstalled"];
-						break;
-					case PackageManager.PackageType.PendingInstall:
-						listViewItem.Group = lvPackages.Groups["packageGroupInstall"];
-						break;
-					case PackageManager.PackageType.PendingRemove:
-						listViewItem.Group = lvPackages.Groups["packageGroupRemove"];
-						break;
-				}
-			}
-		}
-
-		private void btAssociateExtensions_Click(object sender, EventArgs e)
-		{
-			string str = "-rf \"" + (chkOverwriteAssociations.Checked ? "!" : string.Empty);
-			for (int i = 0; i < lbFormats.Items.Count; i++)
-			{
-				FileFormat fileFormat = (FileFormat)lbFormats.Items[i];
-				if (i != 0)
-				{
-					str += ",";
-				}
-				if (!lbFormats.GetItemChecked(i))
-				{
-					str += "-";
-				}
-				str += fileFormat.Name;
-			}
-			str += "\"";
-			if (ProcessRunner.RunElevated(Application.ExecutablePath, str) == 0)
-			{
-				FillExtensionsList();
-			}
-		}
-
-		private void btAddShare_Click(object sender, EventArgs e)
-		{
-			ComicLibraryServerConfig comicLibraryServerConfig = new ComicLibraryServerConfig();
-			comicLibraryServerConfig.Name = $"{Environment.UserName}'s Library";
-			if (tabShares.TabCount > 1)
-			{
-				comicLibraryServerConfig.Name += $" ({tabShares.TabCount + 1})";
-			}
-			AddSharePage(comicLibraryServerConfig);
-			tabShares.SelectedIndex = tabShares.TabPages.Count - 1;
-		}
-
-		private void btRmoveShare_Click(object sender, EventArgs e)
-		{
-			TabPage selectedTab = tabShares.SelectedTab;
-			if (selectedTab != null)
-			{
-				RemoveSharePage(selectedTab);
-			}
-		}
-
-		public static bool Show(IWin32Window parent, KeyboardShortcuts commands, PluginEngine pe, string autoInstallPlugin = null)
-		{
-			using (PreferencesDialog preferencesDialog = new PreferencesDialog())
-			{
-				preferencesDialog.keyboardShortcutEditor.Shortcuts = commands;
-				preferencesDialog.Plugins = pe;
-				preferencesDialog.AutoInstallPlugin = (File.Exists(autoInstallPlugin) ? autoInstallPlugin : null);
-				bool flag = preferencesDialog.ShowDialog(parent) == DialogResult.OK;
-				if (flag)
-				{
-					preferencesDialog.Apply();
-					if (preferencesDialog.NeedsRestart && QuestionDialog.Ask(parent, TR.Messages["RestartQuestion", "ComicRack needs to restart to complete the operation! Do you want to restart now?"], TR.Default["Restart", "Restart"]))
-					{
-						Program.MainForm.MenuRestart();
-					}
-				}
-				else
-				{
-					Program.ScriptPackages.RemovePending();
-				}
-				return flag;
-			}
-		}
-
-	}
+    public partial class PreferencesDialog : Form
+    {
+        private const int MaximumMemoryStepSize = 32;
+
+        private static readonly string DuplicatePackageText = TR.Messages["ScriptPackageExists", "A Script Package with the same name already exists! Do you want to overwrite this Package?"];
+
+        private PluginEngine pluginEngine;
+
+        private bool blockSetTab;
+
+        public string AutoInstallPlugin
+        {
+            get;
+            set;
+        }
+
+        public bool NeedsRestart
+        {
+            get;
+            set;
+        }
+
+        public string BackupFile
+        {
+            get;
+            set;
+        }
+
+        public PluginEngine Plugins
+        {
+            get
+            {
+                return pluginEngine;
+            }
+            set
+            {
+                pluginEngine = value;
+                FillScriptsList();
+            }
+        }
+
+        public PreferencesDialog()
+        {
+            LocalizeUtility.UpdateRightToLeft(this);
+            InitializeComponent();
+            lvPackages.Columns.ScaleDpi();
+            lvScripts.Columns.ScaleDpi();
+            this.RestorePosition();
+            this.RestorePanelStates();
+            tabReader.Tag = pageReader;
+            tabBehavior.Tag = pageBehavior;
+            tabLibraries.Tag = pageLibrary;
+            tabScripts.Tag = pageScripts;
+            tabAdvanced.Tag = pageAdvanced;
+            tabButtons.AddRange(new CheckBox[5]
+            {
+                tabReader,
+                tabBehavior,
+                tabLibraries,
+                tabScripts,
+                tabAdvanced
+            });
+            lbLanguages.ItemHeight = FormUtility.ScaleDpiY(lbLanguages.ItemHeight);
+            tabReader.Image = ((Bitmap)tabReader.Image).ScaleDpi();
+            tabAdvanced.Image = ((Bitmap)tabAdvanced.Image).ScaleDpi();
+            tabBehavior.Image = ((Bitmap)tabBehavior.Image).ScaleDpi();
+            tabLibraries.Image = ((Bitmap)tabLibraries.Image).ScaleDpi();
+            tabScripts.Image = ((Bitmap)tabScripts.Image).ScaleDpi();
+            FormUtility.FillPanelWithOptions(pageBehavior, Program.Settings, TR.Load("Settings"));
+            packageImageList.Images.Add(Resources.Package);
+            LocalizeUtility.Localize(this, components);
+            LocalizeUtility.Localize(TR.Load(base.Name), cbNavigationOverlayPosition);
+            FormUtility.RegisterPanelToTabToggle(pageReader, PropertyCaller.CreateFlagsValueStore(Program.Settings, "TabLayouts", TabLayouts.ReaderSettings));
+            FormUtility.RegisterPanelToTabToggle(pageBehavior, PropertyCaller.CreateFlagsValueStore(Program.Settings, "TabLayouts", TabLayouts.BehaviorSettings));
+            FormUtility.RegisterPanelToTabToggle(pageLibrary, PropertyCaller.CreateFlagsValueStore(Program.Settings, "TabLayouts", TabLayouts.LibrarySettings));
+            FormUtility.RegisterPanelToTabToggle(pageScripts, PropertyCaller.CreateFlagsValueStore(Program.Settings, "TabLayouts", TabLayouts.ScriptSettings));
+            FormUtility.RegisterPanelToTabToggle(pageAdvanced, PropertyCaller.CreateFlagsValueStore(Program.Settings, "TabLayouts", TabLayouts.AdvancedSettings));
+            Program.Scanner.ScanNotify += DatabaseScanNotify;
+            IdleProcess.Idle += ApplicationIdle;
+            numMemPageCount.Minimum = 20m;
+            numMemPageCount.Maximum = 100m;
+            numMemThumbSize.Minimum = 5m;
+            numMemThumbSize.Maximum = 100m;
+            lbLanguages.Items.Add(new TRInfo());
+            lbLanguages.Items.Add(new TRInfo("en"));
+            TRInfo[] installedLanguages = Program.InstalledLanguages;
+            foreach (TRInfo item in installedLanguages)
+            {
+                lbLanguages.Items.Add(item);
+            }
+            SetSettings();
+            foreach (WatchFolder watchFolder in Program.Database.WatchFolders)
+            {
+                lbPaths.Items.Add(watchFolder.Folder, watchFolder.Watch);
+            }
+            lbPaths_SelectedIndexChanged(lbPaths, EventArgs.Empty);
+            SetScanButtonText();
+            btResetMessages.Enabled = Program.Settings.HiddenMessageBoxes != HiddenMessageBoxes.None;
+            FillExtensionsList();
+            chkOverwriteAssociations.Checked = Program.Settings.OverwriteAssociations;
+            if (!FileFormat.CanRegisterShell)
+            {
+                Win7.ShowShield(btAssociateExtensions);
+            }
+            else
+            {
+                btAssociateExtensions.Visible = false;
+                lbFormats.Width = btAssociateExtensions.Right - lbFormats.Left;
+            }
+            Program.InternetCache.SizeChanged += UpdateDiskCacheStatus;
+            Program.ImagePool.Pages.DiskCache.SizeChanged += UpdateDiskCacheStatus;
+            Program.ImagePool.Thumbs.DiskCache.SizeChanged += UpdateDiskCacheStatus;
+            UpdateDiskCacheStatus(this, null);
+            UpdateMemoryCacheStatus();
+            RefreshPackageList();
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+            SetTab((activeTab != -1) ? tabButtons[activeTab] : tabReader);
+            //Fix Auto Word Selection bug
+            rtfVirtualTagCaption.AutoWordSelection = false;
+        }
+
+        protected override void OnShown(EventArgs e)
+        {
+            base.OnShown(e);
+            if (!string.IsNullOrEmpty(AutoInstallPlugin))
+            {
+                SetTab(tabScripts);
+                if (InstallPlugin(AutoInstallPlugin))
+                {
+                    RefreshPackageList();
+                }
+            }
+        }
+
+        private void btTestWifi_Click(object sender, EventArgs e)
+        {
+            string text = string.Empty;
+            using (new WaitCursor(this))
+            {
+                foreach (ISyncProvider item in DeviceSyncFactory.Discover(DeviceSyncFactory.ParseWifiAddressList(txWifiAddresses.Text)))
+                {
+                    text = text.AppendWithSeparator(", ", item.Device.Model);
+                }
+            }
+            lblWifiStatus.Text = (string.IsNullOrEmpty(text) ? TR.Load(base.Name)["msgNoDevicesFound", "No devices found!"] : TR.Load(base.Name)["msgDevicesFound", "{0} found!"].SafeFormat(text));
+        }
+
+        private void chkAdvanced_CheckedChanged(object sender, EventArgs e)
+        {
+            CheckBox checkBox = sender as CheckBox;
+            if (checkBox.Checked)
+            {
+                SetTab(checkBox);
+            }
+        }
+
+        private void chkLibraryGauges_CheckedChanged(object sender, EventArgs e)
+        {
+            CheckBox checkBox = chkLibraryGaugesNew;
+            CheckBox checkBox2 = chkLibraryGaugesUnread;
+            CheckBox checkBox3 = chkLibraryGaugesTotal;
+            bool flag = (chkLibraryGaugesNumeric.Enabled = chkLibraryGauges.Checked);
+            bool flag3 = (checkBox3.Enabled = flag);
+            bool enabled = (checkBox2.Enabled = flag3);
+            checkBox.Enabled = enabled;
+        }
+
+        private void tbSystemMemory_ValueChanged(object sender, EventArgs e)
+        {
+            int num = tbMaximumMemoryUsage.Value * MaximumMemoryStepSize;
+            if (num == Settings.UnlimitedSystemMemory)
+            {
+                lblMaximumMemoryUsageValue.Text = TR.Default["Unlimited"];
+            }
+            else
+            {
+                lblMaximumMemoryUsageValue.Text = $"{num} MB";
+            }
+        }
+
+        private void lbPaths_DragDrop(object sender, DragEventArgs e)
+        {
+            (from d in (e.Data.GetData(DataFormats.FileDrop) as string[])?.Select((string d) => (!Directory.Exists(d)) ? Path.GetDirectoryName(d) : d)
+             where !lbPaths.Items.Contains(d)
+             select d).ForEach(delegate (string d)
+             {
+                 lbPaths.Items.Add(d);
+             });
+        }
+
+        private void lbPaths_DragOver(object sender, DragEventArgs e)
+        {
+            e.Effect = (e.Data.GetDataPresent(DataFormats.FileDrop) ? DragDropEffects.Copy : DragDropEffects.None);
+        }
+
+        private void lvScripts_ItemChecked(object sender, ItemCheckedEventArgs e)
+        {
+            Command command = e.Item.Tag as Command;
+            if (command != null)
+            {
+                command.Enabled = e.Item.Checked;
+            }
+        }
+
+        private void lvScripts_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            Command command = (from lvi in lvScripts.SelectedItems.OfType<ListViewItem>()
+                               select lvi.Tag as Command).FirstOrDefault();
+            btConfigScript.Enabled = command != null && command.Configure != null;
+            if (btConfigScript.Enabled)
+            {
+                btConfigScript.Tag = command.Configure;
+            }
+        }
+
+        private void btConfigScript_Click(object sender, EventArgs e)
+        {
+            (btConfigScript.Tag as Command)?.Invoke(new object[0], catchErrors: true);
+        }
+
+        private void lbPaths_DrawItemText(object sender, DrawItemEventArgs e)
+        {
+            CheckedListBoxEx checkedListBoxEx = (CheckedListBoxEx)sender;
+            using (StringFormat format = new StringFormat
+            {
+                LineAlignment = StringAlignment.Center,
+                Trimming = StringTrimming.EllipsisPath
+            })
+            {
+                checkedListBoxEx.DrawDefaultItemText(e, format);
+            }
+        }
+
+        private void DatabaseScanNotify(object sender, ComicScanNotifyEventArgs e)
+        {
+            try
+            {
+                if (!this.BeginInvokeIfRequired(delegate
+                {
+                    DatabaseScanNotify(sender, e);
+                }))
+                {
+                    if (string.IsNullOrEmpty(e.File))
+                    {
+                        lblScan.Text = string.Empty;
+                    }
+                    else
+                    {
+                        lblScan.Text = StringUtility.Format(LocalizeUtility.GetText(this, "Scanning", "Scanning '{0}' ..."), e.File);
+                    }
+                    SetScanButtonText();
+                }
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        private void btClearThumbnailCache_Click(object sender, EventArgs e)
+        {
+            using (new WaitCursor())
+            {
+                Program.ImagePool.Thumbs.DiskCache.Clear();
+            }
+        }
+
+        private void btClearPageCache_Click(object sender, EventArgs e)
+        {
+            using (new WaitCursor())
+            {
+                Program.ImagePool.Pages.DiskCache.Clear();
+            }
+        }
+
+        private void btClearInternetCache_Click(object sender, EventArgs e)
+        {
+            using (new WaitCursor())
+            {
+                Program.InternetCache.Clear();
+            }
+        }
+
+        private void btAddFolder_Click(object sender, EventArgs e)
+        {
+            using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
+            {
+                folderBrowserDialog.Description = LocalizeUtility.GetText(this, "SelectComicFolder", "Please select a folder containing Books");
+                folderBrowserDialog.ShowNewFolderButton = true;
+                if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
+                {
+                    lbPaths.Items.Add(folderBrowserDialog.SelectedPath);
+                    if (lbPaths.SelectedIndex == -1)
+                    {
+                        lbPaths.SelectedIndex = 0;
+                    }
+                }
+            }
+        }
+
+        private void btChangeFolder_Click(object sender, EventArgs e)
+        {
+            string text = lbPaths.SelectedItem as string;
+            if (text == null)
+            {
+                return;
+            }
+            using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
+            {
+                folderBrowserDialog.Description = LocalizeUtility.GetText(this, "SelectComicFolder", "Please select a folder containing Books");
+                folderBrowserDialog.ShowNewFolderButton = true;
+                folderBrowserDialog.SelectedPath = text;
+                if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
+                {
+                    lbPaths.Items[lbPaths.SelectedIndex] = folderBrowserDialog.SelectedPath;
+                }
+            }
+        }
+
+        private void btAddLibraryFolder_Click(object sender, EventArgs e)
+        {
+            using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
+            {
+                folderBrowserDialog.Description = LocalizeUtility.GetText(this, "SelectScriptFolder", "Please select a script library folder");
+                folderBrowserDialog.ShowNewFolderButton = false;
+                if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
+                {
+                    if (txLibraries.Text.Trim().Length > 0)
+                    {
+                        txLibraries.Text += ";";
+                    }
+                    txLibraries.Text += folderBrowserDialog.SelectedPath;
+                }
+            }
+        }
+
+        private void btRemoveFolder_Click(object sender, EventArgs e)
+        {
+            int selectedIndex = lbPaths.SelectedIndex;
+            if (selectedIndex != -1)
+            {
+                lbPaths.Items.RemoveAt(selectedIndex);
+            }
+        }
+
+        private void btOpenFolder_Click(object sender, EventArgs e)
+        {
+            Program.ShowExplorer(lbPaths.SelectedItem as string);
+        }
+
+        private void btScan_Click(object sender, EventArgs e)
+        {
+            if (Program.Scanner.IsScanning)
+            {
+                Program.Scanner.Stop(clearQueue: true);
+                return;
+            }
+            foreach (string item in lbPaths.Items)
+            {
+                Program.Scanner.ScanFileOrFolder(item, all: true, chkAutoRemoveMissing.Checked);
+            }
+        }
+
+        private void lbPaths_DrawItem(object sender, DrawItemEventArgs e)
+        {
+            e.DrawBackground();
+            string s = lbPaths.Items[e.Index] as string;
+            using (StringFormat format = new StringFormat
+            {
+                Trimming = StringTrimming.EllipsisPath
+            })
+            {
+                using (Brush brush = new SolidBrush(e.ForeColor))
+                {
+                    e.Graphics.DrawString(s, e.Font, brush, e.Bounds, format);
+                }
+            }
+            e.DrawFocusRectangle();
+        }
+
+        private void lbPaths_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            Button button = btOpenFolder;
+            bool enabled = (btRemoveFolder.Enabled = lbPaths.SelectedIndex != -1);
+            button.Enabled = enabled;
+            btScan.Enabled = lbPaths.Items.Count > 0;
+        }
+
+        private void btResetMessages_Click(object sender, EventArgs e)
+        {
+            Program.Settings.HiddenMessageBoxes = HiddenMessageBoxes.None;
+            btResetMessages.Enabled = false;
+        }
+
+        private void ApplicationIdle(object sender, EventArgs e)
+        {
+            CheckBox checkBox = chkEnableDisplayChangeAnimation;
+            CheckBox checkBox2 = chkEnableHardwareFiltering;
+            CheckBox checkBox3 = chkEnableSoftwareFiltering;
+            bool flag = (chkEnableInertialMouseScrolling.Enabled = chkEnableHardware.Checked);
+            bool flag3 = (checkBox3.Enabled = flag);
+            bool enabled = (checkBox2.Enabled = flag3);
+            checkBox.Enabled = enabled;
+            chkAutoConnectShares.Enabled = chkLookForShared.Checked;
+            btRemovePackage.Enabled = lvPackages.SelectedItems.Count > 0;
+            labelPageOverlay.Enabled = chkShowCurrentPageOverlay.Checked;
+            labelVisiblePartOverlay.Enabled = chkShowVisiblePartOverlay.Checked;
+            labelStatusOverlay.Enabled = chkShowStatusOverlay.Checked;
+            labelNavigationOverlay.Top = ((cbNavigationOverlayPosition.SelectedIndex != 0) ? labelPageOverlay.Top : (labelVisiblePartOverlay.Bottom - labelNavigationOverlay.Height));
+            labelPageOverlay.Text = (chkShowPageNames.Checked ? LocalizeUtility.GetText(this, "PageNumberAndName", "Page\nName") : LocalizeUtility.GetText(this, "PageNumberOnly", "Page"));
+        }
+
+        private void btApply_Click(object sender, EventArgs e)
+        {
+            Apply();
+        }
+
+        private void tbSaturation_DoubleClick(object sender, EventArgs e)
+        {
+            tbSaturation.Value = 0;
+        }
+
+        private void tbBrightness_DoubleClick(object sender, EventArgs e)
+        {
+            tbBrightness.Value = 0;
+        }
+
+        private void tbContrast_DoubleClick(object sender, EventArgs e)
+        {
+            tbContrast.Value = 0;
+        }
+
+        private void tbSharpening_DoubleClick(object sender, EventArgs e)
+        {
+            tbSharpening.Value = 0;
+        }
+
+        private void tbGamma_DoubleClick(object sender, EventArgs e)
+        {
+            tbGamma.Value = 0;
+        }
+
+        private void btReset_Click(object sender, EventArgs e)
+        {
+            TrackBarLite trackBarLite = tbSaturation;
+            TrackBarLite trackBarLite2 = tbBrightness;
+            TrackBarLite trackBarLite3 = tbContrast;
+            int num2 = (tbGamma.Value = 0);
+            int num4 = (trackBarLite3.Value = num2);
+            int num7 = (trackBarLite.Value = (trackBarLite2.Value = num4));
+        }
+
+        private void tbOverlayScalingChanged(object sender, EventArgs e)
+        {
+            toolTip.SetToolTip(tbOverlayScaling, $"{tbOverlayScaling.Value}%");
+        }
+
+        private void tbColorAdjustmentChanged(object sender, EventArgs e)
+        {
+            TrackBarLite trackBarLite = (TrackBarLite)sender;
+            toolTip.SetToolTip(trackBarLite, string.Format("{1}{0}%", trackBarLite.Value, (trackBarLite.Value > 0) ? "+" : string.Empty));
+        }
+
+        private void lbLanguages_DrawItem(object sender, DrawItemEventArgs e)
+        {
+            if (e.Index == -1)
+            {
+                return;
+            }
+            TRInfo tRInfo = (TRInfo)lbLanguages.Items[e.Index];
+            e.DrawBackground();
+            using (Brush brush = new SolidBrush((tRInfo.CompletionPercent > 95f) ? ForeColor : Color.Red))
+            {
+                Rectangle bounds = e.Bounds;
+                string cultureCode = tRInfo.CultureName ?? CultureInfo.InstalledUICulture.Name;
+                using (Image image = Flags.GetFlagFromCulture(cultureCode))
+                {
+                    if (image != null)
+                    {
+                        float scale = image.Size.GetScale(bounds.Pad(2).Size);
+                        e.Graphics.DrawImage(image, bounds.X + 1, bounds.Y + 2, (float)image.Width * scale, (float)image.Height * scale);
+                    }
+                }
+                bounds.X += FormUtility.ScaleDpiX(20);
+                bounds.Width -= FormUtility.ScaleDpiX(20);
+                string[] array = tRInfo.ToString().Split('\t');
+                using (StringFormat stringFormat = new StringFormat(StringFormatFlags.NoWrap)
+                {
+                    Trimming = StringTrimming.Character,
+                    LineAlignment = StringAlignment.Center
+                })
+                {
+                    e.Graphics.DrawString(array[0], e.Font, brush, bounds, stringFormat);
+                    if (array.Length > 1)
+                    {
+                        stringFormat.Alignment = StringAlignment.Far;
+                        e.Graphics.DrawString(array[1], e.Font, brush, bounds, stringFormat);
+                    }
+                }
+            }
+            if ((e.State & DrawItemState.Focus) != 0)
+            {
+                ControlPaint.DrawFocusRectangle(e.Graphics, e.Bounds);
+            }
+        }
+
+        private void btBackupDatabase_Click(object sender, EventArgs e)
+        {
+            SaveFileDialog dlg = new SaveFileDialog();
+            try
+            {
+                dlg.Title = btBackupDatabase.Text.Replace(".", string.Empty);
+                dlg.FileName = string.Format("ComicDB Backup {0}.zip", DateTime.Now.ToString("yyyy-MM-dd"));
+                dlg.Filter = TR.Load("FileFilter")["ComicRackBackup", "ComicRack Database|*.zip"];
+                dlg.DefaultExt = ".zip";
+                if (dlg.ShowDialog(this) != DialogResult.OK)
+                {
+                    return;
+                }
+                try
+                {
+                    AutomaticProgressDialog.Process(this, TR.Messages["DatabaseBackup", "Database Backup"], TR.Messages["DatabaseBackupText", "Creating and saving the Backup File"], 1000, delegate
+                    {
+                        Program.DatabaseManager.BackupTo(dlg.FileName, Program.Paths.CustomThumbnailPath);
+                    }, AutomaticProgressDialogOptions.None);
+                }
+                catch
+                {
+                    MessageBox.Show(this, TR.Messages["DatabaseBackupError", "There was an error saving the Database backup"], TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                }
+            }
+            finally
+            {
+                if (dlg != null)
+                {
+                    ((IDisposable)dlg).Dispose();
+                }
+            }
+        }
+
+        private void btRestoreDatabase_Click(object sender, EventArgs e)
+        {
+            using (OpenFileDialog openFileDialog = new OpenFileDialog())
+            {
+                openFileDialog.Title = btRestoreDatabase.Text.Replace(".", string.Empty);
+                openFileDialog.Filter = TR.Load("FileFilter")["ComicRackBackup", "ComicRack Backup|*.zip"];
+                openFileDialog.CheckFileExists = true;
+                if (openFileDialog.ShowDialog(this) == DialogResult.OK)
+                {
+                    BackupFile = openFileDialog.FileName;
+                }
+            }
+        }
+
+        private void btTranslate_Click(object sender, EventArgs e)
+        {
+            Program.StartDocument(Program.DefaultLocalizePage);
+        }
+
+        private void memCacheUpate_Tick(object sender, EventArgs e)
+        {
+            UpdateMemoryCacheStatus();
+        }
+
+        private void btInstallPackage_Click(object sender, EventArgs e)
+        {
+            using (OpenFileDialog openFileDialog = new OpenFileDialog())
+            {
+                openFileDialog.Title = btInstallPackage.Text.Replace(".", string.Empty);
+                openFileDialog.Filter = TR.Load("FileFilter")["ScriptPackageOpen", "ComicRack Plugin|*.crplugin|Script Archive|*.zip"];
+                openFileDialog.CheckFileExists = true;
+                if (openFileDialog.ShowDialog(this) == DialogResult.OK && InstallPlugin(openFileDialog.FileName))
+                {
+                    RefreshPackageList();
+                }
+            }
+        }
+
+        private void btRemovePackage_Click(object sender, EventArgs e)
+        {
+            foreach (ListViewItem selectedItem in lvPackages.SelectedItems)
+            {
+                NeedsRestart = true;
+                if (!Program.ScriptPackages.Uninstall(selectedItem.Tag as PackageManager.Package))
+                {
+                    MessageBox.Show(this, TR.Messages["FailedRemovePackage", "Failed to uninstall package. Please restart ComicRack and try again!"], TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                }
+            }
+            RefreshPackageList();
+        }
+
+        private void lvPackages_DoubleClick(object sender, EventArgs e)
+        {
+            ListViewItem listViewItem = lvPackages.SelectedItems.OfType<ListViewItem>().FirstOrDefault();
+            if (listViewItem != null)
+            {
+                PackageManager.Package package = listViewItem.Tag as PackageManager.Package;
+                if (package.PackageType == PackageManager.PackageType.Installed)
+                {
+                    Program.ShowExplorer(package.PackagePath);
+                }
+            }
+        }
+
+        private void lvPackages_DragDrop(object sender, DragEventArgs e)
+        {
+            try
+            {
+                string[] array = e.Data.GetData(DataFormats.FileDrop) as string[];
+                string[] array2 = array;
+                foreach (string f in array2)
+                {
+                    if (!InstallPlugin(f))
+                    {
+                        break;
+                    }
+                }
+                RefreshPackageList();
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        private void lvPackages_DragOver(object sender, DragEventArgs e)
+        {
+            e.Effect = (e.Data.GetDataPresent(DataFormats.FileDrop) ? DragDropEffects.Copy : DragDropEffects.None);
+        }
+
+        private void keyboardShortcutEditor_DragOver(object sender, DragEventArgs e)
+        {
+            e.Effect = (e.Data.GetDataPresent(DataFormats.FileDrop) ? DragDropEffects.Copy : DragDropEffects.None);
+        }
+
+        private void keyboardShortcutEditor_DragDrop(object sender, DragEventArgs e)
+        {
+            try
+            {
+                LoadKeyboard(((string[])e.Data.GetData(DataFormats.FileDrop))[0]);
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        private void btExportKeyboard_Click(object sender, EventArgs e)
+        {
+            using (SaveFileDialog saveFileDialog = new SaveFileDialog())
+            {
+                saveFileDialog.Title = btExportKeyboard.Text.Replace("&", string.Empty);
+                saveFileDialog.FileName = TR.Load("FileFilter")["KeyboardLayout", "Keyboard Layout"] + ".xml";
+                saveFileDialog.Filter = TR.Load("FileFilter")["KeyboardLayoutFilter", "Keyboard Layout|*.xml"];
+                saveFileDialog.DefaultExt = ".xml";
+                saveFileDialog.CheckPathExists = true;
+                saveFileDialog.OverwritePrompt = true;
+                if (saveFileDialog.ShowDialog(this) != DialogResult.Cancel)
+                {
+                    try
+                    {
+                        List<StringPair> data = keyboardShortcutEditor.Shortcuts.GetKeyMapping().ToList();
+                        XmlUtility.Store(saveFileDialog.FileName, data);
+                        Program.Settings.KeyboardLayouts.UpdateMostRecent(saveFileDialog.FileName);
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show(this, string.Format(TR.Messages["CouldNotExportKeyboardLayout", "Could not export Keyboard Layout!\nReason: {0}"], ex.Message), TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                    }
+                }
+            }
+        }
+
+        private void btLoadKeyboard_Click(object sender, EventArgs e)
+        {
+            using (OpenFileDialog openFileDialog = new OpenFileDialog())
+            {
+                openFileDialog.Title = btImportKeyboard.Text.Replace("&", string.Empty);
+                openFileDialog.Filter = TR.Load("FileFilter")["KeyboardLayoutFilter", "Keyboard Layout|*.xml"];
+                openFileDialog.DefaultExt = ".xml";
+                openFileDialog.CheckFileExists = true;
+                if (openFileDialog.ShowDialog(this) != DialogResult.Cancel)
+                {
+                    LoadKeyboard(openFileDialog.FileName);
+                }
+            }
+        }
+
+        private void btImportKeyboard_ShowContextMenu(object sender, EventArgs e)
+        {
+            FormUtility.SafeToolStripClear(cmKeyboardLayout.Items, 2);
+            foreach (string keyboardLayout in Program.Settings.KeyboardLayouts)
+            {
+                string file = keyboardLayout;
+                cmKeyboardLayout.Items.Add(keyboardLayout, null, delegate
+                {
+                    LoadKeyboard(file);
+                });
+            }
+            cmKeyboardLayout.Items[1].Visible = cmKeyboardLayout.Items.Count > 2;
+        }
+
+        private void miDefaultKeyboardLayout_Click(object sender, EventArgs e)
+        {
+            keyboardShortcutEditor.Shortcuts.SetKeyMapping(Program.DefaultKeyboardMapping);
+            keyboardShortcutEditor.RefreshList();
+        }
+
+        private void chkHideSampleScripts_CheckedChanged(object sender, EventArgs e)
+        {
+            FillScriptsList();
+        }
+
+        private void FillScriptsList()
+        {
+            lvScripts.BeginUpdate();
+            try
+            {
+                lvScripts.Items.Clear();
+                if (pluginEngine == null)
+                {
+                    return;
+                }
+                foreach (Command allCommand in pluginEngine.GetAllCommands())
+                {
+                    if (!lvScripts.Items.ContainsKey(allCommand.Key) && (!allCommand.Name.Contains("[Code Sample]") || !chkHideSampleScripts.Checked))
+                    {
+                        string value = IniFile.GetValue(Path.Combine(allCommand.Environment.CommandPath, "package.ini"), "Name", "Other");
+                        string hookDescription = PluginEngine.GetHookDescription(allCommand.Hook);
+                        ListViewGroup group = lvScripts.Groups[hookDescription] ?? lvScripts.Groups.Add(hookDescription, hookDescription);
+                        ListViewItem listViewItem = lvScripts.Items.Add(allCommand.Key, allCommand.GetLocalizedName(), allCommand.Key);
+                        listViewItem.SubItems.Add(value);
+                        listViewItem.Tag = allCommand;
+                        listViewItem.Checked = allCommand.Enabled;
+                        listViewItem.ToolTipText = allCommand.GetLocalizedDescription();
+                        listViewItem.Group = group;
+                        Image commandImage = allCommand.CommandImage;
+                        if (commandImage != null)
+                        {
+                            imageList.Images.Add(allCommand.Key, commandImage);
+                        }
+                    }
+                }
+                lvScripts.SortGroups();
+            }
+            finally
+            {
+                lvScripts.EndUpdate();
+            }
+        }
+
+        private void LoadKeyboard(string f)
+        {
+            try
+            {
+                keyboardShortcutEditor.Shortcuts.SetKeyMapping(XmlUtility.Load<List<StringPair>>(f));
+                keyboardShortcutEditor.RefreshList();
+                Program.Settings.KeyboardLayouts.UpdateMostRecent(f);
+            }
+            catch (Exception ex)
+            {
+                Program.Settings.KeyboardLayouts.Remove(f);
+                MessageBox.Show(this, string.Format(TR.Messages["CouldNotImportKeyboardLayout", "Could not import Keyboard Layout!\nReason: {0}"], ex.Message), TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+            }
+        }
+
+        private bool InstallPlugin(string f)
+        {
+            if (Program.ScriptPackages.PackageFileExists(f) && !QuestionDialog.Ask(this, DuplicatePackageText, TR.Default["Yes", "Yes"]))
+            {
+                return false;
+            }
+            bool flag = Program.ScriptPackages.Install(f);
+            NeedsRestart |= flag;
+            return flag;
+        }
+
+        private void FillExtensionsList()
+        {
+            lbFormats.Items.Clear();
+            foreach (FileFormat item in from f in Providers.Readers.GetSourceFormats()
+                                        orderby f
+                                        select f)
+            {
+                int index = lbFormats.Items.Add(item);
+                lbFormats.SetItemChecked(index, item.IsShellRegistered(Program.ComicRackTypeId));
+            }
+        }
+
+        public void Apply()
+        {
+            string cultureName = ((TRInfo)lbLanguages.SelectedItem).CultureName;
+            if (cultureName != Program.Settings.CultureName)
+            {
+                NeedsRestart = true;
+                Program.Settings.CultureName = cultureName;
+            }
+            NeedsRestart |= Plugins != null && !string.IsNullOrEmpty(Program.Settings.PluginsStates) && Plugins.CommandStates != Program.Settings.PluginsStates;
+            FormUtility.RetrieveOptionsFromPanel(pageBehavior, Program.Settings);
+            Program.Settings.MouseWheelSpeed = (float)tbMouseWheel.Value / 10f;
+            Program.Settings.LibraryGaugesFormat = LibraryGauges.None.SetMask(LibraryGauges.Unread, chkLibraryGaugesUnread.Checked).SetMask(LibraryGauges.New, chkLibraryGaugesNew.Checked).SetMask(LibraryGauges.Total, chkLibraryGaugesTotal.Checked)
+                .SetMask(LibraryGauges.Numeric, chkLibraryGaugesNumeric.Checked);
+            Program.Settings.DisplayLibraryGauges = chkLibraryGauges.Checked;
+            Program.Settings.PageImageDisplayOptions = Program.Settings.PageImageDisplayOptions.SetMask(ImageDisplayOptions.AnamorphicScaling, chkAnamorphicScaling.Checked);
+            Program.Settings.PageImageDisplayOptions = Program.Settings.PageImageDisplayOptions.SetMask(ImageDisplayOptions.HighQuality, chkHighQualityDisplay.Checked);
+            Program.Settings.InternetCacheEnabled = chkEnableInternetCache.Checked;
+            Program.Settings.InternetCacheSizeMB = (int)numInternetCacheSize.Value;
+            Program.Settings.ThumbCacheEnabled = chkEnableThumbnailCache.Checked;
+            Program.Settings.ThumbCacheSizeMB = (int)numThumbnailCacheSize.Value;
+            Program.Settings.PageCacheEnabled = chkEnablePageCache.Checked;
+            Program.Settings.PageCacheSizeMB = (int)numPageCacheSize.Value;
+            Program.Settings.MaximumMemoryMB = tbMaximumMemoryUsage.Value * MaximumMemoryStepSize;
+            Program.Settings.MemoryPageCacheOptimized = chkMemPageOptimized.Checked;
+            Program.Settings.MemoryPageCacheCount = (int)numMemPageCount.Value;
+            Program.Settings.MemoryThumbCacheOptimized = chkMemThumbOptimized.Checked;
+            Program.Settings.MemoryThumbCacheSizeMB = (int)numMemThumbSize.Value;
+            BitmapAdjustmentOptions options = (chkAutoContrast.Checked ? BitmapAdjustmentOptions.AutoContrast : BitmapAdjustmentOptions.None);
+            Program.Settings.GlobalColorAdjustment = new BitmapAdjustment((float)tbSaturation.Value / 100f, (float)tbBrightness.Value / 100f, (float)tbContrast.Value / 100f, (float)tbGamma.Value / 100f, options, tbSharpening.Value);
+            Program.Settings.ShowCurrentPageOverlay = chkShowCurrentPageOverlay.Checked;
+            Program.Settings.ShowVisiblePagePartOverlay = chkShowVisiblePartOverlay.Checked;
+            Program.Settings.ShowStatusOverlay = chkShowStatusOverlay.Checked;
+            Program.Settings.ShowNavigationOverlay = chkShowNavigationOverlay.Checked;
+            Program.Settings.NavigationOverlayOnTop = cbNavigationOverlayPosition.SelectedIndex == 1;
+            Program.Settings.CurrentPageShowsName = chkShowPageNames.Checked;
+            Program.Settings.HardwareAcceleration = chkEnableHardware.Checked;
+            Program.Settings.SmoothScrolling = chkSmoothAutoScrolling.Checked;
+            Program.Settings.DisplayChangeAnimation = chkEnableDisplayChangeAnimation.Checked;
+            Program.Settings.SoftwareFiltering = chkEnableSoftwareFiltering.Checked;
+            Program.Settings.HardwareFiltering = chkEnableHardwareFiltering.Checked;
+            Program.Settings.FlowingMouseScrolling = chkEnableInertialMouseScrolling.Checked;
+            Program.Settings.OverlayScaling = tbOverlayScaling.Value;
+            Program.Settings.RemoveMissingFilesOnFullScan = chkAutoRemoveMissing.Checked;
+            Program.Settings.DontAddRemoveFiles = chkDontAddRemovedFiles.Checked;
+            if (!Program.Settings.DontAddRemoveFiles)
+            {
+                Program.Database.ClearBlackList();
+            }
+            Program.Settings.OverwriteAssociations = chkOverwriteAssociations.Checked;
+            Program.Settings.LookForShared = chkLookForShared.Checked;
+            Program.Settings.AutoConnectShares = chkAutoConnectShares.Checked;
+            CopyWatchFoldersToDatabase();
+            RegisterFileTypes();
+            Program.Settings.UpdateComicFiles = chkUpdateComicFiles.Checked;
+            Program.Settings.AutoUpdateComicsFiles = chkAutoUpdateComicFiles.Checked;
+            Program.Settings.IgnoredCoverImages = (string.IsNullOrEmpty(txCoverFilter.Text) ? null : txCoverFilter.Text);
+            Program.Settings.ScriptingLibraries = txLibraries.Text;
+            Program.Settings.Scripting = !chkDisableScripting.Checked;
+            Program.Settings.HideSampleScripts = chkHideSampleScripts.Checked;
+            if (!string.IsNullOrEmpty(BackupFile))
+            {
+                try
+                {
+                    try
+                    {
+                        AutomaticProgressDialog.Process(this, TR.Messages["DatabaseRestore", "Database Restore"], TR.Messages["DatabaseRestoreText", "Restoring database from Backup file"], 1000, delegate
+                        {
+                            Program.DatabaseManager.RestoreFrom(BackupFile, Program.Paths.CustomThumbnailPath);
+                        }, AutomaticProgressDialogOptions.None);
+                    }
+                    catch (Exception)
+                    {
+                        MessageBox.Show(this, TR.Messages["DatabaseRestoreError", "There was an error restoring the Database Backup"], TR.Messages["Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                    }
+                    BackupFile = null;
+                    NeedsRestart = true;
+                }
+                catch
+                {
+                }
+            }
+            List<ComicLibraryServerConfig> list = (from p in tabShares.TabPages.OfType<Control>()
+                                                   select p.Controls[0] as ServerEditControl into se
+                                                   select se.Config).ToList();
+            if (!list.SequenceEqual(Program.Settings.Shares, new ComicLibraryServerConfig.EqualityComparer()))
+            {
+                NeedsRestart = true;
+                Program.Settings.Shares.Clear();
+                Program.Settings.Shares.AddRange(list);
+            }
+            string text = txPublicServerAddress.Text.Trim();
+            if (text != Program.Settings.ExternalServerAddress)
+            {
+                NeedsRestart = true;
+                Program.Settings.ExternalServerAddress = text;
+            }
+            if (txPrivateListingPassword.Password != Program.Settings.PrivateListingPassword)
+            {
+                NeedsRestart = true;
+                Program.Settings.PrivateListingPassword = txPrivateListingPassword.Password;
+            }
+            Program.Settings.ExtraWifiDeviceAddresses = txWifiAddresses.Text;
+            SaveVirtualTags();
+            Program.RefreshAllWindows();
+            Program.ForAllForms(delegate (Form f)
+            {
+                f.FindServices<ISettingsChanged>().ForEach(delegate (ISettingsChanged s)
+                {
+                    s.SettingsChanged();
+                });
+            });
+        }
+
+        private void SetScanButtonText()
+        {
+            btScan.Text = (Program.Scanner.IsScanning ? LocalizeUtility.GetText(this, "Stop", "Stop") : LocalizeUtility.GetText(this, "Scan", "Scan"));
+        }
+
+        private void SetSettings()
+        {
+            FormUtility.FillPanelWithOptions(pageBehavior, Program.Settings, TR.Load("Settings"));
+            chkLibraryGauges.Checked = Program.Settings.DisplayLibraryGauges;
+            chkLibraryGaugesUnread.Checked = Program.Settings.LibraryGaugesFormat.IsSet(LibraryGauges.Unread);
+            chkLibraryGaugesNew.Checked = Program.Settings.LibraryGaugesFormat.IsSet(LibraryGauges.New);
+            chkLibraryGaugesTotal.Checked = Program.Settings.LibraryGaugesFormat.IsSet(LibraryGauges.Total);
+            chkLibraryGaugesNumeric.Checked = Program.Settings.LibraryGaugesFormat.IsSet(LibraryGauges.Numeric);
+            tbMouseWheel.Value = (int)(Program.Settings.MouseWheelSpeed * 10f);
+            chkHighQualityDisplay.Checked = Program.Settings.PageImageDisplayOptions.IsSet(ImageDisplayOptions.HighQuality);
+            chkAnamorphicScaling.Checked = Program.Settings.PageImageDisplayOptions.IsSet(ImageDisplayOptions.AnamorphicScaling);
+            chkAutoRemoveMissing.Checked = Program.Settings.RemoveMissingFilesOnFullScan;
+            chkDontAddRemovedFiles.Checked = Program.Settings.DontAddRemoveFiles;
+            tbSaturation.Value = (int)(Program.Settings.GlobalColorAdjustment.Saturation * 100f);
+            tbBrightness.Value = (int)(Program.Settings.GlobalColorAdjustment.Brightness * 100f);
+            tbContrast.Value = (int)(Program.Settings.GlobalColorAdjustment.Contrast * 100f);
+            tbGamma.Value = (int)(Program.Settings.GlobalColorAdjustment.Gamma * 100f);
+            tbSharpening.Value = Program.Settings.GlobalColorAdjustment.Sharpen;
+            chkAutoContrast.Checked = Program.Settings.GlobalColorAdjustment.Options.IsSet(BitmapAdjustmentOptions.AutoContrast);
+            chkShowCurrentPageOverlay.Checked = Program.Settings.ShowCurrentPageOverlay;
+            chkShowVisiblePartOverlay.Checked = Program.Settings.ShowVisiblePagePartOverlay;
+            chkShowStatusOverlay.Checked = Program.Settings.ShowStatusOverlay;
+            chkShowNavigationOverlay.Checked = Program.Settings.ShowNavigationOverlay;
+            cbNavigationOverlayPosition.SelectedIndex = (Program.Settings.NavigationOverlayOnTop ? 1 : 0);
+            chkShowPageNames.Checked = Program.Settings.CurrentPageShowsName;
+            chkEnableHardware.Checked = Program.Settings.HardwareAcceleration;
+            chkSmoothAutoScrolling.Checked = Program.Settings.SmoothScrolling;
+            chkEnableDisplayChangeAnimation.Checked = Program.Settings.DisplayChangeAnimation;
+            chkEnableSoftwareFiltering.Checked = Program.Settings.SoftwareFiltering;
+            chkEnableHardwareFiltering.Checked = Program.Settings.HardwareFiltering;
+            chkEnableInertialMouseScrolling.Checked = Program.Settings.FlowingMouseScrolling;
+            chkEnableInternetCache.Checked = Program.Settings.InternetCacheEnabled;
+            numInternetCacheSize.Value = numInternetCacheSize.Clamp(Program.Settings.InternetCacheSizeMB);
+            chkEnableThumbnailCache.Checked = Program.Settings.ThumbCacheEnabled;
+            numThumbnailCacheSize.Value = numThumbnailCacheSize.Clamp(Program.Settings.ThumbCacheSizeMB);
+            chkEnablePageCache.Checked = Program.Settings.PageCacheEnabled;
+            numPageCacheSize.Value = numPageCacheSize.Clamp(Program.Settings.PageCacheSizeMB);
+            chkMemPageOptimized.Checked = Program.Settings.MemoryPageCacheOptimized;
+            numMemPageCount.Value = numMemPageCount.Clamp(Program.Settings.MemoryPageCacheCount);
+            chkMemThumbOptimized.Checked = Program.Settings.MemoryThumbCacheOptimized;
+            numMemThumbSize.Value = numMemThumbSize.Clamp(Program.Settings.MemoryThumbCacheSizeMB);
+            tbMaximumMemoryUsage.SetRange(2, MaximumMemoryStepSize);
+            tbMaximumMemoryUsage.Value = Program.Settings.MaximumMemoryMB / MaximumMemoryStepSize;
+            tbOverlayScaling.Value = Program.Settings.OverlayScaling;
+            chkOverwriteAssociations.Checked = Program.Settings.OverwriteAssociations;
+            chkUpdateComicFiles.Checked = Program.Settings.UpdateComicFiles;
+            chkAutoUpdateComicFiles.Checked = Program.Settings.AutoUpdateComicsFiles;
+            txCoverFilter.Text = Program.Settings.IgnoredCoverImages;
+            txLibraries.Text = Program.Settings.ScriptingLibraries;
+            chkDisableScripting.Checked = !Program.Settings.Scripting;
+            chkHideSampleScripts.Checked = Program.Settings.HideSampleScripts;
+            lbLanguages.SelectedIndex = 0;
+            foreach (TRInfo item in lbLanguages.Items)
+            {
+                if (item.CultureName == Program.Settings.CultureName)
+                {
+                    lbLanguages.SelectedItem = item;
+                    break;
+                }
+            }
+            txPublicServerAddress.Text = Program.Settings.ExternalServerAddress;
+            txPrivateListingPassword.Password = Program.Settings.PrivateListingPassword;
+            chkLookForShared.Checked = Program.Settings.LookForShared;
+            chkAutoConnectShares.Checked = Program.Settings.AutoConnectShares;
+            foreach (ComicLibraryServerConfig share in Program.Settings.Shares)
+            {
+                AddSharePage(share);
+            }
+            txWifiAddresses.Text = Program.Settings.ExtraWifiDeviceAddresses;
+            AddVirtualTags();
+        }
+
+        private void AddSharePage(ComicLibraryServerConfig cfg)
+        {
+            TabPage tab = new TabPage(cfg.Name)
+            {
+                UseVisualStyleBackColor = true
+            };
+            ServerEditControl sc = new ServerEditControl
+            {
+                Dock = DockStyle.Fill,
+                Config = cfg,
+                BackColor = Color.Transparent
+            };
+            sc.ShareNameChanged += delegate
+            {
+                tab.Text = sc.ShareName;
+            };
+            tab.Controls.Add(sc);
+            tabShares.TabPages.Add(tab);
+        }
+
+        private void RemoveSharePage(TabPage tab)
+        {
+            Control control = tab.Controls[0];
+            tab.Controls.Remove(control);
+            control.Dispose();
+            tabShares.TabPages.Remove(tab);
+            tab.Dispose();
+        }
+
+        private void CopyWatchFoldersToDatabase()
+        {
+            Program.Database.WatchFolders.Clear();
+            for (int i = 0; i < lbPaths.Items.Count; i++)
+            {
+                Program.Database.WatchFolders.Add(new WatchFolder(lbPaths.Items[i].ToString(), lbPaths.GetItemChecked(i)));
+            }
+        }
+
+        private void RegisterFileTypes()
+        {
+            for (int i = 0; i < lbFormats.Items.Count; i++)
+            {
+                FileFormat fileFormat = (FileFormat)lbFormats.Items[i];
+                if (lbFormats.GetItemChecked(i))
+                {
+                    fileFormat.RegisterShell(Program.ComicRackTypeId, Program.ComicRackDocumentName, Program.Settings.OverwriteAssociations);
+                }
+                else
+                {
+                    fileFormat.UnregisterShell(Program.ComicRackTypeId);
+                }
+            }
+        }
+
+        private void SetTab(CheckBox cb)
+        {
+            if (blockSetTab)
+            {
+                return;
+            }
+            blockSetTab = true;
+            try
+            {
+                foreach (CheckBox tabButton in tabButtons)
+                {
+                    tabButton.Checked = tabButton == cb;
+                    Control control = tabButton.Tag as Control;
+                    if (control.Tag is Control)
+                    {
+                        control = control.Tag as Control;
+                    }
+                    control.Visible = tabButton.Checked;
+                }
+            }
+            finally
+            {
+                blockSetTab = false;
+            }
+        }
+
+        private void UpdateDiskCacheStatus(object sender, EventArgs e)
+        {
+            if (!this.BeginInvokeIfRequired(delegate
+            {
+                UpdateDiskCacheStatus(sender, e);
+            }))
+            {
+                lblInternetCacheUsage.Text = string.Format("({0}/{1})", Program.InternetCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
+                {
+                    Program.InternetCache.Size
+                }));
+                lblPageCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Pages.DiskCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
+                {
+                    Program.ImagePool.Pages.DiskCache.Size
+                }));
+                lblThumbCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Thumbs.DiskCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
+                {
+                    Program.ImagePool.Thumbs.DiskCache.Size
+                }));
+            }
+        }
+
+        private void UpdateMemoryCacheStatus()
+        {
+            if (!this.BeginInvokeIfRequired(UpdateMemoryCacheStatus))
+            {
+                lblPageMemCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Pages.MemoryCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
+                {
+                    Program.ImagePool.Pages.MemoryCache.Size
+                }));
+                lblThumbMemCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Thumbs.MemoryCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
+                {
+                    Program.ImagePool.Thumbs.MemoryCache.Size
+                }));
+            }
+        }
+
+        private void RefreshPackageList()
+        {
+            lvPackages.Items.Clear();
+            foreach (PackageManager.Package item in (from p in Program.ScriptPackages.GetPackages()
+                                                     orderby p.PackageType
+                                                     select p).Reverse())
+            {
+                ListViewItem listViewItem = lvPackages.Items.Add(item.Name, item.Name, 0);
+                if (item.Image != null)
+                {
+                    packageImageList.Images.Add(item.Image);
+                    listViewItem.ImageIndex = packageImageList.Images.Count - 1;
+                }
+                listViewItem.Tag = item;
+                if (!string.IsNullOrEmpty(item.Version))
+                {
+                    listViewItem.Text = listViewItem.Text + " V" + item.Version;
+                }
+                listViewItem.SubItems.Add(item.Author);
+                listViewItem.SubItems.Add(item.Description);
+                switch (item.PackageType)
+                {
+                    default:
+                        listViewItem.Group = lvPackages.Groups["packageGroupInstalled"];
+                        break;
+                    case PackageManager.PackageType.PendingInstall:
+                        listViewItem.Group = lvPackages.Groups["packageGroupInstall"];
+                        break;
+                    case PackageManager.PackageType.PendingRemove:
+                        listViewItem.Group = lvPackages.Groups["packageGroupRemove"];
+                        break;
+                }
+            }
+        }
+
+        private void btAssociateExtensions_Click(object sender, EventArgs e)
+        {
+            string str = "-rf \"" + (chkOverwriteAssociations.Checked ? "!" : string.Empty);
+            for (int i = 0; i < lbFormats.Items.Count; i++)
+            {
+                FileFormat fileFormat = (FileFormat)lbFormats.Items[i];
+                if (i != 0)
+                {
+                    str += ",";
+                }
+                if (!lbFormats.GetItemChecked(i))
+                {
+                    str += "-";
+                }
+                str += fileFormat.Name;
+            }
+            str += "\"";
+            if (ProcessRunner.RunElevated(Application.ExecutablePath, str) == 0)
+            {
+                FillExtensionsList();
+            }
+        }
+
+        private void btAddShare_Click(object sender, EventArgs e)
+        {
+            ComicLibraryServerConfig comicLibraryServerConfig = new ComicLibraryServerConfig();
+            comicLibraryServerConfig.Name = $"{Environment.UserName}'s Library";
+            if (tabShares.TabCount > 1)
+            {
+                comicLibraryServerConfig.Name += $" ({tabShares.TabCount + 1})";
+            }
+            AddSharePage(comicLibraryServerConfig);
+            tabShares.SelectedIndex = tabShares.TabPages.Count - 1;
+        }
+
+        private void btRmoveShare_Click(object sender, EventArgs e)
+        {
+            TabPage selectedTab = tabShares.SelectedTab;
+            if (selectedTab != null)
+            {
+                RemoveSharePage(selectedTab);
+            }
+        }
+
+        public static bool Show(IWin32Window parent, KeyboardShortcuts commands, PluginEngine pe, string autoInstallPlugin = null)
+        {
+            using (PreferencesDialog preferencesDialog = new PreferencesDialog())
+            {
+                preferencesDialog.keyboardShortcutEditor.Shortcuts = commands;
+                preferencesDialog.Plugins = pe;
+                preferencesDialog.AutoInstallPlugin = (File.Exists(autoInstallPlugin) ? autoInstallPlugin : null);
+                bool flag = preferencesDialog.ShowDialog(parent) == DialogResult.OK;
+                if (flag)
+                {
+                    preferencesDialog.Apply();
+                    if (preferencesDialog.NeedsRestart && QuestionDialog.Ask(parent, TR.Messages["RestartQuestion", "ComicRack needs to restart to complete the operation! Do you want to restart now?"], TR.Default["Restart", "Restart"]))
+                    {
+                        Program.MainForm.MenuRestart();
+                    }
+                }
+                else
+                {
+                    Program.ScriptPackages.RemovePending();
+                }
+                return flag;
+            }
+        }
+
+        #region Virtual Tags
+        private void AddVirtualTags()
+        {
+            var VirtualTags = new List<VirtualTag>();
+
+            for (int id = 1; id <= 10; id++)
+            {
+                VirtualTag vtag = Program.Settings.VirtualTags.ElementAtOrDefault(i);
+
+                //If the data doesn't already exists, create a default tag for the settings
+                if (vtag is null || vtag.ID != id)
+                {
+                    string name = $"Virtual Tag #{id:00}";
+                    vtag = new VirtualTag(id, name, name, string.Empty, isDefault: true);
+                }
+
+                VirtualTags.Add(vtag);
+            }
+
+            SetVirtualTagsComboBoxDataSource(VirtualTags);
+            CreateValueContextMenu();
+        }
+
+        private void SetVirtualTagsComboBoxDataSource(List<VirtualTag> VirtualTags)
+        {
+            cbVirtualTags.DataSource = VirtualTags;
+            cbVirtualTags.DisplayMember = "DisplayMember";
+        }
+
+        private void CreateValueContextMenu()
+        {
+            components = new Container();
+            ContextMenuBuilder contextMenuBuilder = new ContextMenuBuilder();
+            foreach (string item in ComicBookMatcher.ComicProperties)
+            {
+                contextMenuBuilder.Add(item, topLevel: false, chk: false, SetCaptionField, item, DateTime.MinValue);
+            }
+            ContextMenuStrip cm = new ContextMenuStrip(components);
+            cm.Items.AddRange(contextMenuBuilder.Create(20));
+            btInsertValue.Click += (sender, e) => cm.Show(btInsertValue, 0, btInsertValue.Height);
+        }
+
+        private void SetCaptionField(object sender, EventArgs e)
+        {
+            //Change the button Text & Tag so that when we click Add the Value will be inserted
+            ToolStripMenuItem toolStripMenuItem = sender as ToolStripMenuItem;
+            btInsertValue.Text = (string)toolStripMenuItem.Tag;
+            btInsertValue.Tag = (string)toolStripMenuItem.Tag;
+        }
+
+        private void cbVirtualTags_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (cbVirtualTags.SelectedIndex == -1)
+                return;
+
+            VirtualTag vtag = cbVirtualTags.SelectedItem as VirtualTag;
+            if (vtag is null)
+                return;
+
+            //Fill UI with object from Combo Box
+            txtVirtualTagName.Text = vtag.Name;
+            txtVirtualTagDescription.Text = vtag.Description;
+            rtfVirtualTagCaption.Text = vtag.CaptionFormat;
+            chkVirtualTagEnable.Checked = vtag.IsEnabled;
+            ResetVirtualTagsCaptionControls();
+        }
+
+        private void btnCaptionInsert_Click(object sender, EventArgs e)
+        {
+            if (cbVirtualTags.SelectedIndex == -1)
+                return;
+
+            VirtualTag vtag = cbVirtualTags.SelectedItem as VirtualTag;
+            string caption = btInsertValue.Text;
+
+            //We can't add the current VTAG inside it's own VTAG
+            if (vtag?.PropertyName == caption)
+                return;
+
+            //Number Formatting
+            if (!string.IsNullOrEmpty(txtCaptionFormat.Text))
+                caption = $"{caption}:{txtCaptionFormat.Text}";
+
+            string text = $"[{txtCaptionPrefix.Text}{{{caption}}}{txtCaptionSuffix.Text}]";
+
+            if (!string.IsNullOrEmpty(text) && btInsertValue.Tag != null)
+            {
+                //Insert text into box
+                int cursorPosition = rtfVirtualTagCaption.SelectionStart;
+                rtfVirtualTagCaption.Text = rtfVirtualTagCaption.Text.Insert(cursorPosition, text);
+                rtfVirtualTagCaption.SelectionStart = rtfVirtualTagCaption.TextLength;
+
+                ResetVirtualTagsCaptionControls();
+            }
+        }
+
+        private void ResetVirtualTagsCaptionControls()
+        {
+            //Reset Insert Value button, Prefix & Suffix Textbox
+            btInsertValue.Text = "Choose Value";
+            btInsertValue.Tag = null;
+            txtCaptionPrefix.Text = string.Empty;
+            txtCaptionSuffix.Text = string.Empty;
+            txtCaptionFormat.Text = string.Empty;
+        }
+
+        private void VirtualTag_Validated(object sender, EventArgs e)
+        {
+            VirtualTagUpdate();
+        }
+
+        private void VirtualTagUpdate()
+        {
+            if (cbVirtualTags.SelectedIndex == -1)
+                return;
+
+            VirtualTag vtag = cbVirtualTags.SelectedItem as VirtualTag;
+
+            //Don't save if the Caption contains the current vtag own field
+            if (rtfVirtualTagCaption.Text.Contains($"{{{vtag?.PropertyName}"))
+                return;
+
+            //Update the virtualtags object for the setting
+            vtag.Name = txtVirtualTagName.Text;
+            vtag.Description = txtVirtualTagDescription.Text;
+            vtag.IsEnabled = chkVirtualTagEnable.Checked;
+            vtag.CaptionFormat = rtfVirtualTagCaption.Text;
+
+            //If the caption or the name aren't empty, change the IsDefault so it gets saved.
+            if (!string.IsNullOrEmpty(vtag.CaptionFormat) && !string.IsNullOrEmpty(vtag.Name))
+                vtag.IsDefault = false;
+        }
+
+        private void UpdateVirtualTagsComboBox(object sender, EventArgs e)
+        {
+            VirtualTagUpdate();
+
+            //Reset the DataSource, so the name in the dropdown updates
+            List<VirtualTag> vtags = cbVirtualTags.DataSource as List<VirtualTag>;
+            cbVirtualTags.DataSource = null;
+            SetVirtualTagsComboBoxDataSource(vtags);
+        }
+
+        private void SaveVirtualTags()
+        {
+            Program.Settings.VirtualTags.Clear();
+            VirtualTagUpdate();
+            foreach (VirtualTag item in cbVirtualTags.Items)
+            {
+                if (!item.IsDefault && !string.IsNullOrEmpty(item.CaptionFormat) && !string.IsNullOrEmpty(item.Name))
+                    Program.Settings.VirtualTags.Add(item);
+            }
+        }
+        #endregion
+    }
 }

--- a/ComicRack/Dialogs/PreferencesDialog.resx
+++ b/ComicRack/Dialogs/PreferencesDialog.resx
@@ -126,6 +126,18 @@
   <metadata name="cmKeyboardLayout.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>213, 17</value>
   </metadata>
+  <data name="txtCaptionFormat.ToolTip" xml:space="preserve">
+    <value>Use the number formatting from the "Custom numeric format strings"
+documentation from Microsoft .NET.
+
+You just need to leave out the 0:, this willl be added automatically.
+So for example if you want to pad a number to 3 char (aka: 001)
+
+Entering 000 in the Format box will give you 001, 002, etc.
+
+https://learn.microsoft.com/en-us/dotnet/standard/base-types
+/custom-numeric-format-strings</value>
+  </data>
   <metadata name="memCacheUpate.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>370, 17</value>
   </metadata>

--- a/ComicRack/Views/ComicBrowserControl.cs
+++ b/ComicRack/Views/ComicBrowserControl.cs
@@ -1509,7 +1509,7 @@ namespace cYo.Projects.ComicRack.Viewer.Views
             {
                 int id = 300 + vtag.ID;
 
-                if (vtag.IsEnabled)
+                if (vtag != null && vtag.IsEnabled)
                 {
                     dictionary[id] = new ItemViewColumn(id, vtag.Name, 100,
                                             new ComicListField(vtag.PropertyName, vtag.Description),

--- a/ComicRack/Views/ComicBrowserControl.cs
+++ b/ComicRack/Views/ComicBrowserControl.cs
@@ -567,7 +567,6 @@ namespace cYo.Projects.ComicRack.Viewer.Views
                         SetCustomColumns();
                     };
                     SetCustomColumns();
-                    SetVirtualTagColumns();
                 }
             }
         }
@@ -783,6 +782,7 @@ namespace cYo.Projects.ComicRack.Viewer.Views
             itemView.Columns.Add(new ItemViewColumn(211, "Series: Book added", 50, new ComicListField("SeriesStatLastAddedTime", "Last time a book was added to the Series", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemStatsComparer<ComicBookSeriesStatsLastAddedTimeComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupLastAddedTime>(), visible: false, StringAlignment.Far, strings));
             itemView.Columns.Add(new ItemViewColumn(212, "Series: Opened", 50, new ComicListField("SeriesStatLastOpenedTime", "Last time a book was opened from the Series", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemStatsComparer<ComicBookSeriesStatsLastOpenedTimeComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupLastOpenedTime>(), visible: false, StringAlignment.Far, strings));
             itemView.Columns.Add(new ItemViewColumn(213, "Series: Book released", 50, new ComicListField("SeriesStatLastReleasedTime", "Last time a book of this Series was released", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemStatsComparer<ComicBookSeriesStatsLastReleasedTimeComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupLastReleasedTime>(), visible: false, StringAlignment.Far, strings));
+            SetVirtualTagColumns();
             SubView.TranslateColumns(itemView.Columns);
             foreach (ItemViewColumn column in itemView.Columns)
             {

--- a/ComicRack/Views/ComicBrowserControl.cs
+++ b/ComicRack/Views/ComicBrowserControl.cs
@@ -33,2624 +33,2670 @@ using cYo.Projects.ComicRack.Viewer.Properties;
 
 namespace cYo.Projects.ComicRack.Viewer.Views
 {
-	public partial class ComicBrowserControl : SubView, IComicBrowser, IGetBookList, IRefreshDisplay, ISearchOptions, IDisplayWorkspace, IItemSize, ISettingsChanged
-	{
-		private class StackMatcher : ComicBookMatcher
-		{
-			private readonly HashSet<ComicBook> items;
+    public partial class ComicBrowserControl : SubView, IComicBrowser, IGetBookList, IRefreshDisplay, ISearchOptions, IDisplayWorkspace, IItemSize, ISettingsChanged
+    {
+        private class StackMatcher : ComicBookMatcher
+        {
+            private readonly HashSet<ComicBook> items;
 
-			public string Caption
-			{
-				get;
-				private set;
-			}
+            public string Caption
+            {
+                get;
+                private set;
+            }
 
-			public IGrouper<IViewableItem> Grouper
-			{
-				get;
-				private set;
-			}
+            public IGrouper<IViewableItem> Grouper
+            {
+                get;
+                private set;
+            }
 
-			public StackMatcher(IGrouper<IViewableItem> grouper, string caption, HashSet<ComicBook> items)
-			{
-				this.items = items;
-				Grouper = grouper;
-				Caption = caption;
-			}
+            public StackMatcher(IGrouper<IViewableItem> grouper, string caption, HashSet<ComicBook> items)
+            {
+                this.items = items;
+                Grouper = grouper;
+                Caption = caption;
+            }
 
-			public bool Match(ComicBook item)
-			{
-				return items.Contains(item);
-			}
+            public bool Match(ComicBook item)
+            {
+                return items.Contains(item);
+            }
 
-			public override IEnumerable<ComicBook> Match(IEnumerable<ComicBook> items)
-			{
-				return items.Where(Match);
-			}
+            public override IEnumerable<ComicBook> Match(IEnumerable<ComicBook> items)
+            {
+                return items.Where(Match);
+            }
 
-			public override object Clone()
-			{
-				return new StackMatcher(Grouper, Caption, items);
-			}
-		}
+            public override object Clone()
+            {
+                return new StackMatcher(Grouper, Caption, items);
+            }
+        }
 
-		private class CoverViewItemPropertyComparer : CoverViewItemComparer
-		{
-			private readonly string property;
+        private class CoverViewItemPropertyComparer : CoverViewItemComparer
+        {
+            private readonly string property;
 
-			public CoverViewItemPropertyComparer(string property)
-			{
-				this.property = property;
-			}
+            public CoverViewItemPropertyComparer(string property)
+            {
+                this.property = property;
+            }
 
-			protected override int OnCompare(CoverViewItem x, CoverViewItem y)
-			{
-				return ExtendedStringComparer.Compare(x.Comic.GetStringPropertyValue(property), y.Comic.GetStringPropertyValue(property));
-			}
-		}
+            protected override int OnCompare(CoverViewItem x, CoverViewItem y)
+            {
+                return ExtendedStringComparer.Compare(x.Comic.GetStringPropertyValue(property), y.Comic.GetStringPropertyValue(property));
+            }
+        }
 
-		private class CoverViewItemPropertyGrouper : IGrouper<IViewableItem>
-		{
-			private readonly string property;
+        private class CoverViewItemPropertyGrouper : IGrouper<IViewableItem>
+        {
+            private readonly string property;
 
-			public bool IsMultiGroup => false;
+            public bool IsMultiGroup => false;
 
-			public CoverViewItemPropertyGrouper(string property)
-			{
-				this.property = property;
-			}
+            public CoverViewItemPropertyGrouper(string property)
+            {
+                this.property = property;
+            }
 
-			public IEnumerable<IGroupInfo> GetGroups(IViewableItem item)
-			{
-				throw new NotImplementedException();
-			}
+            public IEnumerable<IGroupInfo> GetGroups(IViewableItem item)
+            {
+                throw new NotImplementedException();
+            }
 
-			public IGroupInfo GetGroup(IViewableItem item)
-			{
-				CoverViewItem coverViewItem = (CoverViewItem)item;
-				return SingleComicGrouper.GetNameGroup(coverViewItem.Comic.GetStringPropertyValue(property));
-			}
-		}
+            public IGroupInfo GetGroup(IViewableItem item)
+            {
+                CoverViewItem coverViewItem = (CoverViewItem)item;
+                return SingleComicGrouper.GetNameGroup(coverViewItem.Comic.GetStringPropertyValue(property));
+            }
+        }
 
-		private readonly string noneText;
+        private readonly string noneText;
 
-		private readonly string arrangedByText;
+        private readonly string arrangedByText;
 
-		private readonly string notArrangedText;
+        private readonly string notArrangedText;
 
-		private readonly string groupedByText;
+        private readonly string groupedByText;
 
-		private readonly string notGroupedText;
+        private readonly string notGroupedText;
 
-		private readonly string stackedByText;
+        private readonly string stackedByText;
 
-		private readonly string notStackedText;
+        private readonly string notStackedText;
 
-		private readonly string eComicText;
+        private readonly string eComicText;
 
-		private readonly string eComicsText;
+        private readonly string eComicsText;
 
-		private readonly string selectedText;
+        private readonly string selectedText;
 
-		private readonly string filteredText;
+        private readonly string filteredText;
 
-		private readonly string customFieldDescription;
+        private readonly string customFieldDescription;
 
-		private volatile bool bookListDirty;
+        private volatile bool bookListDirty;
 
-		private volatile bool updateGroupList;
+        private volatile bool updateGroupList;
 
-		private volatile int newGroupListWidth;
+        private volatile int newGroupListWidth;
 
-		private volatile int totalCount;
+        private volatile int totalCount;
 
-		private long totalSize;
+        private long totalSize;
 
-		private long selectedSize;
+        private long selectedSize;
 
-		private readonly CommandMapper commands = new CommandMapper();
+        private readonly CommandMapper commands = new CommandMapper();
 
-		private readonly Image groupUp = Resources.GroupUp;
+        private readonly Image groupUp = Resources.GroupUp;
 
-		private readonly Image groupDown = Resources.GroupDown;
+        private readonly Image groupDown = Resources.GroupDown;
 
-		private readonly Image sortUp = Resources.SortUp;
+        private readonly Image sortUp = Resources.SortUp;
 
-		private readonly Image sortDown = Resources.SortDown;
+        private readonly Image sortDown = Resources.SortDown;
 
-		private ToolStripMenuItem miCopyListSetup;
+        private ToolStripMenuItem miCopyListSetup;
 
-		private ToolStripMenuItem miPasteListSetup;
+        private ToolStripMenuItem miPasteListSetup;
 
-		private ComicBookMatcher quickFilter;
+        private ComicBookMatcher quickFilter;
 
-		private ComicBookMatcher stackFilter;
+        private ComicBookMatcher stackFilter;
 
-		private IViewableItem stackItem;
+        private IViewableItem stackItem;
 
-		private StacksConfig stacksConfig;
+        private StacksConfig stacksConfig;
 
-		private ItemViewConfig preStackConfig;
+        private ItemViewConfig preStackConfig;
 
-		private Point preStackScrollPosition;
+        private Point preStackScrollPosition;
 
-		private Guid preStackFocusedId;
+        private Guid preStackFocusedId;
 
-		private string currentStackName;
+        private string currentStackName;
 
-		private IComicBookListProvider bookList;
+        private IComicBookListProvider bookList;
 
-		private string quickSearch;
+        private string quickSearch;
 
-		private ComicBookAllPropertiesMatcher.MatcherOption quickSearchType;
+        private ComicBookAllPropertiesMatcher.MatcherOption quickSearchType;
 
-		private ComicBookAllPropertiesMatcher.ShowOptionType showOptionType;
+        private ComicBookAllPropertiesMatcher.ShowOptionType showOptionType;
 
-		private ComicBookAllPropertiesMatcher.ShowComicType showComicType;
+        private ComicBookAllPropertiesMatcher.ShowComicType showComicType;
 
-		private bool showOnlyDuplicates;
+        private bool showOnlyDuplicates;
 
-		private bool showGroupHeaders;
+        private bool showGroupHeaders;
 
-		private ComicsEditModes comicEditMode = ComicsEditModes.Default;
+        private ComicsEditModes comicEditMode = ComicsEditModes.Default;
 
-		private ThumbnailConfig thumbnailConfig;
+        private ThumbnailConfig thumbnailConfig;
 
-		private Image listBackgroundImage;
+        private Image listBackgroundImage;
 
-		private IGrouper<IViewableItem> oldStacker;
+        private IGrouper<IViewableItem> oldStacker;
 
-		private string[] quickSearchCueTexts;
+        private string[] quickSearchCueTexts;
 
-		private Point contextMenuMouseLocation;
+        private Point contextMenuMouseLocation;
 
-		private long contextMenuCloseTime;
+        private long contextMenuCloseTime;
 
-		private int oldQuickWidth;
+        private int oldQuickWidth;
 
-		private int savedOptimizeToolstripRight;
+        private int savedOptimizeToolstripRight;
 
-		private int savedOptimizeToolstripWitdh;
+        private int savedOptimizeToolstripWitdh;
 
-		private string backgroundImageSource;
+        private string backgroundImageSource;
 
-		private IBitmapCursor dragCursor;
+        private IBitmapCursor dragCursor;
 
-		private bool ownDrop;
+        private bool ownDrop;
 
-		private DragDropContainer dragBookContainer;
+        private DragDropContainer dragBookContainer;
 
-		private readonly ManualResetEvent abortBuildMenu = new ManualResetEvent(initialState: false);
+        private readonly ManualResetEvent abortBuildMenu = new ManualResetEvent(initialState: false);
 
-		private Thread buildMenuThread;
+        private Thread buildMenuThread;
 
-		private bool blockQuickSearchUpdate;
+        private bool blockQuickSearchUpdate;
 
-		private CoverViewItem toolTipItem;
+        private CoverViewItem toolTipItem;
 
-		private bool searchBrowserVisible;
+        private bool searchBrowserVisible;
 
-		private ComicLibrary library;
+        private ComicLibrary library;
 
 
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public IComicBookListProvider BookList
-		{
-			get
-			{
-				return bookList;
-			}
-			set
-			{
-				if (bookList == value)
-				{
-					return;
-				}
-				try
-				{
-					itemView.BeginUpdate();
-					UnregisterBookList();
-					bookList = value;
-					RegisterBookList();
-					OnCurrentBookListChanged();
-					if (base.Main != null)
-					{
-						UpdatePending();
-					}
-				}
-				finally
-				{
-					itemView.EndUpdate();
-					if (bookList != null)
-					{
-						IDisplayListConfig displayListConfig = bookList.QueryService<IDisplayListConfig>();
-						if (displayListConfig != null && displayListConfig.Display != null)
-						{
-							itemView.ScrollPosition = displayListConfig.Display.ScrollPosition;
-							SetFocusedItem(displayListConfig.Display.FocusedComicId);
-							Guid id = displayListConfig.Display.StackedComicId;
-							if (id != Guid.Empty)
-							{
-								CoverViewItem coverViewItem = itemView.Items.OfType<CoverViewItem>().FirstOrDefault((CoverViewItem i) => i.Comic.Id == id);
-								if (coverViewItem != null)
-								{
-									itemView.Select(coverViewItem);
-									OpenStack(coverViewItem);
-									itemView.ScrollPosition = displayListConfig.Display.StackScrollPosition;
-									itemView.SelectAll(selectionState: false);
-									SetFocusedItem(displayListConfig.Display.StackFocusedComicId);
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public ItemViewConfig ViewConfig
-		{
-			get
-			{
-				return itemView.ViewConfig;
-			}
-			set
-			{
-				itemView.ViewConfig = value;
-			}
-		}
-
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public ItemViewMode ItemViewMode
-		{
-			get
-			{
-				return itemView.ItemViewMode;
-			}
-			set
-			{
-				itemView.ItemViewMode = value;
-			}
-		}
-
-		[DefaultValue(null)]
-		public string QuickSearch
-		{
-			get
-			{
-				return quickSearch;
-			}
-			set
-			{
-				if (!(quickSearch == value))
-				{
-					quickSearch = value;
-					OnQuickSearchChanged();
-				}
-			}
-		}
-
-		public ItemView ItemView => itemView;
-
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public ComicBookAllPropertiesMatcher.MatcherOption QuickSearchType
-		{
-			get
-			{
-				return quickSearchType;
-			}
-			set
-			{
-				if (quickSearchType != value)
-				{
-					quickSearchType = value;
-					UpdateSearch();
-				}
-			}
-		}
-
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public ComicBookAllPropertiesMatcher.ShowOptionType ShowOptionType
-		{
-			get
-			{
-				return showOptionType;
-			}
-			set
-			{
-				if (showOptionType != value)
-				{
-					showOptionType = value;
-					UpdateSearch();
-				}
-			}
-		}
-
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public ComicBookAllPropertiesMatcher.ShowComicType ShowComicType
-		{
-			get
-			{
-				return showComicType;
-			}
-			set
-			{
-				if (showComicType != value)
-				{
-					showComicType = value;
-					UpdateSearch();
-				}
-			}
-		}
-
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		[DefaultValue(false)]
-		public bool ShowOnlyDuplicates
-		{
-			get
-			{
-				return showOnlyDuplicates;
-			}
-			set
-			{
-				if (showOnlyDuplicates != value)
-				{
-					showOnlyDuplicates = value;
-					UpdateSearch();
-				}
-			}
-		}
-
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		[DefaultValue(false)]
-		public bool ShowGroupHeaders
-		{
-			get
-			{
-				return showGroupHeaders;
-			}
-			set
-			{
-				if (showGroupHeaders != value)
-				{
-					showGroupHeaders = value;
-					updateGroupList = true;
-				}
-			}
-		}
-
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public ComicsEditModes ComicEditMode
-		{
-			get
-			{
-				return comicEditMode;
-			}
-			set
-			{
-				if (comicEditMode != value)
-				{
-					comicEditMode = value;
-					OnComicEditModeChanged();
-				}
-			}
-		}
-
-		[DefaultValue(false)]
-		public bool DisableViewConfigUpdate
-		{
-			get;
-			set;
-		}
-
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		[Browsable(false)]
-		public int SearchBrowserColumn1
-		{
-			get
-			{
-				return bookSelectorPanel.Column1;
-			}
-			set
-			{
-				bookSelectorPanel.Column1 = value;
-			}
-		}
-
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		[Browsable(false)]
-		public int SearchBrowserColumn2
-		{
-			get
-			{
-				return bookSelectorPanel.Column2;
-			}
-			set
-			{
-				bookSelectorPanel.Column2 = value;
-			}
-		}
-
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		[Browsable(false)]
-		public int SearchBrowserColumn3
-		{
-			get
-			{
-				return bookSelectorPanel.Column3;
-			}
-			set
-			{
-				bookSelectorPanel.Column3 = value;
-			}
-		}
-
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public ThumbnailConfig ThumbnailConfig
-		{
-			get
-			{
-				return thumbnailConfig;
-			}
-			set
-			{
-				if (value != null)
-				{
-					thumbnailConfig = value;
-				}
-			}
-		}
-
-		[DefaultValue(null)]
-		public Image ListBackgroundImage
-		{
-			get
-			{
-				return listBackgroundImage;
-			}
-			set
-			{
-				listBackgroundImage = value;
-				if (itemView.BackgroundImage == null)
-				{
-					SetListBackgroundImage();
-				}
-			}
-		}
-
-		[DefaultValue(false)]
-		public bool HideNavigation
-		{
-			get;
-			set;
-		}
-
-		[DefaultValue(false)]
-		public bool SearchBrowserVisible
-		{
-			get
-			{
-				return searchBrowserVisible;
-			}
-			set
-			{
-				if (searchBrowserVisible != value)
-				{
-					searchBrowserVisible = value;
-					OnSearchBrowserVisibleChanged();
-				}
-			}
-		}
-
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public ComicLibrary Library
-		{
-			get
-			{
-				return library;
-			}
-			set
-			{
-				if (library != value)
-				{
-					library = value;
-					library.CustomValuesChanged += delegate
-					{
-						SetCustomColumns();
-					};
-					SetCustomColumns();
-				}
-			}
-		}
-
-		public string SelectionInfo
-		{
-			get
-			{
-				StringBuilder stringBuilder = new StringBuilder();
-				int count = itemView.Items.Count;
-				int selectedCount = itemView.SelectedCount;
-				IComicBookListProvider comicBookListProvider = BookList;
-				if (comicBookListProvider != null && !string.IsNullOrEmpty(comicBookListProvider.Name))
-				{
-					stringBuilder.AppendFormat(comicBookListProvider.Name);
-					stringBuilder.AppendFormat(": ");
-				}
-				stringBuilder.AppendFormat((count == 1) ? eComicText : eComicsText, count);
-				if (totalCount != count)
-				{
-					stringBuilder.Append(" (");
-					try
-					{
-						stringBuilder.AppendFormat(filteredText, totalCount - count);
-					}
-					catch
-					{
-					}
-					stringBuilder.Append(")");
-				}
-				if (totalSize != 0L)
-				{
-					stringBuilder.Append(" / ");
-					stringBuilder.AppendFormat(string.Format(new FileLengthFormat(), "{0}", new object[1]
-					{
-						totalSize
-					}));
-				}
-				if (selectedCount != 0)
-				{
-					stringBuilder.Append(" - ");
-					bool flag = true;
-					if (selectedCount == 1)
-					{
-						ComicBook comicBook = GetBookList(ComicBookFilterType.IsLocal | ComicBookFilterType.IsNotFileless | ComicBookFilterType.Selected).FirstOrDefault();
-						if (comicBook != null)
-						{
-							stringBuilder.Append(comicBook.FilePath);
-							flag = false;
-						}
-					}
-					if (flag)
-					{
-						stringBuilder.AppendFormat(selectedText, selectedCount);
-					}
-				}
-				if (selectedSize != 0L)
-				{
-					stringBuilder.Append(" / ");
-					stringBuilder.AppendFormat(string.Format(new FileLengthFormat(), "{0}", new object[1]
-					{
-						selectedSize
-					}));
-				}
-				return stringBuilder.ToString();
-			}
-		}
-
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public DisplayListConfig ListConfig
-		{
-			get
-			{
-				return new DisplayListConfig
-				{
-					View = ViewConfig,
-					Thumbnail = new ThumbnailConfig(ThumbnailConfig)
-				};
-			}
-			set
-			{
-				ViewConfig = value.View;
-				ThumbnailConfig = new ThumbnailConfig(value.Thumbnail);
-				FillBookList();
-			}
-		}
-
-		public ToolStripItemCollection ListConfigMenu => tsListLayouts.DropDownItems;
-
-		public event EventHandler CurrentBookListChanged;
-
-		public event EventHandler SearchBrowserVisibleChanged;
-
-		public event EventHandler QuickSearchChanged;
-
-		public ComicBrowserControl()
-		{
-			InitializeComponent();
-			searchBrowserContainer.Collapsed = true;
-			itemView.ScrollResizeRefresh = Program.ExtendedSettings.OptimizedListScrolling;
-			toolTip.OwnerDraw = true;
-			toolTip.Draw += toolTip_Draw;
-			ListStyles.SetOwnerDrawn(lvGroupHeaders);
-			KeySearch.Create(lvGroupHeaders);
-			browserContainer.Panel2Collapsed = true;
-			LocalizeUtility.Localize(this, components);
-			noneText = TR.Load(base.Name)["None", "None"];
-			arrangedByText = TR.Load(base.Name)["ArrangedBy", "Arranged by {0}"];
-			notArrangedText = TR.Load(base.Name)["NotArranged", "Not sorted"];
-			groupedByText = TR.Load(base.Name)["GroupedBy", "Grouped by {0}"];
-			notGroupedText = TR.Load(base.Name)["NotGrouped", "Not grouped"];
-			stackedByText = TR.Load(base.Name)["StackedBy", "Stacked by {0}"];
-			notStackedText = TR.Load(base.Name)["NotStacked", "Not stacked"];
-			eComicText = TR.Load(base.Name)["ComicSingle", "{0} Book"];
-			eComicsText = TR.Load(base.Name)["ComicMulti", "{0} Books"];
-			selectedText = TR.Load(base.Name)["ComicSelected", "{0} selected"];
-			filteredText = TR.Load(base.Name)["ComicFiltered", "{0} filtered"];
-			customFieldDescription = TR.Load(base.Name)["CustomFieldDescription", "Shows the value of the custom field '{0}'"];
-			contextRating.Renderer = new MenuRenderer(Resources.StarYellow);
-			contextRating.Items.Insert(contextRating.Items.Count - 2, new ToolStripSeparator());
-			RatingControl.InsertRatingControl(contextRating, contextRating.Items.Count - 2, Resources.StarYellow, () => base.Main.GetRatingEditor());
-			FormUtility.EnableRightClickSplitButtons(toolStrip.Items);
-			string[] strings = TR.Load("Columns").GetStrings("DateFormats", "Long|Short|Relative", '|');
-			itemView.Columns.Add(new ItemViewColumn(101, "State", 60, new ComicListField("State", "State indicators for the Book"), new CoverViewItemBookComparer<ComicBookStatusComparer>()));
-			itemView.Columns.Add(new ItemViewColumn(100, "Position", 30, new ComicListField("Position", "Position of the Book in the list"), new CoverViewItemPositionComparer(), null, visible: true, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(102, "Checked", 22, new ComicListField("Checked", "Book is checked"), new CoverViewItemBookComparer<ComicBookCheckedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupChecked>()));
-			itemView.Columns.Add(new ItemViewColumn(0, "Cover", 40, new ComicListField("Cover", "Cover image of the Book"), null, null, visible: true, StringAlignment.Center)
-			{
-				Name = "Cover"
-			});
-			itemView.Columns.Add(new ItemViewColumn(1, "Series", 200, new ComicListField("Series", "Series name", "Series"), new CoverViewItemBookComparer<ComicBookSeriesComparer>(), new CoverViewItemBookGrouper<ComicBookGroupSeries>()));
-			itemView.Columns.Add(new ItemViewColumn(2, "Number", 40, new ComicListField("NumberAsText", "Number of the Book in the Series", "Number"), new CoverViewItemBookComparer<ComicBookNumberComparer>(), new CoverViewItemBookGrouper<ComicBookGroupNumber>(), visible: true, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(3, "Volume", 40, new ComicListField("VolumeAsText", "Volume number of the Series", "Volume"), new CoverViewItemBookComparer<ComicBookVolumeComparer>(), new CoverViewItemBookGrouper<ComicBookGroupVolume>()));
-			itemView.Columns.Add(new ItemViewColumn(4, "Title", 200, new ComicListField("Title", "Title of the Book", "Title"), new CoverViewItemBookComparer<ComicBookTitleComparer>(), new CoverViewItemBookGrouper<ComicBookGroupTitle>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(5, "Opened", 40, new ComicListField("OpenedTime", "Last time the Book was opened", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemBookComparer<ComicBookOpenedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupOpened>(), visible: true, StringAlignment.Far, strings));
-			itemView.Columns.Add(new ItemViewColumn(6, "Added", 40, new ComicListField("AddedTime", "Time the Book was added to the Database", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemBookComparer<ComicBookAddedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupAdded>(), visible: true, StringAlignment.Far, strings));
-			itemView.Columns.Add(new ItemViewColumn(7, "Pages", 40, new ComicListField("PagesAsTextSimple", "The total count of pages"), new CoverViewItemBookComparer<ComicBookPageCountComparer>(), new CoverViewItemBookGrouper<ComicBookGroupPages>(), visible: true, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(39, "Published", 40, new ComicListField("PublishedAsText", "Publication date of the Book"), new CoverViewItemBookComparer<ComicBookPublishedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupPublished>(), visible: true, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(9, "File Path", 200, new ComicListField("FilePath", "Location where the Book is stored", null, StringTrimming.EllipsisPath), new CoverViewItemBookComparer<ComicBookFileComparer>(), null, visible: false));
-			itemView.Columns.Add(new ItemViewColumn(10, "File Name", 200, new ComicListField("FileName", "Filename without the extension", "FileName"), new CoverViewItemBookComparer<ComicBookFileNameComparer>(), new CoverViewItemBookGrouper<ComicBookGroupFileName>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(11, "Writer", 80, new ComicListField("Writer", "Writer of the Book", "Writer"), new CoverViewItemBookComparer<ComicBookWriterComparer>(), new CoverViewItemBookGrouper<ComicBookGroupWriter>()));
-			itemView.Columns.Add(new ItemViewColumn(12, "Penciller", 80, new ComicListField("Penciller", "Penciller of the Book", "Penciller"), new CoverViewItemBookComparer<ComicBookPencillerComparer>(), new CoverViewItemBookGrouper<ComicBookGroupPenciller>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(13, "Inker", 80, new ComicListField("Inker", "Inker of the Book", "Inker"), new CoverViewItemBookComparer<ComicBookInkerComparer>(), new CoverViewItemBookGrouper<ComicBookGroupInker>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(14, "Colorist", 80, new ComicListField("Colorist", "Colorist of the Book", "Colorist"), new CoverViewItemBookComparer<ComicBookColoristComparer>(), new CoverViewItemBookGrouper<ComicBookGroupColorist>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(15, "My Rating", 50, new ComicListField("Rating", "Your rating of the Book"), new CoverViewItemRatingComparer(), new CoverViewItemBookGrouper<ComicBookGroupRating>()));
-			itemView.Columns.Add(new ItemViewColumn(16, "Opened Count", 40, new ComicListField("OpenedCountAsText", "Times the Book has been opened"), new CoverViewItemBookComparer<ComicBookOpenCountComparer>(), new CoverViewItemBookGrouper<ComicBookGroupOpenCount>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(17, "Read Percentage", 40, new ComicListField("ReadPercentageAsText", "How much has been read"), new CoverViewItemReadPercentageComparer(), new CoverViewItemBookGrouper<ComicBookGroupReadPercentage>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(18, "File Modified", 40, new ComicListField("FileModifiedTime", "Time the Book was modified the last time", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemBookComparer<ComicBookModifiedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupModified>(), visible: false, StringAlignment.Far, strings));
-			itemView.Columns.Add(new ItemViewColumn(19, "Genre", 40, new ComicListField("Genre", "Genre of the Book", "Genre"), new CoverViewItemBookComparer<ComicBookGenreComparer>(), new CoverViewItemBookGrouper<ComicBookGroupGenre>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(20, "Publisher", 40, new ComicListField("Publisher", "Publisher of the Book", "Publisher"), new CoverViewItemBookComparer<ComicBookPublisherComparer>(), new CoverViewItemBookGrouper<ComicBookGroupPublisher>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(21, "Count", 40, new ComicListField("CountAsText", "Total number of issues in this series", "Count"), new CoverViewItemBookComparer<ComicBookCountComparer>(), new CoverViewItemBookGrouper<ComicBookGroupCount>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(22, "Letterer", 80, new ComicListField("Letterer", "Letterer of the Book", "Letterer"), new CoverViewItemBookComparer<ComicBookLettererComparer>(), new CoverViewItemBookGrouper<ComicBookGroupLetterer>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(23, "Cover Artist", 80, new ComicListField("CoverArtist", "The artist responsible for the cover", "CoverArtist"), new CoverViewItemBookComparer<ComicBookCoverArtistComparer>(), new CoverViewItemBookGrouper<ComicBookGroupCoverArtist>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(24, "Editor", 80, new ComicListField("Editor", "Editor of the Book", "Editor"), new CoverViewItemBookComparer<ComicBookEditorComparer>(), new CoverViewItemBookGrouper<ComicBookGroupEditor>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(25, "File Size", 40, new ComicListField("FileSizeAsText", "Size of the Book file in bytes"), new CoverViewItemBookComparer<ComicBookSizeComparer>(), new CoverViewItemBookGrouper<ComicBookGroupSize>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(26, "Alternate Series", 200, new ComicListField("AlternateSeries", "Crossover/story name", "AlternateSeries"), new CoverViewItemBookComparer<ComicBookAlternateSeriesComparer>(), new CoverViewItemBookGrouper<ComicBookGroupAlternateSeries>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(27, "Alternate Number", 40, new ComicListField("AlternateNumberAsText", "Issue number in the crossover/story", "AlternateNumber"), new CoverViewItemBookComparer<ComicBookAlternateNumberComparer>(), new CoverViewItemBookGrouper<ComicBookGroupAlternateNumber>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(28, "Alternate Count", 40, new ComicListField("AlternateCountAsText", "Total issues of the crossover/story", "AlternateCount"), new CoverViewItemBookComparer<ComicBookAlternateCountComparer>(), new CoverViewItemBookGrouper<ComicBookGroupAlternateCount>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(29, "Month", 40, new ComicListField("MonthAsText", "Month the Book was published", "Month"), new CoverViewItemBookComparer<ComicBookMonthComparer>(), new CoverViewItemBookGrouper<ComicBookGroupMonth>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(30, "Caption", 200, new ComicListField("Caption", "Complete caption of the Book", "Series"), new CoverViewItemBookComparer<ComicBookSeriesComparer>(), new CoverViewItemBookGrouper<ComicBookGroupSeries>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(31, "Tags", 60, new ComicListField("Tags", "Tags of the Book", "Tags"), new CoverViewItemBookComparer<ComicBookTagsComparer>(), null, visible: false));
-			itemView.Columns.Add(new ItemViewColumn(32, "Imprint", 40, new ComicListField("Imprint", "Imprint of the Book", "Imprint"), new CoverViewItemBookComparer<ComicBookImprintComparer>(), new CoverViewItemBookGrouper<ComicBookGroupImprint>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(33, "Language", 40, new ComicListField("LanguageAsText", "Language of the Book"), new CoverViewItemBookComparer<ComicBookLanguageComparer>(), new CoverViewItemBookGrouper<ComicBookGroupLanguage>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(34, "Format", 40, new ComicListField("Format", "Format of the Book", "Format"), new CoverViewItemBookComparer<ComicBookFormatComparer>(), new CoverViewItemBookGrouper<ComicBookGroupFormat>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(35, "B&W", 22, new ComicListField("BlackAndWhiteAsText", "Yes if the Book is black and white"), new CoverViewItemBookComparer<ComicBookBlackAndWhiteComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBlackAndWhite>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(36, "Manga", 22, new ComicListField("MangaAsText", "Yes if the Book is a Manga"), new CoverViewItemBookComparer<ComicBookMangaComparer>(), new CoverViewItemBookGrouper<ComicBookGroupManga>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(37, "File Format", 40, new ComicListField("FileFormat", "File format of the Book"), new CoverViewItemBookComparer<ComicBookFileFormatComparer>(), new CoverViewItemBookGrouper<ComicBookGroupFileFormat>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(38, "Age Rating", 40, new ComicListField("AgeRating", "Age rating of the Book"), new CoverViewItemBookComparer<ComicBookAgeRatingComparer>(), new CoverViewItemBookGrouper<ComicBookGroupAgeRating>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(8, "Year", 60, new ComicListField("YearAsText", "Year the Book was published", "Year"), new CoverViewItemBookComparer<ComicBookYearComparer>(), new CoverViewItemBookGrouper<ComicBookGroupYear>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(40, "Characters", 60, new ComicListField("Characters", "Plot characters of the Books", "Characters"), new CoverViewItemBookComparer<ComicBookCharactersComparer>(), new CoverViewItemBookGrouper<ComicBookGroupCharacters>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(41, "File Directory", 60, new ComicListField("FileDirectory", "Directory of the Book"), new CoverViewItemBookComparer<ComicBookDirectoryComparer>(), new CoverViewItemBookGrouper<ComicBookGroupDirectory>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(42, "File Created", 60, new ComicListField("FileCreationTime", "Time the Book has been created", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemBookComparer<ComicBookCreationComparer>(), new CoverViewItemBookGrouper<ComicBookGroupCreation>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(43, "Bookmark Count", 60, new ComicListField("BookmarkCountAsText", "Count of Bookmarks for this Book"), new CoverViewItemBookComparer<ComicBookBookmarkCountComparer>(), null, visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(44, "New Pages", 60, new ComicListField("NewPagesAsText", "Count of new Pages"), new CoverViewItemBookComparer<ComicBookNewPagesComparer>(), null, visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(45, "Teams", 60, new ComicListField("Teams", "Plot teams of the Books", "Teams"), new CoverViewItemBookComparer<ComicBookTeamsComparer>(), new CoverViewItemBookGrouper<ComicBookGroupTeams>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(46, "Locations", 60, new ComicListField("Locations", "Plot locations of the Books", "Locations"), new CoverViewItemBookComparer<ComicBookLocationsComparer>(), new CoverViewItemBookGrouper<ComicBookGroupLocations>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(47, "Web", 60, new ComicListField("Web", "A Web Link", "Web"), new CoverViewItemBookComparer<ComicBookWebComparer>(), new CoverViewItemBookGrouper<ComicBookGroupWeb>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(48, "Community Rating", 50, new ComicListField("CommunityRating", "Rating of the Book"), new CoverViewItemCommunityRatingComparer(), new CoverViewItemBookGrouper<ComicBookGroupCommunityRating>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(49, "Linked", 50, new ComicListField("IsLinkedAsText", "Book is linked to a file"), new CoverViewItemBookComparer<ComicBookLinkedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupLinked>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(50, "Book Price", 50, new ComicListField("BookPriceAsText", "Price of the Book", "BookPriceAsText"), new CoverViewItemBookComparer<ComicBookBookPriceComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBookPrice>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(51, "Book Age", 50, new ComicListField("BookAge", "Age of the Book", "BookAge"), new CoverViewItemBookComparer<ComicBookBookAgeComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBookAge>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(52, "Book Store", 50, new ComicListField("BookStore", "Store the Book was bought", "BookStore"), new CoverViewItemBookComparer<ComicBookBookStoreComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBookStore>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(53, "Book Owner", 50, new ComicListField("BookOwner", "Owner of the Book", "BookOwner"), new CoverViewItemBookComparer<ComicBookBookOwnerComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBookOwner>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(54, "Book Condition", 50, new ComicListField("BookCondition", "Condition of the Book", "BookCondition"), new CoverViewItemBookComparer<ComicBookBookConditionComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBookCondition>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(55, "Book Collection Status", 50, new ComicListField("BookCollectionStatus", "Status of the Book in the Collection", "BookCollectionStatus"), new CoverViewItemBookComparer<ComicBookBookCollectionStatusComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBookCollectionStatus>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(56, "Book Location", 50, new ComicListField("BookLocation", "Location of the Book", "BookLocation"), new CoverViewItemBookComparer<ComicBookBookLocationComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBookLocation>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(57, "ISBN", 50, new ComicListField("ISBN", "ISBN Number", "ISBN"), new CoverViewItemBookComparer<ComicBookISBNComparer>(), null, visible: false));
-			itemView.Columns.Add(new ItemViewColumn(58, "Series complete", 22, new ComicListField("SeriesCompleteAsText", "Series is complete"), new CoverViewItemBookComparer<ComicBookSeriesCompleteComparer>(), new CoverViewItemBookGrouper<ComicBookGroupSeriesComplete>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(59, "Proposed Values", 22, new ComicListField("EnableProposedAsText", "Uses proposed Values from Filename"), new CoverViewItemBookComparer<ComicBookSeriesEnableProposedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupEnableProposed>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(60, "Gap Information", 16, new ComicListField("GapInformation", "Information if this issue is the end or start of a gap in the series"), new CoverViewItemBookComparer<ComicBookSeriesComparer>(), null, visible: false));
-			itemView.Columns.Add(new ItemViewColumn(61, "Read", 22, new ComicListField("HasBeenReadAsText", "Book has been read"), new CoverViewItemBookComparer<ComicBookHasBeenReadComparer>(), new CoverViewItemBookGrouper<ComicBookGroupHasBeenRead>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(62, "Icons", 100, new ComicListField("Icons", "Icons for this Book"), null, null, visible: false));
-			itemView.Columns.Add(new ItemViewColumn(63, "Scan Information", 100, new ComicListField("ScanInformation", "Information about the Scan", "ScanInformation"), new CoverViewItemBookComparer<ComicBookScanInformationComparer>(), new CoverViewItemBookGrouper<ComicBookGroupScanInformation>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(64, "Story Arc", 100, new ComicListField("StoryArc", "Story Arc the book is part of", "StoryArc"), new CoverViewItemBookComparer<ComicBookStoryArcComparer>(), new CoverViewItemBookGrouper<ComicBookGroupStoryArc>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(65, "Series Group", 100, new ComicListField("SeriesGroup", "Series Group the Book is part of", "SeriesGroup"), new CoverViewItemBookComparer<ComicBookSeriesGroupComparer>(), new CoverViewItemBookGrouper<ComicBookGroupSeriesGroup>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(66, "Main Character/Team", 100, new ComicListField("MainCharacterOrTeam", "Main Character or Team of the Book", "MainCharacterOrTeam"), new CoverViewItemBookComparer<ComicBookMainCharacterOrTeamComparer>(), new CoverViewItemBookGrouper<ComicBookGroupMainCharacterOrTeam>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(67, "Review", 100, new ComicListField("Review", "A short Review of the Book"), new CoverViewItemBookComparer<ComicBookReviewComparer>(), null, visible: false));
-			itemView.Columns.Add(new ItemViewColumn(68, "Day", 40, new ComicListField("DayAsText", "Day the Book was published", "Day"), new CoverViewItemBookComparer<ComicBookDayComparer>(), new CoverViewItemBookGrouper<ComicBookGroupDay>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(69, "Week", 40, new ComicListField("WeekAsText", "Week the Book was published"), new CoverViewItemBookComparer<ComicBookWeekComparer>(), new CoverViewItemBookGrouper<ComicBookGroupWeek>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(70, "Released", 60, new ComicListField("ReleasedTime", "Time the Book was released", null, StringTrimming.Word, typeof(DateTime), ComicBook.TR["Unknown"]), new CoverViewItemBookComparer<ComicBookReleasedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupReleased>(), visible: false, StringAlignment.Far, strings));
-			itemView.Columns.Add(new ItemViewColumn(200, "Series: Books", 50, new ComicListField("SeriesStatCountAsText", "Books in the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsCountComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupCount>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(201, "Series: Pages", 50, new ComicListField("SeriesStatPageCountAsText", "Pages in the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsPageCountComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupPageCount>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(202, "Series: Pages Read", 50, new ComicListField("SeriesStatPageReadCountAsText", "Pages of the Series read"), new CoverViewItemStatsComparer<ComicBookSeriesStatsPageReadCountComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupPageReadCount>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(203, "Series: Percent Read", 50, new ComicListField("SeriesStatReadPercentageAsText", "Percentage of the Series read"), new CoverViewItemStatsComparer<ComicBookSeriesStatsReadPercentageComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupReadPercentage>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(204, "Series: First Number", 50, new ComicListField("SeriesStatMinNumberAsText", "First Number of the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsMinNumberComparer>(), null, visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(205, "Series: Last Number", 50, new ComicListField("SeriesStatMaxNumberAsText", "Last Number of the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsMaxNumberComparer>(), null, visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(206, "Series: First Year", 50, new ComicListField("SeriesStatMinYearAsText", "First Year of the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsMinYearComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupMinYear>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(207, "Series: Last Year", 50, new ComicListField("SeriesStatMaxYearAsText", "Last Year of the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsMaxYearComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupMaxYear>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(208, "Series: Average Rating", 50, new ComicListField("SeriesStatAverageRating", "Average Rating of the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsAverageRatingComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupAverageRating>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(209, "Series: Average Community Rating", 50, new ComicListField("SeriesStatAverageCommunityRating", "Average Community Rating of the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsAverageCommunityRatingComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupAverageCommunityRating>(), visible: false));
-			itemView.Columns.Add(new ItemViewColumn(210, "Series: Gaps", 50, new ComicListField("SeriesStatGapCountAsText", "Count of Gaps in the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsGapCountComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupGapCount>(), visible: false, StringAlignment.Far));
-			itemView.Columns.Add(new ItemViewColumn(211, "Series: Book added", 50, new ComicListField("SeriesStatLastAddedTime", "Last time a book was added to the Series", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemStatsComparer<ComicBookSeriesStatsLastAddedTimeComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupLastAddedTime>(), visible: false, StringAlignment.Far, strings));
-			itemView.Columns.Add(new ItemViewColumn(212, "Series: Opened", 50, new ComicListField("SeriesStatLastOpenedTime", "Last time a book was opened from the Series", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemStatsComparer<ComicBookSeriesStatsLastOpenedTimeComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupLastOpenedTime>(), visible: false, StringAlignment.Far, strings));
-			itemView.Columns.Add(new ItemViewColumn(213, "Series: Book released", 50, new ComicListField("SeriesStatLastReleasedTime", "Last time a book of this Series was released", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemStatsComparer<ComicBookSeriesStatsLastReleasedTimeComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupLastReleasedTime>(), visible: false, StringAlignment.Far, strings));
-			SubView.TranslateColumns(itemView.Columns);
-			foreach (ItemViewColumn column in itemView.Columns)
-			{
-				column.TooltipText = ((ComicListField)column.Tag).Description;
-				column.Width = FormUtility.ScaleDpiX(column.Width);
-			}
-			ThumbnailConfig = new ThumbnailConfig();
-			ThumbnailConfig.CaptionIds.Add(30);
-			tsQuickSearch.TextBox.SearchButtonImage = Resources.Search.ScaleDpi();
-			tsQuickSearch.TextBox.ClearButtonImage = Resources.SmallCloseGray.ScaleDpi();
-			itemView.Font = SystemFonts.IconTitleFont;
-			itemView.ItemContextMenuStrip = contextMenuItems;
-			itemView.ItemRowHeight = itemView.Font.Height + FormUtility.ScaleDpiY(6);
-			itemView.ColumnHeaderHeight = itemView.ItemRowHeight;
-			itemView.Items.Changed += ComicItemAdded;
-			itemView.MouseWheel += itemView_MouseWheel;
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public IComicBookListProvider BookList
+        {
+            get
+            {
+                return bookList;
+            }
+            set
+            {
+                if (bookList == value)
+                {
+                    return;
+                }
+                try
+                {
+                    itemView.BeginUpdate();
+                    UnregisterBookList();
+                    bookList = value;
+                    RegisterBookList();
+                    OnCurrentBookListChanged();
+                    if (base.Main != null)
+                    {
+                        UpdatePending();
+                    }
+                }
+                finally
+                {
+                    itemView.EndUpdate();
+                    if (bookList != null)
+                    {
+                        IDisplayListConfig displayListConfig = bookList.QueryService<IDisplayListConfig>();
+                        if (displayListConfig != null && displayListConfig.Display != null)
+                        {
+                            itemView.ScrollPosition = displayListConfig.Display.ScrollPosition;
+                            SetFocusedItem(displayListConfig.Display.FocusedComicId);
+                            Guid id = displayListConfig.Display.StackedComicId;
+                            if (id != Guid.Empty)
+                            {
+                                CoverViewItem coverViewItem = itemView.Items.OfType<CoverViewItem>().FirstOrDefault((CoverViewItem i) => i.Comic.Id == id);
+                                if (coverViewItem != null)
+                                {
+                                    itemView.Select(coverViewItem);
+                                    OpenStack(coverViewItem);
+                                    itemView.ScrollPosition = displayListConfig.Display.StackScrollPosition;
+                                    itemView.SelectAll(selectionState: false);
+                                    SetFocusedItem(displayListConfig.Display.StackFocusedComicId);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public ItemViewConfig ViewConfig
+        {
+            get
+            {
+                return itemView.ViewConfig;
+            }
+            set
+            {
+                itemView.ViewConfig = value;
+            }
+        }
+
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public ItemViewMode ItemViewMode
+        {
+            get
+            {
+                return itemView.ItemViewMode;
+            }
+            set
+            {
+                itemView.ItemViewMode = value;
+            }
+        }
+
+        [DefaultValue(null)]
+        public string QuickSearch
+        {
+            get
+            {
+                return quickSearch;
+            }
+            set
+            {
+                if (!(quickSearch == value))
+                {
+                    quickSearch = value;
+                    OnQuickSearchChanged();
+                }
+            }
+        }
+
+        public ItemView ItemView => itemView;
+
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public ComicBookAllPropertiesMatcher.MatcherOption QuickSearchType
+        {
+            get
+            {
+                return quickSearchType;
+            }
+            set
+            {
+                if (quickSearchType != value)
+                {
+                    quickSearchType = value;
+                    UpdateSearch();
+                }
+            }
+        }
+
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public ComicBookAllPropertiesMatcher.ShowOptionType ShowOptionType
+        {
+            get
+            {
+                return showOptionType;
+            }
+            set
+            {
+                if (showOptionType != value)
+                {
+                    showOptionType = value;
+                    UpdateSearch();
+                }
+            }
+        }
+
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public ComicBookAllPropertiesMatcher.ShowComicType ShowComicType
+        {
+            get
+            {
+                return showComicType;
+            }
+            set
+            {
+                if (showComicType != value)
+                {
+                    showComicType = value;
+                    UpdateSearch();
+                }
+            }
+        }
+
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [DefaultValue(false)]
+        public bool ShowOnlyDuplicates
+        {
+            get
+            {
+                return showOnlyDuplicates;
+            }
+            set
+            {
+                if (showOnlyDuplicates != value)
+                {
+                    showOnlyDuplicates = value;
+                    UpdateSearch();
+                }
+            }
+        }
+
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [DefaultValue(false)]
+        public bool ShowGroupHeaders
+        {
+            get
+            {
+                return showGroupHeaders;
+            }
+            set
+            {
+                if (showGroupHeaders != value)
+                {
+                    showGroupHeaders = value;
+                    updateGroupList = true;
+                }
+            }
+        }
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public ComicsEditModes ComicEditMode
+        {
+            get
+            {
+                return comicEditMode;
+            }
+            set
+            {
+                if (comicEditMode != value)
+                {
+                    comicEditMode = value;
+                    OnComicEditModeChanged();
+                }
+            }
+        }
+
+        [DefaultValue(false)]
+        public bool DisableViewConfigUpdate
+        {
+            get;
+            set;
+        }
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
+        public int SearchBrowserColumn1
+        {
+            get
+            {
+                return bookSelectorPanel.Column1;
+            }
+            set
+            {
+                bookSelectorPanel.Column1 = value;
+            }
+        }
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
+        public int SearchBrowserColumn2
+        {
+            get
+            {
+                return bookSelectorPanel.Column2;
+            }
+            set
+            {
+                bookSelectorPanel.Column2 = value;
+            }
+        }
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
+        public int SearchBrowserColumn3
+        {
+            get
+            {
+                return bookSelectorPanel.Column3;
+            }
+            set
+            {
+                bookSelectorPanel.Column3 = value;
+            }
+        }
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public ThumbnailConfig ThumbnailConfig
+        {
+            get
+            {
+                return thumbnailConfig;
+            }
+            set
+            {
+                if (value != null)
+                {
+                    thumbnailConfig = value;
+                }
+            }
+        }
+
+        [DefaultValue(null)]
+        public Image ListBackgroundImage
+        {
+            get
+            {
+                return listBackgroundImage;
+            }
+            set
+            {
+                listBackgroundImage = value;
+                if (itemView.BackgroundImage == null)
+                {
+                    SetListBackgroundImage();
+                }
+            }
+        }
+
+        [DefaultValue(false)]
+        public bool HideNavigation
+        {
+            get;
+            set;
+        }
+
+        [DefaultValue(false)]
+        public bool SearchBrowserVisible
+        {
+            get
+            {
+                return searchBrowserVisible;
+            }
+            set
+            {
+                if (searchBrowserVisible != value)
+                {
+                    searchBrowserVisible = value;
+                    OnSearchBrowserVisibleChanged();
+                }
+            }
+        }
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public ComicLibrary Library
+        {
+            get
+            {
+                return library;
+            }
+            set
+            {
+                if (library != value)
+                {
+                    library = value;
+                    library.CustomValuesChanged += delegate
+                    {
+                        SetCustomColumns();
+                    };
+                    SetCustomColumns();
+                    SetVirtualTagColumns();
+                }
+            }
+        }
+
+        public string SelectionInfo
+        {
+            get
+            {
+                StringBuilder stringBuilder = new StringBuilder();
+                int count = itemView.Items.Count;
+                int selectedCount = itemView.SelectedCount;
+                IComicBookListProvider comicBookListProvider = BookList;
+                if (comicBookListProvider != null && !string.IsNullOrEmpty(comicBookListProvider.Name))
+                {
+                    stringBuilder.AppendFormat(comicBookListProvider.Name);
+                    stringBuilder.AppendFormat(": ");
+                }
+                stringBuilder.AppendFormat((count == 1) ? eComicText : eComicsText, count);
+                if (totalCount != count)
+                {
+                    stringBuilder.Append(" (");
+                    try
+                    {
+                        stringBuilder.AppendFormat(filteredText, totalCount - count);
+                    }
+                    catch
+                    {
+                    }
+                    stringBuilder.Append(")");
+                }
+                if (totalSize != 0L)
+                {
+                    stringBuilder.Append(" / ");
+                    stringBuilder.AppendFormat(string.Format(new FileLengthFormat(), "{0}", new object[1]
+                    {
+                        totalSize
+                    }));
+                }
+                if (selectedCount != 0)
+                {
+                    stringBuilder.Append(" - ");
+                    bool flag = true;
+                    if (selectedCount == 1)
+                    {
+                        ComicBook comicBook = GetBookList(ComicBookFilterType.IsLocal | ComicBookFilterType.IsNotFileless | ComicBookFilterType.Selected).FirstOrDefault();
+                        if (comicBook != null)
+                        {
+                            stringBuilder.Append(comicBook.FilePath);
+                            flag = false;
+                        }
+                    }
+                    if (flag)
+                    {
+                        stringBuilder.AppendFormat(selectedText, selectedCount);
+                    }
+                }
+                if (selectedSize != 0L)
+                {
+                    stringBuilder.Append(" / ");
+                    stringBuilder.AppendFormat(string.Format(new FileLengthFormat(), "{0}", new object[1]
+                    {
+                        selectedSize
+                    }));
+                }
+                return stringBuilder.ToString();
+            }
+        }
+
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public DisplayListConfig ListConfig
+        {
+            get
+            {
+                return new DisplayListConfig
+                {
+                    View = ViewConfig,
+                    Thumbnail = new ThumbnailConfig(ThumbnailConfig)
+                };
+            }
+            set
+            {
+                ViewConfig = value.View;
+                ThumbnailConfig = new ThumbnailConfig(value.Thumbnail);
+                FillBookList();
+            }
+        }
+
+        public ToolStripItemCollection ListConfigMenu => tsListLayouts.DropDownItems;
+
+        public event EventHandler CurrentBookListChanged;
+
+        public event EventHandler SearchBrowserVisibleChanged;
+
+        public event EventHandler QuickSearchChanged;
+
+        public ComicBrowserControl()
+        {
+            InitializeComponent();
+            searchBrowserContainer.Collapsed = true;
+            itemView.ScrollResizeRefresh = Program.ExtendedSettings.OptimizedListScrolling;
+            toolTip.OwnerDraw = true;
+            toolTip.Draw += toolTip_Draw;
+            ListStyles.SetOwnerDrawn(lvGroupHeaders);
+            KeySearch.Create(lvGroupHeaders);
+            browserContainer.Panel2Collapsed = true;
+            LocalizeUtility.Localize(this, components);
+            noneText = TR.Load(base.Name)["None", "None"];
+            arrangedByText = TR.Load(base.Name)["ArrangedBy", "Arranged by {0}"];
+            notArrangedText = TR.Load(base.Name)["NotArranged", "Not sorted"];
+            groupedByText = TR.Load(base.Name)["GroupedBy", "Grouped by {0}"];
+            notGroupedText = TR.Load(base.Name)["NotGrouped", "Not grouped"];
+            stackedByText = TR.Load(base.Name)["StackedBy", "Stacked by {0}"];
+            notStackedText = TR.Load(base.Name)["NotStacked", "Not stacked"];
+            eComicText = TR.Load(base.Name)["ComicSingle", "{0} Book"];
+            eComicsText = TR.Load(base.Name)["ComicMulti", "{0} Books"];
+            selectedText = TR.Load(base.Name)["ComicSelected", "{0} selected"];
+            filteredText = TR.Load(base.Name)["ComicFiltered", "{0} filtered"];
+            customFieldDescription = TR.Load(base.Name)["CustomFieldDescription", "Shows the value of the custom field '{0}'"];
+            contextRating.Renderer = new MenuRenderer(Resources.StarYellow);
+            contextRating.Items.Insert(contextRating.Items.Count - 2, new ToolStripSeparator());
+            RatingControl.InsertRatingControl(contextRating, contextRating.Items.Count - 2, Resources.StarYellow, () => base.Main.GetRatingEditor());
+            FormUtility.EnableRightClickSplitButtons(toolStrip.Items);
+            string[] strings = TR.Load("Columns").GetStrings("DateFormats", "Long|Short|Relative", '|');
+            itemView.Columns.Add(new ItemViewColumn(101, "State", 60, new ComicListField("State", "State indicators for the Book"), new CoverViewItemBookComparer<ComicBookStatusComparer>()));
+            itemView.Columns.Add(new ItemViewColumn(100, "Position", 30, new ComicListField("Position", "Position of the Book in the list"), new CoverViewItemPositionComparer(), null, visible: true, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(102, "Checked", 22, new ComicListField("Checked", "Book is checked"), new CoverViewItemBookComparer<ComicBookCheckedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupChecked>()));
+            itemView.Columns.Add(new ItemViewColumn(0, "Cover", 40, new ComicListField("Cover", "Cover image of the Book"), null, null, visible: true, StringAlignment.Center)
+            {
+                Name = "Cover"
+            });
+            itemView.Columns.Add(new ItemViewColumn(1, "Series", 200, new ComicListField("Series", "Series name", "Series"), new CoverViewItemBookComparer<ComicBookSeriesComparer>(), new CoverViewItemBookGrouper<ComicBookGroupSeries>()));
+            itemView.Columns.Add(new ItemViewColumn(2, "Number", 40, new ComicListField("NumberAsText", "Number of the Book in the Series", "Number"), new CoverViewItemBookComparer<ComicBookNumberComparer>(), new CoverViewItemBookGrouper<ComicBookGroupNumber>(), visible: true, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(3, "Volume", 40, new ComicListField("VolumeAsText", "Volume number of the Series", "Volume"), new CoverViewItemBookComparer<ComicBookVolumeComparer>(), new CoverViewItemBookGrouper<ComicBookGroupVolume>()));
+            itemView.Columns.Add(new ItemViewColumn(4, "Title", 200, new ComicListField("Title", "Title of the Book", "Title"), new CoverViewItemBookComparer<ComicBookTitleComparer>(), new CoverViewItemBookGrouper<ComicBookGroupTitle>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(5, "Opened", 40, new ComicListField("OpenedTime", "Last time the Book was opened", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemBookComparer<ComicBookOpenedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupOpened>(), visible: true, StringAlignment.Far, strings));
+            itemView.Columns.Add(new ItemViewColumn(6, "Added", 40, new ComicListField("AddedTime", "Time the Book was added to the Database", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemBookComparer<ComicBookAddedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupAdded>(), visible: true, StringAlignment.Far, strings));
+            itemView.Columns.Add(new ItemViewColumn(7, "Pages", 40, new ComicListField("PagesAsTextSimple", "The total count of pages"), new CoverViewItemBookComparer<ComicBookPageCountComparer>(), new CoverViewItemBookGrouper<ComicBookGroupPages>(), visible: true, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(39, "Published", 40, new ComicListField("PublishedAsText", "Publication date of the Book"), new CoverViewItemBookComparer<ComicBookPublishedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupPublished>(), visible: true, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(9, "File Path", 200, new ComicListField("FilePath", "Location where the Book is stored", null, StringTrimming.EllipsisPath), new CoverViewItemBookComparer<ComicBookFileComparer>(), null, visible: false));
+            itemView.Columns.Add(new ItemViewColumn(10, "File Name", 200, new ComicListField("FileName", "Filename without the extension", "FileName"), new CoverViewItemBookComparer<ComicBookFileNameComparer>(), new CoverViewItemBookGrouper<ComicBookGroupFileName>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(11, "Writer", 80, new ComicListField("Writer", "Writer of the Book", "Writer"), new CoverViewItemBookComparer<ComicBookWriterComparer>(), new CoverViewItemBookGrouper<ComicBookGroupWriter>()));
+            itemView.Columns.Add(new ItemViewColumn(12, "Penciller", 80, new ComicListField("Penciller", "Penciller of the Book", "Penciller"), new CoverViewItemBookComparer<ComicBookPencillerComparer>(), new CoverViewItemBookGrouper<ComicBookGroupPenciller>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(13, "Inker", 80, new ComicListField("Inker", "Inker of the Book", "Inker"), new CoverViewItemBookComparer<ComicBookInkerComparer>(), new CoverViewItemBookGrouper<ComicBookGroupInker>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(14, "Colorist", 80, new ComicListField("Colorist", "Colorist of the Book", "Colorist"), new CoverViewItemBookComparer<ComicBookColoristComparer>(), new CoverViewItemBookGrouper<ComicBookGroupColorist>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(15, "My Rating", 50, new ComicListField("Rating", "Your rating of the Book"), new CoverViewItemRatingComparer(), new CoverViewItemBookGrouper<ComicBookGroupRating>()));
+            itemView.Columns.Add(new ItemViewColumn(16, "Opened Count", 40, new ComicListField("OpenedCountAsText", "Times the Book has been opened"), new CoverViewItemBookComparer<ComicBookOpenCountComparer>(), new CoverViewItemBookGrouper<ComicBookGroupOpenCount>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(17, "Read Percentage", 40, new ComicListField("ReadPercentageAsText", "How much has been read"), new CoverViewItemReadPercentageComparer(), new CoverViewItemBookGrouper<ComicBookGroupReadPercentage>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(18, "File Modified", 40, new ComicListField("FileModifiedTime", "Time the Book was modified the last time", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemBookComparer<ComicBookModifiedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupModified>(), visible: false, StringAlignment.Far, strings));
+            itemView.Columns.Add(new ItemViewColumn(19, "Genre", 40, new ComicListField("Genre", "Genre of the Book", "Genre"), new CoverViewItemBookComparer<ComicBookGenreComparer>(), new CoverViewItemBookGrouper<ComicBookGroupGenre>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(20, "Publisher", 40, new ComicListField("Publisher", "Publisher of the Book", "Publisher"), new CoverViewItemBookComparer<ComicBookPublisherComparer>(), new CoverViewItemBookGrouper<ComicBookGroupPublisher>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(21, "Count", 40, new ComicListField("CountAsText", "Total number of issues in this series", "Count"), new CoverViewItemBookComparer<ComicBookCountComparer>(), new CoverViewItemBookGrouper<ComicBookGroupCount>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(22, "Letterer", 80, new ComicListField("Letterer", "Letterer of the Book", "Letterer"), new CoverViewItemBookComparer<ComicBookLettererComparer>(), new CoverViewItemBookGrouper<ComicBookGroupLetterer>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(23, "Cover Artist", 80, new ComicListField("CoverArtist", "The artist responsible for the cover", "CoverArtist"), new CoverViewItemBookComparer<ComicBookCoverArtistComparer>(), new CoverViewItemBookGrouper<ComicBookGroupCoverArtist>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(24, "Editor", 80, new ComicListField("Editor", "Editor of the Book", "Editor"), new CoverViewItemBookComparer<ComicBookEditorComparer>(), new CoverViewItemBookGrouper<ComicBookGroupEditor>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(25, "File Size", 40, new ComicListField("FileSizeAsText", "Size of the Book file in bytes"), new CoverViewItemBookComparer<ComicBookSizeComparer>(), new CoverViewItemBookGrouper<ComicBookGroupSize>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(26, "Alternate Series", 200, new ComicListField("AlternateSeries", "Crossover/story name", "AlternateSeries"), new CoverViewItemBookComparer<ComicBookAlternateSeriesComparer>(), new CoverViewItemBookGrouper<ComicBookGroupAlternateSeries>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(27, "Alternate Number", 40, new ComicListField("AlternateNumberAsText", "Issue number in the crossover/story", "AlternateNumber"), new CoverViewItemBookComparer<ComicBookAlternateNumberComparer>(), new CoverViewItemBookGrouper<ComicBookGroupAlternateNumber>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(28, "Alternate Count", 40, new ComicListField("AlternateCountAsText", "Total issues of the crossover/story", "AlternateCount"), new CoverViewItemBookComparer<ComicBookAlternateCountComparer>(), new CoverViewItemBookGrouper<ComicBookGroupAlternateCount>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(29, "Month", 40, new ComicListField("MonthAsText", "Month the Book was published", "Month"), new CoverViewItemBookComparer<ComicBookMonthComparer>(), new CoverViewItemBookGrouper<ComicBookGroupMonth>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(30, "Caption", 200, new ComicListField("Caption", "Complete caption of the Book", "Series"), new CoverViewItemBookComparer<ComicBookSeriesComparer>(), new CoverViewItemBookGrouper<ComicBookGroupSeries>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(31, "Tags", 60, new ComicListField("Tags", "Tags of the Book", "Tags"), new CoverViewItemBookComparer<ComicBookTagsComparer>(), null, visible: false));
+            itemView.Columns.Add(new ItemViewColumn(32, "Imprint", 40, new ComicListField("Imprint", "Imprint of the Book", "Imprint"), new CoverViewItemBookComparer<ComicBookImprintComparer>(), new CoverViewItemBookGrouper<ComicBookGroupImprint>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(33, "Language", 40, new ComicListField("LanguageAsText", "Language of the Book"), new CoverViewItemBookComparer<ComicBookLanguageComparer>(), new CoverViewItemBookGrouper<ComicBookGroupLanguage>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(34, "Format", 40, new ComicListField("Format", "Format of the Book", "Format"), new CoverViewItemBookComparer<ComicBookFormatComparer>(), new CoverViewItemBookGrouper<ComicBookGroupFormat>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(35, "B&W", 22, new ComicListField("BlackAndWhiteAsText", "Yes if the Book is black and white"), new CoverViewItemBookComparer<ComicBookBlackAndWhiteComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBlackAndWhite>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(36, "Manga", 22, new ComicListField("MangaAsText", "Yes if the Book is a Manga"), new CoverViewItemBookComparer<ComicBookMangaComparer>(), new CoverViewItemBookGrouper<ComicBookGroupManga>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(37, "File Format", 40, new ComicListField("FileFormat", "File format of the Book"), new CoverViewItemBookComparer<ComicBookFileFormatComparer>(), new CoverViewItemBookGrouper<ComicBookGroupFileFormat>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(38, "Age Rating", 40, new ComicListField("AgeRating", "Age rating of the Book"), new CoverViewItemBookComparer<ComicBookAgeRatingComparer>(), new CoverViewItemBookGrouper<ComicBookGroupAgeRating>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(8, "Year", 60, new ComicListField("YearAsText", "Year the Book was published", "Year"), new CoverViewItemBookComparer<ComicBookYearComparer>(), new CoverViewItemBookGrouper<ComicBookGroupYear>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(40, "Characters", 60, new ComicListField("Characters", "Plot characters of the Books", "Characters"), new CoverViewItemBookComparer<ComicBookCharactersComparer>(), new CoverViewItemBookGrouper<ComicBookGroupCharacters>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(41, "File Directory", 60, new ComicListField("FileDirectory", "Directory of the Book"), new CoverViewItemBookComparer<ComicBookDirectoryComparer>(), new CoverViewItemBookGrouper<ComicBookGroupDirectory>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(42, "File Created", 60, new ComicListField("FileCreationTime", "Time the Book has been created", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemBookComparer<ComicBookCreationComparer>(), new CoverViewItemBookGrouper<ComicBookGroupCreation>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(43, "Bookmark Count", 60, new ComicListField("BookmarkCountAsText", "Count of Bookmarks for this Book"), new CoverViewItemBookComparer<ComicBookBookmarkCountComparer>(), null, visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(44, "New Pages", 60, new ComicListField("NewPagesAsText", "Count of new Pages"), new CoverViewItemBookComparer<ComicBookNewPagesComparer>(), null, visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(45, "Teams", 60, new ComicListField("Teams", "Plot teams of the Books", "Teams"), new CoverViewItemBookComparer<ComicBookTeamsComparer>(), new CoverViewItemBookGrouper<ComicBookGroupTeams>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(46, "Locations", 60, new ComicListField("Locations", "Plot locations of the Books", "Locations"), new CoverViewItemBookComparer<ComicBookLocationsComparer>(), new CoverViewItemBookGrouper<ComicBookGroupLocations>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(47, "Web", 60, new ComicListField("Web", "A Web Link", "Web"), new CoverViewItemBookComparer<ComicBookWebComparer>(), new CoverViewItemBookGrouper<ComicBookGroupWeb>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(48, "Community Rating", 50, new ComicListField("CommunityRating", "Rating of the Book"), new CoverViewItemCommunityRatingComparer(), new CoverViewItemBookGrouper<ComicBookGroupCommunityRating>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(49, "Linked", 50, new ComicListField("IsLinkedAsText", "Book is linked to a file"), new CoverViewItemBookComparer<ComicBookLinkedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupLinked>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(50, "Book Price", 50, new ComicListField("BookPriceAsText", "Price of the Book", "BookPriceAsText"), new CoverViewItemBookComparer<ComicBookBookPriceComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBookPrice>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(51, "Book Age", 50, new ComicListField("BookAge", "Age of the Book", "BookAge"), new CoverViewItemBookComparer<ComicBookBookAgeComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBookAge>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(52, "Book Store", 50, new ComicListField("BookStore", "Store the Book was bought", "BookStore"), new CoverViewItemBookComparer<ComicBookBookStoreComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBookStore>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(53, "Book Owner", 50, new ComicListField("BookOwner", "Owner of the Book", "BookOwner"), new CoverViewItemBookComparer<ComicBookBookOwnerComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBookOwner>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(54, "Book Condition", 50, new ComicListField("BookCondition", "Condition of the Book", "BookCondition"), new CoverViewItemBookComparer<ComicBookBookConditionComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBookCondition>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(55, "Book Collection Status", 50, new ComicListField("BookCollectionStatus", "Status of the Book in the Collection", "BookCollectionStatus"), new CoverViewItemBookComparer<ComicBookBookCollectionStatusComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBookCollectionStatus>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(56, "Book Location", 50, new ComicListField("BookLocation", "Location of the Book", "BookLocation"), new CoverViewItemBookComparer<ComicBookBookLocationComparer>(), new CoverViewItemBookGrouper<ComicBookGroupBookLocation>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(57, "ISBN", 50, new ComicListField("ISBN", "ISBN Number", "ISBN"), new CoverViewItemBookComparer<ComicBookISBNComparer>(), null, visible: false));
+            itemView.Columns.Add(new ItemViewColumn(58, "Series complete", 22, new ComicListField("SeriesCompleteAsText", "Series is complete"), new CoverViewItemBookComparer<ComicBookSeriesCompleteComparer>(), new CoverViewItemBookGrouper<ComicBookGroupSeriesComplete>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(59, "Proposed Values", 22, new ComicListField("EnableProposedAsText", "Uses proposed Values from Filename"), new CoverViewItemBookComparer<ComicBookSeriesEnableProposedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupEnableProposed>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(60, "Gap Information", 16, new ComicListField("GapInformation", "Information if this issue is the end or start of a gap in the series"), new CoverViewItemBookComparer<ComicBookSeriesComparer>(), null, visible: false));
+            itemView.Columns.Add(new ItemViewColumn(61, "Read", 22, new ComicListField("HasBeenReadAsText", "Book has been read"), new CoverViewItemBookComparer<ComicBookHasBeenReadComparer>(), new CoverViewItemBookGrouper<ComicBookGroupHasBeenRead>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(62, "Icons", 100, new ComicListField("Icons", "Icons for this Book"), null, null, visible: false));
+            itemView.Columns.Add(new ItemViewColumn(63, "Scan Information", 100, new ComicListField("ScanInformation", "Information about the Scan", "ScanInformation"), new CoverViewItemBookComparer<ComicBookScanInformationComparer>(), new CoverViewItemBookGrouper<ComicBookGroupScanInformation>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(64, "Story Arc", 100, new ComicListField("StoryArc", "Story Arc the book is part of", "StoryArc"), new CoverViewItemBookComparer<ComicBookStoryArcComparer>(), new CoverViewItemBookGrouper<ComicBookGroupStoryArc>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(65, "Series Group", 100, new ComicListField("SeriesGroup", "Series Group the Book is part of", "SeriesGroup"), new CoverViewItemBookComparer<ComicBookSeriesGroupComparer>(), new CoverViewItemBookGrouper<ComicBookGroupSeriesGroup>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(66, "Main Character/Team", 100, new ComicListField("MainCharacterOrTeam", "Main Character or Team of the Book", "MainCharacterOrTeam"), new CoverViewItemBookComparer<ComicBookMainCharacterOrTeamComparer>(), new CoverViewItemBookGrouper<ComicBookGroupMainCharacterOrTeam>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(67, "Review", 100, new ComicListField("Review", "A short Review of the Book"), new CoverViewItemBookComparer<ComicBookReviewComparer>(), null, visible: false));
+            itemView.Columns.Add(new ItemViewColumn(68, "Day", 40, new ComicListField("DayAsText", "Day the Book was published", "Day"), new CoverViewItemBookComparer<ComicBookDayComparer>(), new CoverViewItemBookGrouper<ComicBookGroupDay>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(69, "Week", 40, new ComicListField("WeekAsText", "Week the Book was published"), new CoverViewItemBookComparer<ComicBookWeekComparer>(), new CoverViewItemBookGrouper<ComicBookGroupWeek>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(70, "Released", 60, new ComicListField("ReleasedTime", "Time the Book was released", null, StringTrimming.Word, typeof(DateTime), ComicBook.TR["Unknown"]), new CoverViewItemBookComparer<ComicBookReleasedComparer>(), new CoverViewItemBookGrouper<ComicBookGroupReleased>(), visible: false, StringAlignment.Far, strings));
+            itemView.Columns.Add(new ItemViewColumn(200, "Series: Books", 50, new ComicListField("SeriesStatCountAsText", "Books in the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsCountComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupCount>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(201, "Series: Pages", 50, new ComicListField("SeriesStatPageCountAsText", "Pages in the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsPageCountComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupPageCount>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(202, "Series: Pages Read", 50, new ComicListField("SeriesStatPageReadCountAsText", "Pages of the Series read"), new CoverViewItemStatsComparer<ComicBookSeriesStatsPageReadCountComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupPageReadCount>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(203, "Series: Percent Read", 50, new ComicListField("SeriesStatReadPercentageAsText", "Percentage of the Series read"), new CoverViewItemStatsComparer<ComicBookSeriesStatsReadPercentageComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupReadPercentage>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(204, "Series: First Number", 50, new ComicListField("SeriesStatMinNumberAsText", "First Number of the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsMinNumberComparer>(), null, visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(205, "Series: Last Number", 50, new ComicListField("SeriesStatMaxNumberAsText", "Last Number of the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsMaxNumberComparer>(), null, visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(206, "Series: First Year", 50, new ComicListField("SeriesStatMinYearAsText", "First Year of the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsMinYearComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupMinYear>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(207, "Series: Last Year", 50, new ComicListField("SeriesStatMaxYearAsText", "Last Year of the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsMaxYearComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupMaxYear>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(208, "Series: Average Rating", 50, new ComicListField("SeriesStatAverageRating", "Average Rating of the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsAverageRatingComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupAverageRating>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(209, "Series: Average Community Rating", 50, new ComicListField("SeriesStatAverageCommunityRating", "Average Community Rating of the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsAverageCommunityRatingComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupAverageCommunityRating>(), visible: false));
+            itemView.Columns.Add(new ItemViewColumn(210, "Series: Gaps", 50, new ComicListField("SeriesStatGapCountAsText", "Count of Gaps in the Series"), new CoverViewItemStatsComparer<ComicBookSeriesStatsGapCountComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupGapCount>(), visible: false, StringAlignment.Far));
+            itemView.Columns.Add(new ItemViewColumn(211, "Series: Book added", 50, new ComicListField("SeriesStatLastAddedTime", "Last time a book was added to the Series", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemStatsComparer<ComicBookSeriesStatsLastAddedTimeComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupLastAddedTime>(), visible: false, StringAlignment.Far, strings));
+            itemView.Columns.Add(new ItemViewColumn(212, "Series: Opened", 50, new ComicListField("SeriesStatLastOpenedTime", "Last time a book was opened from the Series", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemStatsComparer<ComicBookSeriesStatsLastOpenedTimeComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupLastOpenedTime>(), visible: false, StringAlignment.Far, strings));
+            itemView.Columns.Add(new ItemViewColumn(213, "Series: Book released", 50, new ComicListField("SeriesStatLastReleasedTime", "Last time a book of this Series was released", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemStatsComparer<ComicBookSeriesStatsLastReleasedTimeComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupLastReleasedTime>(), visible: false, StringAlignment.Far, strings));
+            SubView.TranslateColumns(itemView.Columns);
+            foreach (ItemViewColumn column in itemView.Columns)
+            {
+                column.TooltipText = ((ComicListField)column.Tag).Description;
+                column.Width = FormUtility.ScaleDpiX(column.Width);
+            }
+            ThumbnailConfig = new ThumbnailConfig();
+            ThumbnailConfig.CaptionIds.Add(30);
+            tsQuickSearch.TextBox.SearchButtonImage = Resources.Search.ScaleDpi();
+            tsQuickSearch.TextBox.ClearButtonImage = Resources.SmallCloseGray.ScaleDpi();
+            itemView.Font = SystemFonts.IconTitleFont;
+            itemView.ItemContextMenuStrip = contextMenuItems;
+            itemView.ItemRowHeight = itemView.Font.Height + FormUtility.ScaleDpiY(6);
+            itemView.ColumnHeaderHeight = itemView.ItemRowHeight;
+            itemView.Items.Changed += ComicItemAdded;
+            itemView.MouseWheel += itemView_MouseWheel;
             miPasteData.Click += new EventHandler((sender, e) => PasteComicData());
             KeySearch.Create(itemView);
-		}
+        }
 
-		private void ComicItemAdded(object sender, SmartListChangedEventArgs<IViewableItem> e)
-		{
-			CoverViewItem coverViewItem = e.Item as CoverViewItem;
-			if (coverViewItem != null)
-			{
-				coverViewItem.ThumbnailConfig = ThumbnailConfig;
-			}
-		}
+        private void ComicItemAdded(object sender, SmartListChangedEventArgs<IViewableItem> e)
+        {
+            CoverViewItem coverViewItem = e.Item as CoverViewItem;
+            if (coverViewItem != null)
+            {
+                coverViewItem.ThumbnailConfig = ThumbnailConfig;
+            }
+        }
 
-		protected override void OnLoad(EventArgs e)
-		{
-			base.OnLoad(e);
-			if (base.DesignMode)
-			{
-				return;
-			}
-			commands.Add(delegate
-			{
-				QuickSearchType = ComicBookAllPropertiesMatcher.MatcherOption.All;
-			}, true, () => QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.All, miSearchAll);
-			commands.Add(delegate
-			{
-				QuickSearchType = ComicBookAllPropertiesMatcher.MatcherOption.Series;
-			}, true, () => QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.Series, miSearchSeries);
-			commands.Add(delegate
-			{
-				QuickSearchType = ComicBookAllPropertiesMatcher.MatcherOption.Writer;
-			}, true, () => QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.Writer, miSearchWriter);
-			commands.Add(delegate
-			{
-				QuickSearchType = ComicBookAllPropertiesMatcher.MatcherOption.Artists;
-			}, true, () => QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.Artists, miSearchArtists);
-			commands.Add(delegate
-			{
-				QuickSearchType = ComicBookAllPropertiesMatcher.MatcherOption.Descriptive;
-			}, true, () => QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.Descriptive, miSearchDescriptive);
-			commands.Add(delegate
-			{
-				QuickSearchType = ComicBookAllPropertiesMatcher.MatcherOption.File;
-			}, true, () => QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.File, miSearchFile);
-			commands.Add(delegate
-			{
-				QuickSearchType = ComicBookAllPropertiesMatcher.MatcherOption.Catalog;
-			}, true, () => QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.Catalog, miSearchCatalog);
-			ContextMenuStrip autoViewContextMenuStrip = itemView.AutoViewContextMenuStrip;
-			ToolStripMenuItem toolStripMenuItem = (ToolStripMenuItem)autoViewContextMenuStrip.Items.Add(TR.Default["Layout", "Layout"]);
-			toolStripMenuItem.DropDown.Opening += LayoutMenuOpening;
-			miCopyListSetup = toolStripMenuItem.DropDown.Items.Add(TR.Default["Copy", "Copy"]) as ToolStripMenuItem;
-			miPasteListSetup = toolStripMenuItem.DropDown.Items.Add(TR.Default["Paste", "Paste"]) as ToolStripMenuItem;
-			autoViewContextMenuStrip.Items.Add(new ToolStripSeparator());
-			ToolStripMenuItem toolStripMenuItem2;
-			autoViewContextMenuStrip.Items.Add(toolStripMenuItem2 = miSelectAll.Clone());
-			ToolStripMenuItem toolStripMenuItem3;
-			autoViewContextMenuStrip.Items.Add(toolStripMenuItem3 = miResetListBackground.Clone());
-			tsQuickSearch.TextBox.SearchMenu = contextQuickSearch;
-			components.Add(commands);
-			commands.Add(delegate
-			{
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+            if (base.DesignMode)
+            {
+                return;
+            }
+            commands.Add(delegate
+            {
+                QuickSearchType = ComicBookAllPropertiesMatcher.MatcherOption.All;
+            }, true, () => QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.All, miSearchAll);
+            commands.Add(delegate
+            {
+                QuickSearchType = ComicBookAllPropertiesMatcher.MatcherOption.Series;
+            }, true, () => QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.Series, miSearchSeries);
+            commands.Add(delegate
+            {
+                QuickSearchType = ComicBookAllPropertiesMatcher.MatcherOption.Writer;
+            }, true, () => QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.Writer, miSearchWriter);
+            commands.Add(delegate
+            {
+                QuickSearchType = ComicBookAllPropertiesMatcher.MatcherOption.Artists;
+            }, true, () => QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.Artists, miSearchArtists);
+            commands.Add(delegate
+            {
+                QuickSearchType = ComicBookAllPropertiesMatcher.MatcherOption.Descriptive;
+            }, true, () => QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.Descriptive, miSearchDescriptive);
+            commands.Add(delegate
+            {
+                QuickSearchType = ComicBookAllPropertiesMatcher.MatcherOption.File;
+            }, true, () => QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.File, miSearchFile);
+            commands.Add(delegate
+            {
+                QuickSearchType = ComicBookAllPropertiesMatcher.MatcherOption.Catalog;
+            }, true, () => QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.Catalog, miSearchCatalog);
+            ContextMenuStrip autoViewContextMenuStrip = itemView.AutoViewContextMenuStrip;
+            ToolStripMenuItem toolStripMenuItem = (ToolStripMenuItem)autoViewContextMenuStrip.Items.Add(TR.Default["Layout", "Layout"]);
+            toolStripMenuItem.DropDown.Opening += LayoutMenuOpening;
+            miCopyListSetup = toolStripMenuItem.DropDown.Items.Add(TR.Default["Copy", "Copy"]) as ToolStripMenuItem;
+            miPasteListSetup = toolStripMenuItem.DropDown.Items.Add(TR.Default["Paste", "Paste"]) as ToolStripMenuItem;
+            autoViewContextMenuStrip.Items.Add(new ToolStripSeparator());
+            ToolStripMenuItem toolStripMenuItem2;
+            autoViewContextMenuStrip.Items.Add(toolStripMenuItem2 = miSelectAll.Clone());
+            ToolStripMenuItem toolStripMenuItem3;
+            autoViewContextMenuStrip.Items.Add(toolStripMenuItem3 = miResetListBackground.Clone());
+            tsQuickSearch.TextBox.SearchMenu = contextQuickSearch;
+            components.Add(commands);
+            commands.Add(delegate
+            {
 				base.Main.Control.InvokeActiveService(delegate(IBrowseHistory t)
-				{
-					t.BrowsePrevious();
-				});
-			}, () => base.Main.Control.InvokeActiveService((IBrowseHistory t) => t.CanBrowsePrevious(), defaultReturn: false), btBrowsePrev);
-			commands.Add(delegate
-			{
+                {
+                    t.BrowsePrevious();
+                });
+            }, () => base.Main.Control.InvokeActiveService((IBrowseHistory t) => t.CanBrowsePrevious(), defaultReturn: false), btBrowsePrev);
+            commands.Add(delegate
+            {
 				base.Main.Control.InvokeActiveService(delegate(IBrowseHistory t)
-				{
-					t.BrowseNext();
-				});
-			}, () => base.Main.Control.InvokeActiveService((IBrowseHistory t) => t.CanBrowseNext(), defaultReturn: false), btBrowseNext);
-			commands.Add(delegate
-			{
-				ShowOptionType = ComicBookAllPropertiesMatcher.ShowOptionType.All;
-			}, true, () => ShowOptionType == ComicBookAllPropertiesMatcher.ShowOptionType.All, miShowOnlyAllComics);
-			commands.Add(delegate
-			{
-				ShowOptionType = ComicBookAllPropertiesMatcher.ShowOptionType.Unread;
-			}, true, () => ShowOptionType == ComicBookAllPropertiesMatcher.ShowOptionType.Unread, miShowOnlyUnreadComics);
-			commands.Add(delegate
-			{
-				ShowOptionType = ComicBookAllPropertiesMatcher.ShowOptionType.Reading;
-			}, true, () => ShowOptionType == ComicBookAllPropertiesMatcher.ShowOptionType.Reading, miShowOnlyReadingComics);
-			commands.Add(delegate
-			{
-				ShowOptionType = ComicBookAllPropertiesMatcher.ShowOptionType.Read;
-			}, true, () => ShowOptionType == ComicBookAllPropertiesMatcher.ShowOptionType.Read, miShowOnlyReadComics);
-			commands.Add(delegate
-			{
-				ShowOnlyDuplicates = !ShowOnlyDuplicates;
-			}, true, () => ShowOnlyDuplicates, miShowOnlyDuplicates);
-			commands.Add(ShowWeb, miShowWeb);
-			commands.Add(delegate
-			{
-				ShowComicType = ((ShowComicType != ComicBookAllPropertiesMatcher.ShowComicType.Comics) ? ComicBookAllPropertiesMatcher.ShowComicType.Comics : ComicBookAllPropertiesMatcher.ShowComicType.All);
-			}, true, () => ShowComicType == ComicBookAllPropertiesMatcher.ShowComicType.Comics, miShowOnlyComics);
-			commands.Add(delegate
-			{
-				ShowComicType = ((ShowComicType != ComicBookAllPropertiesMatcher.ShowComicType.FilelessComics) ? ComicBookAllPropertiesMatcher.ShowComicType.FilelessComics : ComicBookAllPropertiesMatcher.ShowComicType.All);
-			}, true, () => ShowComicType == ComicBookAllPropertiesMatcher.ShowComicType.FilelessComics, miShowOnlyFileless);
-			commands.Add(itemView.ToggleGroups, () => itemView.AreGroupsVisible, miExpandAllGroups);
-			commands.Add(delegate
-			{
-				ShowGroupHeaders = !ShowGroupHeaders;
-			}, true, () => ShowGroupHeaders, miShowGroupHeaders);
-			commands.Add(delegate
-			{
+                {
+                    t.BrowseNext();
+                });
+            }, () => base.Main.Control.InvokeActiveService((IBrowseHistory t) => t.CanBrowseNext(), defaultReturn: false), btBrowseNext);
+            commands.Add(delegate
+            {
+                ShowOptionType = ComicBookAllPropertiesMatcher.ShowOptionType.All;
+            }, true, () => ShowOptionType == ComicBookAllPropertiesMatcher.ShowOptionType.All, miShowOnlyAllComics);
+            commands.Add(delegate
+            {
+                ShowOptionType = ComicBookAllPropertiesMatcher.ShowOptionType.Unread;
+            }, true, () => ShowOptionType == ComicBookAllPropertiesMatcher.ShowOptionType.Unread, miShowOnlyUnreadComics);
+            commands.Add(delegate
+            {
+                ShowOptionType = ComicBookAllPropertiesMatcher.ShowOptionType.Reading;
+            }, true, () => ShowOptionType == ComicBookAllPropertiesMatcher.ShowOptionType.Reading, miShowOnlyReadingComics);
+            commands.Add(delegate
+            {
+                ShowOptionType = ComicBookAllPropertiesMatcher.ShowOptionType.Read;
+            }, true, () => ShowOptionType == ComicBookAllPropertiesMatcher.ShowOptionType.Read, miShowOnlyReadComics);
+            commands.Add(delegate
+            {
+                ShowOnlyDuplicates = !ShowOnlyDuplicates;
+            }, true, () => ShowOnlyDuplicates, miShowOnlyDuplicates);
+            commands.Add(ShowWeb, miShowWeb);
+            commands.Add(delegate
+            {
+                ShowComicType = ((ShowComicType != ComicBookAllPropertiesMatcher.ShowComicType.Comics) ? ComicBookAllPropertiesMatcher.ShowComicType.Comics : ComicBookAllPropertiesMatcher.ShowComicType.All);
+            }, true, () => ShowComicType == ComicBookAllPropertiesMatcher.ShowComicType.Comics, miShowOnlyComics);
+            commands.Add(delegate
+            {
+                ShowComicType = ((ShowComicType != ComicBookAllPropertiesMatcher.ShowComicType.FilelessComics) ? ComicBookAllPropertiesMatcher.ShowComicType.FilelessComics : ComicBookAllPropertiesMatcher.ShowComicType.All);
+            }, true, () => ShowComicType == ComicBookAllPropertiesMatcher.ShowComicType.FilelessComics, miShowOnlyFileless);
+            commands.Add(itemView.ToggleGroups, () => itemView.AreGroupsVisible, miExpandAllGroups);
+            commands.Add(delegate
+            {
+                ShowGroupHeaders = !ShowGroupHeaders;
+            }, true, () => ShowGroupHeaders, miShowGroupHeaders);
+            commands.Add(delegate
+            {
 				base.Main.Control.InvokeActiveService(delegate(ISidebar s)
-				{
-					s.Visible = !s.Visible;
-				});
-			}, true, () => base.Main.Control.InvokeActiveService((ISidebar s) => s.Visible, defaultReturn: false), tbSidebar);
-			commands.Add(OpenComic, AllSelectedLinked, miRead);
-			commands.Add(OpenComicNewTab, AllSelectedLinked, miReadTab);
-			commands.Add(itemView.SelectAll, miSelectAll, toolStripMenuItem2);
-			commands.Add(itemView.InvertSelection, miInvertSelection);
-			commands.Add(RemoveBooks, CanRemoveBooks, miRemove);
-			commands.Add(RevealInExplorer, () => ComicEditMode.CanShowComics() && AllSelectedLinked(), miRevealBrowser);
-			commands.Add(delegate
-			{
-				base.Main.ShowInfo();
-			}, () => itemView.SelectedCount > 0, miProperties);
-			commands.Add(EditItem, () => ComicEditMode.CanEditProperties() && itemView.SelectedCount > 0, miEdit);
-			commands.Add(RefreshInformation, miRefreshInformation);
-			commands.Add(AddFilesToLibrary, () => !GetBookList(ComicBookFilterType.NotInLibrary | ComicBookFilterType.IsLocal | ComicBookFilterType.IsNotFileless).IsEmpty(), miAddLibrary);
-			commands.Add(delegate
-			{
-				base.Main.ConvertComic(GetBookList(ComicBookFilterType.IsNotFileless | ComicBookFilterType.CanExport | ComicBookFilterType.Selected, asArray: true), null);
-			}, () => ComicEditMode.CanExport() && AnySelectedLinked(), miExportComicsAs);
-			commands.Add(delegate
-			{
-				base.Main.ConvertComic(GetBookList(ComicBookFilterType.IsNotFileless | ComicBookFilterType.CanExport | ComicBookFilterType.Selected, asArray: true), Program.Settings.CurrentExportSetting);
-			}, () => Program.Settings.CurrentExportSetting != null && ComicEditMode.CanExport() && AnySelectedLinked(), miExportComicsWithPrevious);
-			commands.Add(MarkSelectedRead, ComicEditMode.CanEditProperties() && itemView.SelectedCount > 0, miMarkRead);
-			commands.Add(MarkSelectedNotRead, ComicEditMode.CanEditProperties() && itemView.SelectedCount > 0, miMarkUnread);
-			commands.Add(MarkSelectedChecked, ComicEditMode.CanEditProperties() && itemView.SelectedCount > 0, miMarkChecked);
-			commands.Add(MarkSelectedUnchecked, ComicEditMode.CanEditProperties() && itemView.SelectedCount > 0, miMarkUnchecked);
-			commands.Add(SetSelectedComicAsListBackground, AllSelectedLinked, miSetListBackground);
-			commands.Add(ResetListBackgroundImage, () => itemView.BackgroundImage != ListBackgroundImage, miResetListBackground, toolStripMenuItem3);
-			commands.Add(delegate
-			{
-				MoveBooks(GetBookList(ComicBookFilterType.Library | ComicBookFilterType.Selected), bottom: false);
-			}, () => CanReorderList(), miEditListMoveToTop);
-			commands.Add(delegate
-			{
-				MoveBooks(GetBookList(ComicBookFilterType.Library | ComicBookFilterType.Selected), bottom: true);
-			}, () => CanReorderList(), miEditListMoveToBottom);
-			commands.Add(delegate
-			{
-				ApplyBookOrder(GetBookList(ComicBookFilterType.Library));
-			}, () => CanReorderList(mustBeOrdered: false), miEditListApplyOrder);
+                {
+                    s.Visible = !s.Visible;
+                });
+            }, true, () => base.Main.Control.InvokeActiveService((ISidebar s) => s.Visible, defaultReturn: false), tbSidebar);
+            commands.Add(OpenComic, AllSelectedLinked, miRead);
+            commands.Add(OpenComicNewTab, AllSelectedLinked, miReadTab);
+            commands.Add(itemView.SelectAll, miSelectAll, toolStripMenuItem2);
+            commands.Add(itemView.InvertSelection, miInvertSelection);
+            commands.Add(RemoveBooks, CanRemoveBooks, miRemove);
+            commands.Add(RevealInExplorer, () => ComicEditMode.CanShowComics() && AllSelectedLinked(), miRevealBrowser);
+            commands.Add(delegate
+            {
+                base.Main.ShowInfo();
+            }, () => itemView.SelectedCount > 0, miProperties);
+            commands.Add(EditItem, () => ComicEditMode.CanEditProperties() && itemView.SelectedCount > 0, miEdit);
+            commands.Add(RefreshInformation, miRefreshInformation);
+            commands.Add(AddFilesToLibrary, () => !GetBookList(ComicBookFilterType.NotInLibrary | ComicBookFilterType.IsLocal | ComicBookFilterType.IsNotFileless).IsEmpty(), miAddLibrary);
+            commands.Add(delegate
+            {
+                base.Main.ConvertComic(GetBookList(ComicBookFilterType.IsNotFileless | ComicBookFilterType.CanExport | ComicBookFilterType.Selected, asArray: true), null);
+            }, () => ComicEditMode.CanExport() && AnySelectedLinked(), miExportComicsAs);
+            commands.Add(delegate
+            {
+                base.Main.ConvertComic(GetBookList(ComicBookFilterType.IsNotFileless | ComicBookFilterType.CanExport | ComicBookFilterType.Selected, asArray: true), Program.Settings.CurrentExportSetting);
+            }, () => Program.Settings.CurrentExportSetting != null && ComicEditMode.CanExport() && AnySelectedLinked(), miExportComicsWithPrevious);
+            commands.Add(MarkSelectedRead, ComicEditMode.CanEditProperties() && itemView.SelectedCount > 0, miMarkRead);
+            commands.Add(MarkSelectedNotRead, ComicEditMode.CanEditProperties() && itemView.SelectedCount > 0, miMarkUnread);
+            commands.Add(MarkSelectedChecked, ComicEditMode.CanEditProperties() && itemView.SelectedCount > 0, miMarkChecked);
+            commands.Add(MarkSelectedUnchecked, ComicEditMode.CanEditProperties() && itemView.SelectedCount > 0, miMarkUnchecked);
+            commands.Add(SetSelectedComicAsListBackground, AllSelectedLinked, miSetListBackground);
+            commands.Add(ResetListBackgroundImage, () => itemView.BackgroundImage != ListBackgroundImage, miResetListBackground, toolStripMenuItem3);
+            commands.Add(delegate
+            {
+                MoveBooks(GetBookList(ComicBookFilterType.Library | ComicBookFilterType.Selected), bottom: false);
+            }, () => CanReorderList(), miEditListMoveToTop);
+            commands.Add(delegate
+            {
+                MoveBooks(GetBookList(ComicBookFilterType.Library | ComicBookFilterType.Selected), bottom: true);
+            }, () => CanReorderList(), miEditListMoveToBottom);
+            commands.Add(delegate
+            {
+                ApplyBookOrder(GetBookList(ComicBookFilterType.Library));
+            }, () => CanReorderList(mustBeOrdered: false), miEditListApplyOrder);
             //commands.Add(PasteComicData, () => ComicEditMode.CanEditProperties() && Clipboard.ContainsData(ComicBook.ClipboardFormat) && !GetBookList(ComicBookFilterType.Selected).IsEmpty(), miPasteData);
             commands.Add(CopyComicData, () => itemView.SelectedCount > 0, miCopyData);
-			commands.Add(ClearComicData, () => ComicEditMode.CanEditProperties() && !GetBookList(ComicBookFilterType.Selected).IsEmpty(), miClearData);
-			commands.Add(UpdateFiles, AnySelectedLinked, miUpdateComicFiles);
-			commands.Add(delegate
-			{
-				itemView.ItemViewMode = ItemViewMode.Thumbnail;
-			}, true, () => itemView.ItemViewMode == ItemViewMode.Thumbnail, miViewThumbnails);
-			commands.Add(delegate
-			{
-				itemView.ItemViewMode = ItemViewMode.Tile;
-			}, true, () => itemView.ItemViewMode == ItemViewMode.Tile, miViewTiles);
-			commands.Add(delegate
-			{
-				itemView.ItemViewMode = ItemViewMode.Detail;
-			}, true, () => itemView.ItemViewMode == ItemViewMode.Detail, miViewDetails);
-			commands.Add(delegate
-			{
-				base.Main.GetRatingEditor().SetRating(0f);
-			}, () => base.Main.GetRatingEditor().IsValid(), () => Math.Round(base.Main.GetRatingEditor().GetRating()) == 0.0, miRating0);
-			commands.Add(delegate
-			{
-				base.Main.GetRatingEditor().SetRating(1f);
-			}, () => base.Main.GetRatingEditor().IsValid(), () => Math.Round(base.Main.GetRatingEditor().GetRating()) == 1.0, miRating1);
-			commands.Add(delegate
-			{
-				base.Main.GetRatingEditor().SetRating(2f);
-			}, () => base.Main.GetRatingEditor().IsValid(), () => Math.Round(base.Main.GetRatingEditor().GetRating()) == 2.0, miRating2);
-			commands.Add(delegate
-			{
-				base.Main.GetRatingEditor().SetRating(3f);
-			}, () => base.Main.GetRatingEditor().IsValid(), () => Math.Round(base.Main.GetRatingEditor().GetRating()) == 3.0, miRating3);
-			commands.Add(delegate
-			{
-				base.Main.GetRatingEditor().SetRating(4f);
-			}, () => base.Main.GetRatingEditor().IsValid(), () => Math.Round(base.Main.GetRatingEditor().GetRating()) == 4.0, miRating4);
-			commands.Add(delegate
-			{
-				base.Main.GetRatingEditor().SetRating(5f);
-			}, () => base.Main.GetRatingEditor().IsValid(), () => Math.Round(base.Main.GetRatingEditor().GetRating()) == 5.0, miRating5);
-			commands.Add(delegate
-			{
-				base.Main.GetRatingEditor().QuickRatingAndReview();
-			}, () => base.Main.GetRatingEditor().IsValid(), miQuickRating);
-			commands.Add(CopyListSetup, miCopyListSetup);
-			commands.Add(PasteListSetup, miPasteListSetup);
-			commands.Add(SetTopOfStack, () => itemView.SelectedCount == 1, miSetTopOfStack);
-			commands.Add(SetStackThumbnail, true, miSetStackThumbnail);
-			commands.Add(RemoveStackThumbnail, true, miRemoveStackThumbnail);
-			miAutomation.DropDownItems.AddRange(ScriptUtility.CreateToolItems<ToolStripMenuItem>(this, "Books", () => GetBookList(ComicBookFilterType.Selected)).ToArray());
-			miAutomation.Visible = miAutomation.DropDownItems.Count != 0;
-			List<ToolStripItem> list = new List<ToolStripItem>();
-			list.AddRange(ScriptUtility.CreateToolItems<ToolStripButton>(this, "Books", () => GetBookList(ComicBookFilterType.Selected), (Command c) => c.Image != null && c.Configure == null));
-			list.AddRange(ScriptUtility.CreateToolItems<ToolStripSplitButton>(this, "Books", () => GetBookList(ComicBookFilterType.Selected), (Command c) => c.Image != null && c.Configure != null));
-			if (list.Count != 0)
-			{
+            commands.Add(ClearComicData, () => ComicEditMode.CanEditProperties() && !GetBookList(ComicBookFilterType.Selected).IsEmpty(), miClearData);
+            commands.Add(UpdateFiles, AnySelectedLinked, miUpdateComicFiles);
+            commands.Add(delegate
+            {
+                itemView.ItemViewMode = ItemViewMode.Thumbnail;
+            }, true, () => itemView.ItemViewMode == ItemViewMode.Thumbnail, miViewThumbnails);
+            commands.Add(delegate
+            {
+                itemView.ItemViewMode = ItemViewMode.Tile;
+            }, true, () => itemView.ItemViewMode == ItemViewMode.Tile, miViewTiles);
+            commands.Add(delegate
+            {
+                itemView.ItemViewMode = ItemViewMode.Detail;
+            }, true, () => itemView.ItemViewMode == ItemViewMode.Detail, miViewDetails);
+            commands.Add(delegate
+            {
+                base.Main.GetRatingEditor().SetRating(0f);
+            }, () => base.Main.GetRatingEditor().IsValid(), () => Math.Round(base.Main.GetRatingEditor().GetRating()) == 0.0, miRating0);
+            commands.Add(delegate
+            {
+                base.Main.GetRatingEditor().SetRating(1f);
+            }, () => base.Main.GetRatingEditor().IsValid(), () => Math.Round(base.Main.GetRatingEditor().GetRating()) == 1.0, miRating1);
+            commands.Add(delegate
+            {
+                base.Main.GetRatingEditor().SetRating(2f);
+            }, () => base.Main.GetRatingEditor().IsValid(), () => Math.Round(base.Main.GetRatingEditor().GetRating()) == 2.0, miRating2);
+            commands.Add(delegate
+            {
+                base.Main.GetRatingEditor().SetRating(3f);
+            }, () => base.Main.GetRatingEditor().IsValid(), () => Math.Round(base.Main.GetRatingEditor().GetRating()) == 3.0, miRating3);
+            commands.Add(delegate
+            {
+                base.Main.GetRatingEditor().SetRating(4f);
+            }, () => base.Main.GetRatingEditor().IsValid(), () => Math.Round(base.Main.GetRatingEditor().GetRating()) == 4.0, miRating4);
+            commands.Add(delegate
+            {
+                base.Main.GetRatingEditor().SetRating(5f);
+            }, () => base.Main.GetRatingEditor().IsValid(), () => Math.Round(base.Main.GetRatingEditor().GetRating()) == 5.0, miRating5);
+            commands.Add(delegate
+            {
+                base.Main.GetRatingEditor().QuickRatingAndReview();
+            }, () => base.Main.GetRatingEditor().IsValid(), miQuickRating);
+            commands.Add(CopyListSetup, miCopyListSetup);
+            commands.Add(PasteListSetup, miPasteListSetup);
+            commands.Add(SetTopOfStack, () => itemView.SelectedCount == 1, miSetTopOfStack);
+            commands.Add(SetStackThumbnail, true, miSetStackThumbnail);
+            commands.Add(RemoveStackThumbnail, true, miRemoveStackThumbnail);
+            miAutomation.DropDownItems.AddRange(ScriptUtility.CreateToolItems<ToolStripMenuItem>(this, "Books", () => GetBookList(ComicBookFilterType.Selected)).ToArray());
+            miAutomation.Visible = miAutomation.DropDownItems.Count != 0;
+            List<ToolStripItem> list = new List<ToolStripItem>();
+            list.AddRange(ScriptUtility.CreateToolItems<ToolStripButton>(this, "Books", () => GetBookList(ComicBookFilterType.Selected), (Command c) => c.Image != null && c.Configure == null));
+            list.AddRange(ScriptUtility.CreateToolItems<ToolStripSplitButton>(this, "Books", () => GetBookList(ComicBookFilterType.Selected), (Command c) => c.Image != null && c.Configure != null));
+            if (list.Count != 0)
+            {
 				list.ForEach(delegate(ToolStripItem bt)
-				{
-					bt.DisplayStyle = ToolStripItemDisplayStyle.Image;
-				});
-				toolStrip.Items.Add(new ToolStripSeparator());
-				toolStrip.Items.AddRange(list.ToArray());
-			}
-			ToolStripSeparator toolStripSeparator = sepDuplicateList;
-			bool visible = (tbbDuplicateList.Visible = Library != null && Library.EditMode.CanEditList());
-			toolStripSeparator.Visible = visible;
-			miShowInList.Visible = Library != null;
-			if (Library != Program.Database)
-			{
-				ToolStripSeparator toolStripSeparator2 = sepUndo;
-				ToolStripButton toolStripButton = tbUndo;
-				bool flag3 = (tbRedo.Visible = false);
-				visible = (toolStripButton.Visible = flag3);
-				toolStripSeparator2.Visible = visible;
-			}
-			else
-			{
-				commands.Add(Program.Database.Undo.Undo, () => Program.Database.Undo.CanUndo, tbUndo);
-				commands.Add(Program.Database.Undo.Redo, () => Program.Database.Undo.CanRedo, tbRedo);
-			}
-			base.Controls.SetChildIndex(toolStrip, base.Controls.Count - 1);
-		}
-
-		protected override void OnVisibleChanged(EventArgs e)
-		{
-			base.OnVisibleChanged(e);
-			toolTip.SetToolTip(itemView, null);
-		}
-
-		protected override void OnMainFormChanged()
-		{
-			base.OnMainFormChanged();
-			if (base.Main != null)
-			{
-				commands.Add(base.Main.EditListLayout, tsEditListLayout);
-				commands.Add(base.Main.SaveListLayout, tsSaveListLayout);
-				commands.Add(base.Main.EditListLayouts, () => Program.Settings.ListConfigurations.Count > 0, tsEditLayouts);
-				base.Main.OpenBooks.BookClosed += OpenBooksChanged;
-				base.Main.OpenBooks.BookOpened += OpenBooksChanged;
-				UpdatePending();
-			}
-		}
-
-		protected virtual void OnComicEditModeChanged()
-		{
-			itemView.LabelEdit = ComicEditMode.CanEditProperties();
-			miRevealBrowser.Visible = ComicEditMode.CanShowComics();
-			ToolStripMenuItem toolStripMenuItem = miCopyData;
-			ToolStripMenuItem toolStripMenuItem2 = miPasteData;
-			ToolStripMenuItem toolStripMenuItem3 = miClearData;
-			bool flag2 = (tsCopySeparator.Visible = ComicEditMode.CanEditProperties());
-			bool flag4 = (toolStripMenuItem3.Visible = flag2);
-			bool visible = (toolStripMenuItem2.Visible = flag4);
-			toolStripMenuItem.Visible = visible;
-			ToolStripSeparator toolStripSeparator = toolStripRemoveSeparator;
-			visible = (miRemove.Visible = ComicEditMode.CanDeleteComics());
-			toolStripSeparator.Visible = visible;
-		}
-
-		private void lvGroupHeaders_ColumnClick(object sender, ColumnClickEventArgs e)
-		{
-			itemView.GroupSortingOrder = ItemView.FlipSortOrder(itemView.GroupSortingOrder);
-		}
-
-		private void lvGroupHeaders_ClientSizeChanged(object sender, EventArgs e)
-		{
-			int num = lvGroupHeaders.ClientRectangle.Width - (lvGroupsCount.Width + 2);
-			if (num > 0)
-			{
-				lvGroupsName.Width = num;
-			}
-		}
-
-		private void browserContainer_DoubleClick(object sender, EventArgs e)
-		{
-			ShowGroupHeaders = !ShowGroupHeaders;
-		}
-
-		private void OpenBooksChanged(object sender, BookEventArgs e)
-		{
-			UpdateBookMarkers();
-		}
-
-		private void btCloseStack_Click(object sender, EventArgs e)
-		{
-			CloseStack(withUpdate: true);
-		}
-
-		private void btPrevStack_Click(object sender, EventArgs e)
-		{
-			CoverViewItem oldItem = stackItem as CoverViewItem;
-			CloseStack(withUpdate: true);
-			CoverViewItem[] array = itemView.DisplayedItems.OfType<CoverViewItem>().ToArray();
-			int num = array.FindIndex((CoverViewItem ci) => (from sci in itemView.GetStackItems(ci).OfType<CoverViewItem>()
-				select sci.Comic).Contains(oldItem.Comic)) - 1;
-			if (num < 0)
-			{
-				num = array.Length - 1;
-			}
-			try
-			{
-				OpenStack(array[num]);
-			}
-			catch (Exception)
-			{
-			}
-		}
-
-		private void btNextStack_Click(object sender, EventArgs e)
-		{
-			CoverViewItem oldItem = stackItem as CoverViewItem;
-			CloseStack(withUpdate: true);
-			CoverViewItem[] array = itemView.DisplayedItems.OfType<CoverViewItem>().ToArray();
-			int num = array.FindIndex((CoverViewItem ci) => (from sci in itemView.GetStackItems(ci).OfType<CoverViewItem>()
-				select sci.Comic).Contains(oldItem.Comic)) + 1;
-			if (num >= array.Length)
-			{
-				num = 0;
-			}
-			try
-			{
-				OpenStack(array[num]);
-			}
-			catch (Exception)
-			{
-			}
-		}
-
-		private void btDisplayAll_Click(object sender, EventArgs e)
-		{
-			ShowOnlyDuplicates = false;
-			ShowOptionType = ComicBookAllPropertiesMatcher.ShowOptionType.All;
-			ShowComicType = ComicBookAllPropertiesMatcher.ShowComicType.All;
-		}
-
-		private void itemView_MouseWheel(object sender, MouseEventArgs e)
-		{
-			if ((Control.ModifierKeys & Keys.Control) != 0 && itemView.ItemViewMode != ItemViewMode.Detail)
-			{
-				ItemSizeInfo itemSize = GetItemSize();
-				SetItemSize(itemSize.Value + e.Delta / SystemInformation.MouseWheelScrollDelta * 16);
-			}
-		}
-
-		private void tbbSort_DropDownOpening(object sender, EventArgs e)
-		{
-			FormUtility.SafeToolStripClear(tbbSort.DropDownItems);
-			itemView.CreateArrangeMenu(tbbSort.DropDownItems);
-		}
-
-		private void tbbGroup_DropDownOpening(object sender, EventArgs e)
-		{
-			FormUtility.SafeToolStripClear(tbbGroup.DropDownItems);
-			itemView.CreateGroupMenu(tbbGroup.DropDownItems);
-		}
-
-		private void tbbGroup_ButtonClick(object sender, EventArgs e)
-		{
-			itemView.GroupSortingOrder = ItemView.FlipSortOrder(itemView.GroupSortingOrder);
-		}
-
-		private void tbbStack_ButtonClick(object sender, EventArgs e)
-		{
-			itemView.ItemStacker = ((itemView.ItemStacker != null) ? null : oldStacker);
-		}
-
-		private void tbbStack_DropDownOpening(object sender, EventArgs e)
-		{
-			FormUtility.SafeToolStripClear(tbbStack.DropDownItems);
-			itemView.CreateStackMenu(tbbStack.DropDownItems);
-		}
-
-		private void tbbSort_ButtonClick(object sender, EventArgs e)
-		{
-			itemView.ItemSortOrder = ItemView.FlipSortOrder(itemView.ItemSortOrder);
-		}
-
-		private void tbbView_ButtonClick(object sender, EventArgs e)
-		{
-			ItemViewMode itemViewMode = itemView.ItemViewMode;
-			switch (itemViewMode)
-			{
-			case ItemViewMode.Thumbnail:
-				itemViewMode = ItemViewMode.Tile;
-				break;
-			case ItemViewMode.Tile:
-				itemViewMode = ItemViewMode.Detail;
-				break;
-			case ItemViewMode.Detail:
-				itemViewMode = ItemViewMode.Thumbnail;
-				break;
-			}
-			itemView.ItemViewMode = itemViewMode;
-		}
-
-		private void tsQuickSearch_TextChanged(object sender, EventArgs e)
-		{
-			QuickSearch = tsQuickSearch.TextBox.Text;
-		}
-
-		private void bookList_BookListRefreshed(object sender, EventArgs e)
-		{
-			OnCurrentBookListChanged();
-		}
-
-		private void bookSelectorPanel_FilterChanged(object sender, EventArgs e)
-		{
-			bookListDirty = true;
-		}
-
-		protected override void OnIdle()
-		{
-			if (base.DesignMode || !base.Visible)
-			{
-				return;
-			}
-			UpdatePending();
-			if (updateGroupList)
-			{
-				updateGroupList = false;
-				FillGroupList();
-			}
-			if (newGroupListWidth != 0 && showGroupHeaders)
-			{
-				int num = browserContainer.ClientRectangle.Width - newGroupListWidth;
-				if (num > 0)
-				{
-					browserContainer.SplitterDistance = num;
-				}
-				newGroupListWidth = 0;
-			}
-			if (quickSearchCueTexts == null)
-			{
-				quickSearchCueTexts = new string[6]
-				{
-					miSearchAll.Text,
-					miSearchSeries.Text,
-					miSearchWriter.Text,
-					miSearchArtists.Text,
-					miSearchDescriptive.Text,
-					miSearchFile.Text
-				};
-				for (int i = 0; i < quickSearchCueTexts.Length; i++)
-				{
-					quickSearchCueTexts[i] = TR.Default["Search", "Search"] + " " + quickSearchCueTexts[i].Replace("&", string.Empty);
-				}
-			}
-			tsQuickSearch.TextBox.SetCueText(quickSearchCueTexts[(int)QuickSearchType]);
-			tbSidebar.Visible = !HideNavigation && base.Main != null && base.Main.Control.FindActiveService<ISidebar>() != null;
-			ToolStripSeparator toolStripSeparator = tbBrowseSeparator;
-			ToolStripButton toolStripButton = btBrowseNext;
-			bool flag2 = (btBrowsePrev.Visible = !HideNavigation && base.Main != null && base.Main.Control.FindActiveService<IBrowseHistory>() != null);
-			bool visible = (toolStripButton.Visible = flag2);
-			toolStripSeparator.Visible = visible;
-			tbbSort.Enabled = itemView.Columns.Count != 0;
-			tbbSort.Text = ((itemView.SortColumn != null) ? itemView.SortColumn.Text : noneText);
-			tbbSort.ToolTipText = ((itemView.SortColumn != null) ? StringUtility.Format(arrangedByText, tbbSort.Text) : notArrangedText);
-			tbbGroup.Enabled = itemView.Columns.Count != 0;
-			tbbGroup.Text = ((itemView.GroupColumn != null) ? itemView.GroupColumn.Text : noneText);
-			tbbGroup.ToolTipText = ((itemView.GroupColumn != null) ? StringUtility.Format(groupedByText, tbbGroup.Text) : notGroupedText);
-			openStackPanel.Visible = stackFilter is StackMatcher;
-			if (openStackPanel.Visible)
-			{
-				currentStackName = ((StackMatcher)stackFilter).Caption;
-				lblOpenStackText.Text = currentStackName;
-			}
-			tbbStack.Visible = itemView.ItemViewMode != ItemViewMode.Detail && !openStackPanel.Visible;
-			if (tbbStack.Visible)
-			{
-				tbbStack.Enabled = itemView.Columns.Count != 0;
-				tbbStack.Text = ((itemView.StackColumn != null) ? itemView.StackColumn.Text : noneText);
-				tbbStack.ToolTipText = ((itemView.StackColumn != null) ? StringUtility.Format(stackedByText, tbbStack.Text) : notStackedText);
-			}
-			if (itemView.ItemStacker != null)
-			{
-				oldStacker = itemView.ItemStacker;
-			}
-			tbbSort.Image = ((itemView.ItemSortOrder == SortOrder.Ascending) ? sortUp : sortDown);
-			tbbGroup.Image = ((itemView.GroupSortingOrder == SortOrder.Ascending) ? groupDown : groupUp);
-			if (tbUndo.Visible)
-			{
-				if (tbUndo.Tag == null)
-				{
-					tbUndo.Tag = tbUndo.Text;
-				}
-				string undoLabel = Program.Database.Undo.UndoLabel;
-				tbUndo.ToolTipText = (string)tbUndo.Tag + (string.IsNullOrEmpty(undoLabel) ? string.Empty : (": " + undoLabel));
-				if (tbRedo.Tag == null)
-				{
-					tbRedo.Tag = tbRedo.Text;
-				}
-				string text = Program.Database.Undo.RedoEntries.FirstOrDefault();
-				tbRedo.ToolTipText = (string)tbRedo.Tag + (string.IsNullOrEmpty(text) ? string.Empty : (": " + text));
-			}
-			OptimizeToolstripDisplay();
-		}
-
-		private void UpdatePending()
-		{
-			if (bookListDirty)
-			{
-				bookListDirty = false;
-				FillBookList();
-			}
-		}
-
-		private void itemView_ItemActivate(object sender, EventArgs e)
-		{
-			IViewableItem focusedItem = itemView.FocusedItem;
-			if (!itemView.IsStack(focusedItem) || itemView.GetStackCount(focusedItem) == 1)
-			{
-				CoverViewItem coverViewItem = focusedItem as CoverViewItem;
-				if (coverViewItem != null && coverViewItem.Comic.IsLinked)
-				{
-					OpenComic();
-				}
-				else
-				{
-					base.Main.ShowInfo();
-				}
-			}
-			else
-			{
-				OpenStack(focusedItem);
-			}
-		}
-
-		private void itemView_PostPaint(object sender, PaintEventArgs e)
-		{
-			e.Graphics.DrawShadow(itemView.DisplayRectangle, 8, Color.Black, 0.125f, BlurShadowType.Inside, BlurShadowParts.Edges);
-		}
-
-		private void searchBrowserContainer_ExpandedChanged(object sender, EventArgs e)
-		{
-			SearchBrowserVisible = searchBrowserContainer.Expanded;
-		}
-
-		private void itemView_SelectedIndexChanged(object sender, EventArgs e)
-		{
-			selectedSize = itemView.SelectedItems.Cast<CoverViewItem>().Sum((CoverViewItem cvi) => Math.Max(cvi.Comic.FileSize, 0L));
-		}
-
-		private void BookInListChanged(object sender, PropertyChangedEventArgs e)
-		{
-			string propertyName = e.PropertyName;
-			if (propertyName == "OpenedTime")
-			{
-				UpdateBookMarkers();
-			}
-		}
-
-		private void itemView_KeyDown(object sender, KeyEventArgs e)
-		{
-			if (e.KeyCode == Keys.Delete)
-			{
-				RemoveBooks();
-			}
-		}
-
-		private void contextMenuItems_Opened(object sender, EventArgs e)
-		{
-			contextMenuMouseLocation = Cursor.Position;
-		}
-
-		private void contextMenuItems_Closed(object sender, ToolStripDropDownClosedEventArgs e)
-		{
-			contextMenuCloseTime = Machine.Ticks;
-		}
-
-		private void quickSearchTimer_Tick(object sender, EventArgs e)
-		{
-			quickSearchTimer.Stop();
-			UpdateSearch();
-		}
-
-		private void itemView_ProcessStack(object sender, ItemView.StackEventArgs e)
-		{
-			if (stacksConfig == null)
-			{
-				return;
-			}
-			StacksConfig.StackConfigItem stackConfigItem = stacksConfig.FindItem(e.Stack.Text);
-			if (stackConfigItem == null)
-			{
-				return;
-			}
-			if (!string.IsNullOrEmpty(stackConfigItem.ThumbnailKey))
-			{
-				ISetCustomThumbnail setCustomThumbnail = e.Stack.Items.FirstOrDefault() as ISetCustomThumbnail;
-				if (setCustomThumbnail != null)
-				{
-					setCustomThumbnail.CustomThumbnailKey = ThumbnailKey.GetResource(ThumbnailKey.CustomKey, stackConfigItem.ThumbnailKey);
-				}
-			}
-			Guid id = stackConfigItem.TopId;
-			if (id != Guid.Empty)
-			{
-				int num = e.Stack.Items.FindIndex((IViewableItem item) => ((CoverViewItem)item).Comic.Id == id);
-				if (num != -1)
-				{
-					IViewableItem item2 = e.Stack.Items[num];
-					e.Stack.Items.RemoveAt(num);
-					e.Stack.Items.Insert(0, item2);
-				}
-			}
-		}
-
-		private void tsQuickSearch_Enter(object sender, EventArgs e)
-		{
-			oldQuickWidth = tsQuickSearch.Width;
-			tsQuickSearch.AutoSize = false;
-			tsQuickSearch.Width *= 2;
-		}
-
-		private void tsQuickSearch_Leave(object sender, EventArgs e)
-		{
-			tsQuickSearch.AutoSize = true;
-			tsQuickSearch.Width = oldQuickWidth;
-		}
-
-		private void itemView_GroupDisplayChanged(object sender, EventArgs e)
-		{
-			updateGroupList = true;
-		}
-
-		private void itemView_ItemDisplayChanged(object sender, EventArgs e)
-		{
-			updateGroupList = true;
-		}
-
-		private void lvGroupHeaders_SelectedIndexChanged(object sender, EventArgs e)
-		{
-			if (lvGroupHeaders.SelectedIndices.Count != 0)
-			{
-				string text = lvGroupHeaders.SelectedItems[0].Text;
-				IViewableItem firstGroupItem = itemView.GetFirstGroupItem(text);
-				if (firstGroupItem != null)
-				{
-					itemView.ExpandGroups(expand: true, text);
-					itemView.EnsureGroupVisible(text);
-				}
-			}
-		}
-
-		private void SetCustomColumns()
-		{
-			Dictionary<int, ItemViewColumn> dictionary = null;
-			if (Library != null && Program.Settings.ShowCustomBookFields)
-			{
-				dictionary = (from customKey in Library.CustomValues
-					where Program.ExtendedSettings.ShowCustomScriptValues || !customKey.Contains('.')
-					select new
-					{
-						Id = 10000 + Math.Abs(customKey.GetHashCode()),
-						Prop = "{" + customKey + "}",
-						Key = customKey
-					} into customField
-					select new ItemViewColumn(customField.Id, customField.Key, 100, new ComicListField(customField.Prop, customFieldDescription.SafeFormat(customField.Key), customField.Prop), new CoverViewItemPropertyComparer(customField.Prop), new CoverViewItemPropertyGrouper(customField.Prop), visible: false)).ToDictionary((ItemViewColumn item) => item.Id);
-			}
-			for (int num = itemView.Columns.Count - 1; num >= 0; num--)
-			{
-				int id = itemView.Columns[num].Id;
-				if (id >= 10000)
-				{
-					if (dictionary != null && dictionary.ContainsKey(id))
-					{
-						dictionary.Remove(id);
-					}
-					else
-					{
-						itemView.Columns.RemoveAt(num);
-					}
-				}
-			}
-			if (dictionary == null)
-			{
-				return;
-			}
-			foreach (ItemViewColumn value in dictionary.Values)
-			{
-				value.TooltipText = ((ComicListField)value.Tag).Description;
-				itemView.Columns.Add(value);
-			}
-		}
-
-		private bool CanReorderList(bool mustBeOrdered = true)
-		{
-			IEditableComicBookListProvider editableComicBookListProvider = BookList.QueryService<IEditableComicBookListProvider>();
-			if (ComicEditMode.CanEditList() && editableComicBookListProvider != null && !editableComicBookListProvider.IsLibrary)
-			{
-				if (mustBeOrdered)
-				{
-					return IsViewSortedByPosition();
-				}
-				return true;
-			}
-			return false;
-		}
-
-		private bool MoveBooks(IEnumerable<ComicBook> books, bool bottom)
-		{
-			if (!CanReorderList())
-			{
-				return false;
-			}
-			IEditableComicBookListProvider editableComicBookListProvider = BookList.QueryService<IEditableComicBookListProvider>();
-			ComicBook[] source = books.Where(editableComicBookListProvider.Remove).ToArray();
-			if (bottom)
-			{
-				foreach (ComicBook book in books)
-				{
-					editableComicBookListProvider.Add(book);
-				}
-			}
-			else
-			{
-				foreach (ComicBook item in source.Reverse())
-				{
-					editableComicBookListProvider.Insert(0, item);
-				}
-			}
-			return true;
-		}
-
-		private void ApplyBookOrder(IEnumerable<ComicBook> books)
-		{
-			if (!CanReorderList(mustBeOrdered: false))
-			{
-				return;
-			}
-			books = books.ToArray();
-			IEditableComicBookListProvider editableComicBookListProvider = BookList.QueryService<IEditableComicBookListProvider>();
-			ComicBook[] source = books.Where(editableComicBookListProvider.Remove).ToArray();
-			foreach (ComicBook item in source.Reverse())
-			{
-				editableComicBookListProvider.Insert(0, item);
-			}
-		}
-
-		private bool AllSelectedLinked()
-		{
-			return GetBookList(ComicBookFilterType.Selected).All((ComicBook cb) => cb.IsLinked);
-		}
-
-		private bool AnySelectedLinked()
-		{
-			return GetBookList(ComicBookFilterType.Selected).Any((ComicBook cb) => cb.IsLinked);
-		}
-
-		private void OptimizeToolstripDisplay()
-		{
-			IEnumerable<ToolStripItem> source = toolStrip.Items.OfType<ToolStripItem>();
-			int num = source.Sum((ToolStripItem n) => n.Width);
-			int num2 = toolStrip.Width - 20;
-			if (num2 == savedOptimizeToolstripRight && num == savedOptimizeToolstripWitdh)
-			{
-				return;
-			}
-			if (num > num2)
-			{
-				SaveStyleSet(ToolStripItemDisplayStyle.Image, tbbView, tbbGroup, tbbSort, tbbStack);
-			}
-			if (num < num2)
-			{
-				SaveStyleSet(ToolStripItemDisplayStyle.ImageAndText, tbbView, tbbGroup, tbbSort, tbbStack);
-				num = source.Sum((ToolStripItem n) => n.Width);
-				if (num > num2)
-				{
-					SaveStyleSet(ToolStripItemDisplayStyle.Image, tbbView, tbbGroup, tbbSort, tbbStack);
-				}
-			}
-			savedOptimizeToolstripRight = num2;
-			savedOptimizeToolstripWitdh = source.Sum((ToolStripItem n) => n.Width);
-		}
-
-		private static void SaveStyleSet(ToolStripItemDisplayStyle style, params ToolStripItem[] items)
-		{
-			foreach (ToolStripItem toolStripItem in items)
-			{
-				if (toolStripItem.DisplayStyle != style)
-				{
-					toolStripItem.DisplayStyle = style;
-				}
-			}
-		}
-
-		private void SetSelectedComicAsListBackground()
-		{
-			ComicBook comicBook = GetBookList(ComicBookFilterType.Selected).FirstOrDefault();
-			if (comicBook != null)
-			{
-				SetListBackgroundImage(comicBook);
-			}
-		}
-
-		private void ResetListBackgroundImage()
-		{
-			SetListBackgroundImage((string)null);
-		}
-
-		private void SetTopOfStack()
-		{
-			ComicBook comicBook = GetBookList(ComicBookFilterType.Selected).FirstOrDefault();
-			if (comicBook != null)
-			{
-				if (stacksConfig == null)
-				{
-					stacksConfig = new StacksConfig();
-				}
-				stacksConfig.SetStackTop(currentStackName, comicBook);
-			}
-		}
-
-		private void SetStackThumbnail()
-		{
-			IViewableItem viewableItem = itemView.SelectedItems.FirstOrDefault();
-			if (viewableItem == null || !itemView.IsStack(viewableItem))
-			{
-				return;
-			}
-			viewableItem = itemView.GetStackItems(viewableItem).FirstOrDefault();
-			string text = Program.LoadCustomThumbnail(null, this, miSetStackThumbnail.Text.Replace("&", string.Empty));
-			if (text != null)
-			{
-				if (stacksConfig == null)
-				{
-					stacksConfig = new StacksConfig();
-				}
-				stacksConfig.SetStackThumbnailKey(itemView.GetStackCaption(viewableItem), text);
-				FillBookList();
-			}
-		}
-
-		private void RemoveStackThumbnail()
-		{
-			IViewableItem viewableItem = itemView.SelectedItems.FirstOrDefault();
-			if (viewableItem != null && itemView.IsStack(viewableItem))
-			{
-				stacksConfig.SetStackThumbnailKey(itemView.GetStackCaption(viewableItem), null);
-				FillBookList();
-			}
-		}
-
-		private void CloseStack(bool withUpdate)
-		{
-			using (new WaitCursor(this))
-			{
-				if (stackFilter == null)
-				{
-					return;
-				}
-				stackItem = null;
-				if (withUpdate)
-				{
-					ItemView.BeginUpdate();
-					try
-					{
-						if (stacksConfig != null)
-						{
-							stacksConfig.SetStackViewConfig(Program.Settings.CommonListStackLayout ? BookList.Name : currentStackName, itemView.ViewConfig);
-						}
-						itemView.StackDisplayEnabled = true;
-						if (preStackConfig != null)
-						{
-							itemView.ViewConfig = preStackConfig;
-						}
-						stackFilter = null;
-						FillBookList();
-					}
-					finally
-					{
-						itemView.EndUpdate();
-						itemView.ScrollPosition = preStackScrollPosition;
-					}
-				}
-				else
-				{
-					itemView.ItemStacker = ((StackMatcher)stackFilter).Grouper;
-					stackFilter = null;
-				}
-			}
-		}
-
-		private void OpenStack(IViewableItem item)
-		{
-			OpenStack(item, storeConfig: true);
-		}
-
-		private void OpenStack(IViewableItem item, bool storeConfig)
-		{
-			using (new WaitCursor(this))
-			{
-				if (item == null)
-				{
-					return;
-				}
-				itemView.BeginUpdate();
-				try
-				{
-					stackItem = item;
-					HashSet<ComicBook> hashSet = new HashSet<ComicBook>();
-					IViewableItem[] stackItems = itemView.GetStackItems(item);
-					for (int i = 0; i < stackItems.Length; i++)
-					{
-						CoverViewItem coverViewItem = (CoverViewItem)stackItems[i];
-						hashSet.Add(coverViewItem.Comic);
-					}
-					string stackCaption = itemView.GetStackCaption(item);
-					stackFilter = new StackMatcher(itemView.ItemStacker, stackCaption, hashSet);
-					if (storeConfig)
-					{
-						preStackConfig = itemView.ViewConfig;
-						preStackScrollPosition = itemView.ScrollPosition;
-						preStackFocusedId = GetFocusedId();
-					}
-					itemView.ItemStacker = null;
-					if (stacksConfig == null)
-					{
-						stacksConfig = new StacksConfig();
-					}
-					ItemViewConfig stackViewConfig = stacksConfig.GetStackViewConfig(Program.Settings.CommonListStackLayout ? BookList.Name : stackCaption);
-					if (stackViewConfig != null)
-					{
-						itemView.ViewConfig = stackViewConfig;
-					}
-					itemView.StackDisplayEnabled = false;
-					FillBookList();
-				}
-				finally
-				{
-					itemView.EndUpdate();
-				}
-			}
-		}
-
-		private void RegisterBookList()
-		{
-			if (bookList == null)
-			{
-				return;
-			}
-			IDisplayListConfig displayListConfig = bookList.QueryService<IDisplayListConfig>();
-			ResetListBackgroundImage();
-			if (displayListConfig != null && displayListConfig.Display != null)
-			{
-				stacksConfig = CloneUtility.Clone(displayListConfig.Display.StackConfig);
-				itemView.ViewConfig = displayListConfig.Display.View;
-				ThumbnailConfig = displayListConfig.Display.Thumbnail;
-				if (Program.Settings.LocalQuickSearch)
-				{
-					blockQuickSearchUpdate = true;
-					ShowOptionType = displayListConfig.Display.ShowOptionType;
-					ShowComicType = displayListConfig.Display.ShowComicType;
-					ShowOnlyDuplicates = displayListConfig.Display.ShowOnlyDuplicates;
-					QuickSearchType = displayListConfig.Display.QuickSearchType;
-					QuickSearch = displayListConfig.Display.QuickSearch;
-					blockQuickSearchUpdate = false;
-					ShowGroupHeaders = displayListConfig.Display.ShowGroupHeaders;
-					newGroupListWidth = displayListConfig.Display.ShowGroupHeadersWidth;
-				}
-				UpdateQuickFilter();
-				if (displayListConfig.Display.View == null && bookList.QueryService<IEditableComicBookListProvider>() != null)
-				{
-					itemView.ItemGrouper = null;
-					itemView.SortColumn = itemView.Columns.FindById(100);
-				}
-				SetListBackgroundImage(displayListConfig.Display.BackgroundImageSource);
-			}
-			bookList.BookListChanged += bookList_BookListRefreshed;
-		}
-
-		private void UnregisterBookList()
-		{
-			itemView.FocusedItem = null;
-			StoreWorkspace(null);
-			CloseStack(withUpdate: true);
-			if (bookList != null)
-			{
-				bookList.BookListChanged -= bookList_BookListRefreshed;
-			}
-		}
-
-		private void FillBookSelector()
-		{
-			FillBookSelector(GetCurrentList(withSelector: false), updateNow: true);
-		}
-
-		private void FillBookSelector(IEnumerable<ComicBook> books, bool updateNow)
-		{
-			bookSelectorPanel.Books.Clear();
-			if (searchBrowserVisible && BookList != null)
-			{
-				bookSelectorPanel.Books.AddRange(books);
-			}
-			if (updateNow)
-			{
-				bookSelectorPanel.UpdateLists();
-			}
-		}
-
-		private IEnumerable<ComicBook> GetCurrentList(bool withSelector)
-		{
-			if (BookList == null)
-			{
-				return Enumerable.Empty<ComicBook>();
-			}
-			ComicBookGroupMatcher currentMatcher = GetCurrentMatcher(withStack: true, withSelector);
-			IEnumerable<ComicBook> books = BookList.GetBooks();
-			if (currentMatcher != null)
-			{
-				return currentMatcher.Match(books);
-			}
-			return books;
-		}
-
-		private ComicBookGroupMatcher GetCurrentMatcher(bool withStack, bool withSelector)
-		{
-			ComicBookGroupMatcher comicBookGroupMatcher = new ComicBookGroupMatcher();
-			if (stackFilter != null && withStack)
-			{
-				comicBookGroupMatcher.Matchers.Add(stackFilter);
-			}
-			if (quickFilter != null)
-			{
-				comicBookGroupMatcher.Matchers.Add(quickFilter);
-			}
-			if (bookSelectorPanel.CurrentMatcher != null && withSelector)
-			{
-				comicBookGroupMatcher.Matchers.Add(bookSelectorPanel.CurrentMatcher);
-			}
-			if (ShowOnlyDuplicates)
-			{
-				comicBookGroupMatcher.Matchers.Add(new ComicBookDuplicateMatcher());
-			}
-			return comicBookGroupMatcher;
-		}
-
-		private void FillBookList()
-		{
-			IViewableItem focusedItem = itemView.FocusedItem;
-			int num = itemView.FocusedItemDisplayIndex;
-			ComicBookGroupMatcher currentMatcher = GetCurrentMatcher(withStack: true, withSelector: false);
-			ComicBookMatcher currentMatcher2 = bookSelectorPanel.CurrentMatcher;
-			ComicBook comicBook = ((focusedItem != null) ? ((CoverViewItem)focusedItem).Comic : null);
-			itemView.BeginUpdate();
-			try
-			{
-				int num2 = 1;
-				itemView.Items.Clear();
-				totalCount = 0;
-				totalSize = 0L;
-				selectedSize = 0L;
-				if (BookList != null)
-				{
-					ComicBook[] array = BookList.GetBooks().ToArray();
-					IComicBookStatsProvider statsProvider = BookList as IComicBookStatsProvider;
-					IEnumerable<ComicBook> enumerable = currentMatcher.Match(array).ToArray();
-					totalCount = array.Length;
-					FillBookSelector(enumerable, updateNow: true);
-					if (currentMatcher2 != null)
-					{
-						enumerable = currentMatcher2.Match(enumerable);
-					}
-					foreach (ComicBook item in enumerable)
-					{
-						CoverViewItem coverViewItem = CoverViewItem.Create(item, num2++, statsProvider);
-						coverViewItem.BookChanged += BookInListChanged;
-						itemView.Items.Add(coverViewItem);
-						totalSize += Math.Max(item.FileSize, 0L);
-					}
-					UpdateBookMarkers();
-				}
-				if (comicBook == null || itemView.Items.Count == 0)
-				{
-					return;
-				}
-				foreach (CoverViewItem displayedItem in itemView.DisplayedItems)
-				{
-					IViewableItem[] stackItems = itemView.GetStackItems(displayedItem);
-					for (int i = 0; i < stackItems.Length; i++)
-					{
-						CoverViewItem coverViewItem3 = (CoverViewItem)stackItems[i];
-						if (coverViewItem3.Comic == comicBook)
-						{
-							displayedItem.Selected = true;
-							displayedItem.Focused = true;
-							itemView.EnsureItemVisible(displayedItem);
-							return;
-						}
-					}
-				}
-				if (num < 0)
-				{
-					return;
-				}
-				if (num >= itemView.DisplayedItems.Count())
-				{
-					num = itemView.DisplayedItems.Count() - 1;
-				}
-				foreach (CoverViewItem displayedItem2 in itemView.DisplayedItems)
-				{
-					if (num == 0)
-					{
-						displayedItem2.Selected = true;
-						displayedItem2.Focused = true;
-						itemView.EnsureItemVisible(displayedItem2);
-						break;
-					}
-					num--;
-				}
-			}
-			catch (Exception)
-			{
-			}
-			finally
-			{
-				itemView.EndUpdate();
-				updateGroupList = true;
-			}
-		}
-
-		private void FillGroupList()
-		{
-			if (showGroupHeaders && itemView.AreGroupsVisible)
-			{
-				lvGroupHeaders.BeginUpdate();
-				IColumn column = itemView.Columns.FirstOrDefault((IColumn c) => c.ColumnGrouper == itemView.ItemGrouper);
-				lvGroupsName.Text = ((column == null) ? string.Empty : column.Text);
-				lvGroupHeaders.Items.Clear();
-				foreach (string displayedGroup in itemView.DisplayedGroups)
-				{
-					lvGroupHeaders.Items.Add(displayedGroup).SubItems.Add(itemView.GetGroupSizeFromCaption(displayedGroup).ToString());
-				}
-				lvGroupHeaders.EndUpdate();
-				browserContainer.Panel2Collapsed = false;
-			}
-			else
-			{
-				browserContainer.Panel2Collapsed = true;
-			}
-		}
-
-		public IEnumerable<ComicBook> GetOpenBooks()
-		{
-			try
-			{
-				return from nav in base.Main.OpenBooks.Slots
-					where nav != null
-					select nav.Comic;
-			}
-			catch (NullReferenceException)
-			{
-				return Enumerable.Empty<ComicBook>();
-			}
-		}
-
-		private void UpdateBookMarkers()
-		{
-			DateTime t = DateTime.MinValue;
-			ComicBook comicBook = null;
-			foreach (CoverViewItem item in itemView.Items)
-			{
-				if (t < item.Comic.OpenedTime)
-				{
-					t = item.Comic.OpenedTime;
-					comicBook = item.Comic;
-				}
-			}
-			IEnumerable<ComicBook> openBooks = GetOpenBooks();
-			foreach (CoverViewItem item2 in itemView.Items)
-			{
-				item2.Marker = ((item2.Comic == comicBook) ? MarkerType.IsLast : MarkerType.None);
-				item2.Marker = (openBooks.Contains(item2.Comic) ? MarkerType.IsOpen : item2.Marker);
-			}
-		}
-
-		private void AddFilesToLibrary()
-		{
-			Program.Scanner.ScanFilesOrFolders(from cb in GetBookList(ComicBookFilterType.NotInLibrary | ComicBookFilterType.IsNotFileless | ComicBookFilterType.Selected, asArray: true)
-				select cb.FilePath, all: false, removeMissing: false);
-		}
-
-		private void DuplicateList(ComicListItemFolder clif = null)
-		{
-			if (Library == null || !Library.EditMode.CanEditList())
-			{
-				return;
-			}
-			ComicBookGroupMatcher currentMatcher = GetCurrentMatcher(withStack: false, withSelector: true);
-			if (currentMatcher == null || currentMatcher.Matchers.Count == 0)
-			{
-				return;
-			}
-			string name = string.Empty;
-			ComicSmartListItem comicSmartListItem = new ComicSmartListItem("")
-			{
-				BaseListId = BookList.Id,
-				MatcherMode = currentMatcher.MatcherMode
-			};
-			foreach (ComicBookMatcher matcher in currentMatcher.Matchers)
-			{
-				comicSmartListItem.Matchers.Add(matcher.Clone() as ComicBookMatcher);
-			}
-			foreach (ComicBookValueMatcher item in comicSmartListItem.Matchers.Recurse<ComicBookValueMatcher>((object cbm) => (!(cbm is ComicBookGroupMatcher)) ? null : ((ComicBookGroupMatcher)cbm).Matchers))
-			{
-				string text = item.MatchValue.Trim();
-				if (!string.IsNullOrEmpty(text))
-				{
-					if (!string.IsNullOrEmpty(name))
-					{
-						name += "/";
-					}
-					name += text;
-				}
-			}
-			if (string.IsNullOrEmpty(name))
-			{
-				name = NumberedString.StripNumber(BookList.Name);
-			}
-			int number = NumberedString.MaxNumber(from cli in Library.ComicLists.GetItems<ComicListItem>()
-				where NumberedString.StripNumber(cli.Name) == name
-				select cli.Name);
-			comicSmartListItem.Name = NumberedString.Format(name, number);
-			if (clif == null)
-			{
-				Library.TemporaryFolder.Items.Add(comicSmartListItem);
-			}
-			else
-			{
-				clif.Items.Add(comicSmartListItem);
-			}
-		}
-
-		private void SetListBackgroundImage(ComicBook cb)
-		{
-			SetListBackgroundImage(cb?.Id.ToString());
-		}
-
-		private void SetListBackgroundImage(string source)
-		{
-			backgroundImageSource = source;
-			try
-			{
-				ThreadUtility.RunInBackground("Create library backdrop", delegate
-				{
-					bool flag = false;
-					try
-					{
-						if (!base.IsDisposed && source != null)
-						{
-							ComicBook comicBook = Library.Books[new Guid(source)];
-							if (comicBook != null)
-							{
-								using (IItemLock<ThumbnailImage> itemLock = Program.ImagePool.GetThumbnail(comicBook.GetFrontCoverThumbnailKey(), comicBook))
-								{
-									Bitmap bitmap = ComicBox3D.CreateDefaultBook(itemLock.Item.Bitmap, null, EngineConfiguration.Default.ListCoverSize, comicBook.PageCount);
-									bitmap.ChangeAlpha(EngineConfiguration.Default.ListCoverAlpha);
-									SetListBackgroundImage(bitmap);
-									flag = true;
-								}
-							}
-						}
-					}
-					catch (Exception)
-					{
-					}
-					finally
-					{
-						if (!flag)
-						{
-							SetListBackgroundImage();
-						}
-					}
-				});
-			}
-			catch
-			{
-				SetListBackgroundImage();
-			}
-		}
-
-		private void SetListBackgroundImage(Image image)
-		{
-			if (!itemView.BeginInvokeIfRequired(delegate
-			{
-				SetListBackgroundImage(image);
-			}) && itemView.BackgroundImage != image)
-			{
-				if (itemView.BackgroundImage != null && itemView.BackgroundImage != ListBackgroundImage)
-				{
-					Image backgroundImage = itemView.BackgroundImage;
-					itemView.BackgroundImage = null;
-					backgroundImage.Dispose();
-				}
-				if (image != null && itemView.BackColor.GetBrightness() >= 0.95f)
-				{
-					itemView.BackgroundImage = image;
-					itemView.BackgroundImageAlignment = System.Drawing.ContentAlignment.BottomRight;
-				}
-			}
-		}
-
-		private void SetListBackgroundImage()
-		{
-			SetListBackgroundImage(ListBackgroundImage);
-		}
-
-		private void bookSelectorPanel_ItemDrag(object sender, ItemDragEventArgs e)
-		{
-			if (ComicEditMode.CanEditList())
-			{
-				Control control = (Control)sender;
-				control.DoDragDrop(e.Item, DragDropEffects.Copy);
-			}
-		}
-
-		private void DragGiveDragCursorFeedback(object sender, GiveFeedbackEventArgs e)
-		{
-			if (dragCursor != null && !(dragCursor.Cursor == null))
-			{
-				e.UseDefaultCursors = false;
-				dragCursor.OverlayCursor = ((e.Effect == DragDropEffects.None) ? Cursors.No : Cursors.Default);
-				dragCursor.OverlayEffect = ((e.Effect == DragDropEffects.Copy) ? BitmapCursorOverlayEffect.Plus : BitmapCursorOverlayEffect.None);
-				Cursor.Current = dragCursor.Cursor;
-			}
-		}
-
-		private void DragQueryContinueDrag(object sender, QueryContinueDragEventArgs e)
-		{
-			if (e.Action == DragAction.Drop)
-			{
-				Cursor.Current = Cursors.WaitCursor;
-			}
-		}
-
-		private void itemView_ItemDrag(object sender, ItemDragEventArgs e)
-		{
-			if (!ComicEditMode.CanEditList())
-			{
-				return;
-			}
-			ComicBookContainer comicBookContainer = new ComicBookContainer();
-			ComicBookGroupMatcher comicBookGroupMatcher = new ComicBookGroupMatcher();
-			comicBookContainer.Books.AddRange(GetBookList(ComicBookFilterType.Selected));
-			if (comicBookContainer.Books.Count == 0)
-			{
-				return;
-			}
-			if (itemView.IsStacked)
-			{
-				IViewableItem[] array = itemView.SelectedItems.Where((IViewableItem si) => itemView.IsStack(si)).ToArray();
-				comicBookContainer.Name = array.Select((IViewableItem si) => itemView.GetStackCaption(si)).FirstOrDefault();
-				SingleComicGrouper[] array2 = (from bg in itemView.ItemStacker.GetGroupers().OfType<IBookGrouper>()
-					select bg.BookGrouper).OfType<SingleComicGrouper>().ToArray();
-				IViewableItem[] array3 = array;
-				foreach (IViewableItem item in array3)
-				{
-					ComicBookGroupMatcher comicBookGroupMatcher2 = new ComicBookGroupMatcher
-					{
-						MatcherMode = MatcherMode.And
-					};
-					IGroupInfo stackGroupInfo = itemView.GetStackGroupInfo(item);
-					IEnumerable<IGroupInfo> source;
-					if (!(stackGroupInfo is ICompoundGroupInfo))
-					{
-						source = ListExtensions.AsEnumerable<IGroupInfo>(stackGroupInfo);
-					}
-					else
-					{
-						IEnumerable<IGroupInfo> infos = ((ICompoundGroupInfo)stackGroupInfo).Infos;
-						source = infos;
-					}
-					IGroupInfo[] array4 = source.ToArray();
-					for (int j = 0; j < array2.Length; j++)
-					{
-						ComicBookMatcher comicBookMatcher = array2[j].CreateMatcher(array4[j]);
-						if (comicBookMatcher != null)
-						{
-							comicBookGroupMatcher2.Matchers.Add(comicBookMatcher);
-						}
-					}
-					if (comicBookGroupMatcher2.Matchers.Count > 1)
-					{
-						comicBookGroupMatcher.Matchers.Add(comicBookGroupMatcher2);
-					}
-					else if (comicBookGroupMatcher2.Matchers.Count == 1)
-					{
-						comicBookGroupMatcher.Matchers.Add(comicBookGroupMatcher2.Matchers[0]);
-					}
-				}
-			}
-			dragCursor = itemView.GetDragCursor(Program.ExtendedSettings.DragDropCursorAlpha);
-			try
-			{
-				IEditableComicBookListProvider editableComicBookListProvider = BookList.QueryService<IEditableComicBookListProvider>();
-				bool flag = editableComicBookListProvider != null;
-				bool flag2 = editableComicBookListProvider?.IsLibrary ?? false;
-				bool flag3 = !flag2 && flag;
-				DragDropEffects dragDropEffects = DragDropEffects.Copy;
-				itemView.AllowDrop = !flag2 && flag && IsViewSortedByPosition();
-				if (flag3)
-				{
-					dragDropEffects |= DragDropEffects.Move;
-				}
-				DataObject dataObject = new DataObject();
-				dataObject.SetData(comicBookContainer);
-				StringCollection stringCollection = new StringCollection();
-				stringCollection.AddRange(comicBookContainer.GetBookFiles().ToArray());
-				dataObject.SetFileDropList(stringCollection);
-				if (comicBookGroupMatcher.Matchers.Count > 0)
-				{
-					dataObject.SetData(ComicBookMatcher.ClipboardFormat, (comicBookGroupMatcher.Matchers.Count == 1) ? comicBookGroupMatcher.Matchers[0] : comicBookGroupMatcher);
-				}
-				ownDrop = false;
-				DragDropEffects dragDropEffects2 = itemView.DoDragDrop(dataObject, dragDropEffects);
-				if (dragDropEffects2 != DragDropEffects.Move || editableComicBookListProvider == null || ownDrop)
-				{
-					return;
-				}
-				foreach (ComicBook book in comicBookContainer.Books)
-				{
-					editableComicBookListProvider.Remove(book);
-				}
-			}
-			finally
-			{
-				if (dragCursor != null)
-				{
-					dragCursor.Dispose();
-					dragCursor = null;
-				}
-				itemView.AllowDrop = true;
-			}
-		}
-
-		private bool CreateDragContainter(DragEventArgs e)
-		{
-			if (dragBookContainer == null)
-			{
-				dragBookContainer = DragDropContainer.Create(e.Data);
-			}
-			return dragBookContainer.IsValid;
-		}
-
-		private void InsertBooksIntoToList(IEditableComicBookListProvider list, int index)
-		{
-			if (list == null)
-			{
-				return;
-			}
-			if (list.IsLibrary && dragBookContainer.IsFilesContainer)
-			{
-				Program.Scanner.ScanFilesOrFolders(dragBookContainer.FilesOrFolders, all: true, removeMissing: false);
-			}
-			else
-			{
-				if (!dragBookContainer.IsBookContainer)
-				{
-					return;
-				}
-				foreach (ComicBook book in dragBookContainer.Books.GetBooks())
-				{
-					ComicBook comicBook = Program.BookFactory.Create(book.FilePath, CreateBookOption.AddToStorage);
-					if (comicBook != null)
-					{
-						if (index != -1)
-						{
-							index = list.Insert(index, comicBook) + 1;
-						}
-						else
-						{
-							list.Add(comicBook);
-						}
-					}
-				}
-				FillBookList();
-			}
-		}
-
-		private bool IsViewSortedByPosition()
-		{
-			if (itemView.SortColumn != null && itemView.SortColumn.Id == 100 && itemView.ItemSortOrder == SortOrder.Ascending && itemView.GroupColumn == null)
-			{
-				return !itemView.IsStacked;
-			}
-			return false;
-		}
-
-		private void SetDropEffects(DragEventArgs e)
-		{
-			IEditableComicBookListProvider editableComicBookListProvider = BookList.QueryService<IEditableComicBookListProvider>();
-			e.Effect = DragDropEffects.None;
-			if (ComicEditMode.CanEditList() && editableComicBookListProvider != null && CreateDragContainter(e))
-			{
-				if (dragCursor != null && IsViewSortedByPosition())
-				{
-					e.Effect = DragDropEffects.Move;
-				}
-				else if (editableComicBookListProvider.IsLibrary && dragBookContainer.IsFilesContainer)
-				{
-					e.Effect = DragDropEffects.Link;
-				}
-				else
-				{
-					e.Effect = e.AllowedEffect;
-				}
-			}
-			if (e.Effect == DragDropEffects.None)
-			{
-				itemView.MarkerVisible = false;
-				return;
-			}
-			Point pt = itemView.PointToClient(new Point(e.X, e.Y));
-			CoverViewItem coverViewItem = itemView.ItemHitTest(pt) as CoverViewItem;
-			if (coverViewItem != null && IsViewSortedByPosition() && dragBookContainer.IsBookContainer)
-			{
-				itemView.MarkerItem = coverViewItem;
-				itemView.MarkerVisible = true;
-			}
-			else
-			{
-				itemView.MarkerVisible = false;
-			}
-		}
-
-		private void itemView_DragEnter(object sender, DragEventArgs e)
-		{
-			SetDropEffects(e);
-		}
-
-		private void itemView_DragOver(object sender, DragEventArgs e)
-		{
-			SetDropEffects(e);
-		}
-
-		private void itemView_DragDrop(object sender, DragEventArgs e)
-		{
-			Point pt = itemView.PointToClient(new Point(e.X, e.Y));
-			CoverViewItem coverViewItem = itemView.ItemHitTest(pt) as CoverViewItem;
-			int index = -1;
-			if (coverViewItem != null && IsViewSortedByPosition())
-			{
-				index = coverViewItem.Position - 1;
-			}
-			InsertBooksIntoToList(BookList.QueryService<IEditableComicBookListProvider>(), index);
-			itemView.MarkerVisible = false;
-			dragBookContainer = null;
-			ownDrop = true;
-		}
-
-		private void itemView_DragLeave(object sender, EventArgs e)
-		{
-			itemView.MarkerVisible = false;
-			dragBookContainer = null;
-		}
-
-		public virtual ItemSizeInfo GetItemSize()
-		{
-			switch (itemView.ItemViewMode)
-			{
-			case ItemViewMode.Thumbnail:
-				return new ItemSizeInfo(FormUtility.ScaleDpiY(Program.MinThumbHeight), FormUtility.ScaleDpiY(Program.MaxThumbHeight), itemView.ItemThumbSize.Height);
-			case ItemViewMode.Tile:
-				return new ItemSizeInfo(FormUtility.ScaleDpiY(Program.MinTileHeight), FormUtility.ScaleDpiY(Program.MaxTileHeight), itemView.ItemTileSize.Height);
-			case ItemViewMode.Detail:
-				return new ItemSizeInfo(FormUtility.ScaleDpiY(Program.MinRowHeight), FormUtility.ScaleDpiY(Program.MaxRowHeight), itemView.ItemRowHeight);
-			default:
-				return null;
-			}
-		}
-
-		public void SetItemSize(int height)
-		{
-			switch (itemView.ItemViewMode)
-			{
-			case ItemViewMode.Thumbnail:
-				height = height.Clamp(FormUtility.ScaleDpiY(Program.MinThumbHeight), FormUtility.ScaleDpiY(Program.MaxThumbHeight));
-				itemView.ItemThumbSize = new Size(height, height);
-				break;
-			case ItemViewMode.Tile:
-				height = height.Clamp(FormUtility.ScaleDpiY(Program.MinTileHeight), FormUtility.ScaleDpiY(Program.MaxTileHeight));
-				itemView.ItemTileSize = new Size(height * 2, height);
-				break;
-			case ItemViewMode.Detail:
-				height = height.Clamp(FormUtility.ScaleDpiY(Program.MinRowHeight), FormUtility.ScaleDpiY(Program.MaxRowHeight));
-				itemView.ItemRowHeight = height;
-				break;
-			}
-		}
-
-		public Guid GetBookListId()
-		{
-			if (BookList != null)
-			{
-				return BookList.Id;
-			}
-			return Guid.Empty;
-		}
-
-		public void RefreshInformation()
-		{
-			IEnumerable<CoverViewItem> enumerable = from CoverViewItem cvi in new List<IViewableItem>(itemView.SelectedItems)
-				where cvi.Comic.IsInContainer
-				select cvi;
-			foreach (CoverViewItem item in enumerable)
-			{
-				if (item.Comic.IsDynamicSource)
-				{
-					base.Main.UpdateWebComic(item.Comic, fullRefresh: true);
-				}
-				else
-				{
-					item.RefreshImage();
-				}
-			}
-			if (ComicEditMode.CanScan())
-			{
-				Program.Scanner.ScanFilesOrFolders(enumerable.Select((CoverViewItem cvi) => cvi.Comic.FilePath), all: false, removeMissing: false);
-			}
-		}
-
-		public void MarkSelectedRead()
-		{
-			foreach (ComicBook book in GetBookList(ComicBookFilterType.Library | ComicBookFilterType.Selected, asArray: true))
-			{
-				book.MarkAsRead();
-			}
-		}
-
-		public void MarkSelectedNotRead()
-		{
-			foreach (ComicBook book in GetBookList(ComicBookFilterType.Library | ComicBookFilterType.Selected, asArray: true))
-			{
-				book.MarkAsNotRead();
-			}
-		}
-
-		public void MarkSelectedChecked()
-		{
-			foreach (ComicBook book in GetBookList(ComicBookFilterType.Library | ComicBookFilterType.Selected, asArray: true))
-			{
-				book.Checked = true;
-			}
-		}
-
-		public void MarkSelectedUnchecked()
-		{
-			foreach (ComicBook book in GetBookList(ComicBookFilterType.Library | ComicBookFilterType.Selected, asArray: true))
-			{
-				book.Checked = false;
-			}
-		}
-
-		public void ShowWeb()
-		{
-			CoverViewItem coverViewItem = itemView.FocusedItem as CoverViewItem;
-			if (coverViewItem != null && !string.IsNullOrEmpty(coverViewItem.Comic.Web))
-			{
-				Program.StartDocument(coverViewItem.Comic.Web);
-			}
-		}
-
-		public void OpenComic()
-		{
-			CoverViewItem coverViewItem = itemView.FocusedItem as CoverViewItem;
-			if (coverViewItem != null && base.Main != null)
-			{
-				coverViewItem.Comic.LastOpenedFromListId = BookList.Id;
-				base.Main.OpenBooks.Open(coverViewItem.Comic, Program.Settings.OpenInNewTab ^ ((Control.ModifierKeys & Keys.Control) != 0 || (itemView.ActivateButton & MouseButtons.Middle) != 0));
-			}
-		}
-
-		public void OpenComicNewTab()
-		{
-			CoverViewItem coverViewItem = itemView.FocusedItem as CoverViewItem;
-			if (coverViewItem != null && base.Main != null)
-			{
-				coverViewItem.Comic.LastOpenedFromListId = BookList.Id;
-				base.Main.OpenBooks.Open(coverViewItem.Comic, inNewSlot: true);
-			}
-		}
-
-		public void EditItem()
-		{
-			if (itemView.LabelEdit && itemView.ItemViewMode == ItemViewMode.Detail && itemView.SelectedCount != 0)
-			{
-				if (Machine.Ticks - contextMenuCloseTime < 250)
-				{
-					itemView.EditItem(contextMenuMouseLocation);
-				}
-				else
-				{
-					itemView.EditItem(itemView.SelectedItems.FirstOrDefault());
-				}
-			}
-		}
-
-		public void CopyListSetup()
-		{
-			Clipboard.SetDataObject(new DisplayListConfig(ViewConfig, ThumbnailConfig, null, stacksConfig, backgroundImageSource));
-		}
-
-		public void PasteListSetup()
-		{
-			try
-			{
-				IDataObject dataObject = Clipboard.GetDataObject();
-				if (dataObject != null)
-				{
-					DisplayListConfig displayListConfig = dataObject.GetData(typeof(DisplayListConfig)) as DisplayListConfig;
-					if (displayListConfig != null)
-					{
-						itemView.ViewConfig = displayListConfig.View;
-						ThumbnailConfig = displayListConfig.Thumbnail;
-						stacksConfig = displayListConfig.StackConfig;
-						FillBookList();
-						SetListBackgroundImage(displayListConfig.BackgroundImageSource);
-					}
-				}
-			}
-			catch
-			{
-			}
-		}
-
-		public void RevealInExplorer()
-		{
-			ComicBook comicBook = GetBookList(ComicBookFilterType.IsNotFileless | ComicBookFilterType.Selected).FirstOrDefault();
-			if (comicBook != null)
-			{
-				Program.ShowExplorer(comicBook.FilePath);
-			}
-		}
-
-		public void ShowBook(ComicBook comicBook)
-		{
-			foreach (CoverViewItem item in itemView.Items)
-			{
-				if (item.Comic == comicBook)
-				{
-					item.Selected = true;
-					item.Focused = true;
-					item.EnsureVisible();
-					break;
-				}
-			}
-		}
-
-		public void UpdateQuickFilter()
-		{
-			quickFilter = null;
-			if (QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.All)
-			{
-				try
-				{
-					string text = QuickSearch?.Trim() ?? "";
-					if (text.StartsWith("NOT", StringComparison.OrdinalIgnoreCase) || text.StartsWith("MATCH", StringComparison.OrdinalIgnoreCase))
-					{
-						quickFilter = ComicBookGroupMatcher.CreateMatcherFromQuery(ComicSmartListItem.TokenizeQuery(text));
-					}
-				}
-				catch
-				{
-				}
-			}
-			if (quickFilter == null)
-			{
-				quickFilter = ComicBookAllPropertiesMatcher.Create(QuickSearch, 3, QuickSearchType, ShowOptionType, ShowComicType);
-			}
-		}
-
-		public void UpdateSearch()
-		{
-			UpdateQuickFilter();
-			FillBookList();
-			displayOptionPanel.Visible = ShowOptionType != 0 || ShowComicType != 0 || ShowOnlyDuplicates;
-		}
-
-		public void RemoveBooks(IEnumerable<ComicBook> books)
-		{
-			IRemoveBooks removeBooks = BookList.QueryService<IRemoveBooks>();
-			if (removeBooks != null)
-			{
-				ItemView.BeginUpdate();
-				try
-				{
-					removeBooks.RemoveBooks(books, Control.ModifierKeys != Keys.Control);
-				}
-				finally
-				{
-					ItemView.EndUpdate();
-				}
-			}
-		}
-
-		private bool CanRemoveBooks()
-		{
-			if (itemView.InplaceEditItem == null && ComicEditMode.CanDeleteComics() && BookList != null)
-			{
-				return BookList.QueryService<IRemoveBooks>() != null;
-			}
-			return false;
-		}
-
-		private void RemoveBooks()
-		{
-			RemoveBooks(GetBookList(ComicBookFilterType.Selected, asArray: true));
-		}
-
-		public void CopyComicData()
-		{
-			try
-			{
-				((CoverViewItem)itemView.SelectedItems.First()).Comic.ToClipboard();
-			}
-			catch (Exception)
-			{
-			}
-		}
-
-		public void ClearComicData()
-		{
-			if (Program.AskQuestion(this, TR.Messages["AskClearComicData", "Do you want to remove all entered data from the selected Books (can be reverted with Undo)?"], TR.Default["Clear"], HiddenMessageBoxes.AskClearData, null, TR.Default["No"]))
-			{
-				Program.Database.Undo.SetMarker(miClearData.Text);
+                {
+                    bt.DisplayStyle = ToolStripItemDisplayStyle.Image;
+                });
+                toolStrip.Items.Add(new ToolStripSeparator());
+                toolStrip.Items.AddRange(list.ToArray());
+            }
+            ToolStripSeparator toolStripSeparator = sepDuplicateList;
+            bool visible = (tbbDuplicateList.Visible = Library != null && Library.EditMode.CanEditList());
+            toolStripSeparator.Visible = visible;
+            miShowInList.Visible = Library != null;
+            if (Library != Program.Database)
+            {
+                ToolStripSeparator toolStripSeparator2 = sepUndo;
+                ToolStripButton toolStripButton = tbUndo;
+                bool flag3 = (tbRedo.Visible = false);
+                visible = (toolStripButton.Visible = flag3);
+                toolStripSeparator2.Visible = visible;
+            }
+            else
+            {
+                commands.Add(Program.Database.Undo.Undo, () => Program.Database.Undo.CanUndo, tbUndo);
+                commands.Add(Program.Database.Undo.Redo, () => Program.Database.Undo.CanRedo, tbRedo);
+            }
+            base.Controls.SetChildIndex(toolStrip, base.Controls.Count - 1);
+        }
+
+        protected override void OnVisibleChanged(EventArgs e)
+        {
+            base.OnVisibleChanged(e);
+            toolTip.SetToolTip(itemView, null);
+        }
+
+        protected override void OnMainFormChanged()
+        {
+            base.OnMainFormChanged();
+            if (base.Main != null)
+            {
+                commands.Add(base.Main.EditListLayout, tsEditListLayout);
+                commands.Add(base.Main.SaveListLayout, tsSaveListLayout);
+                commands.Add(base.Main.EditListLayouts, () => Program.Settings.ListConfigurations.Count > 0, tsEditLayouts);
+                base.Main.OpenBooks.BookClosed += OpenBooksChanged;
+                base.Main.OpenBooks.BookOpened += OpenBooksChanged;
+                UpdatePending();
+            }
+        }
+
+        protected virtual void OnComicEditModeChanged()
+        {
+            itemView.LabelEdit = ComicEditMode.CanEditProperties();
+            miRevealBrowser.Visible = ComicEditMode.CanShowComics();
+            ToolStripMenuItem toolStripMenuItem = miCopyData;
+            ToolStripMenuItem toolStripMenuItem2 = miPasteData;
+            ToolStripMenuItem toolStripMenuItem3 = miClearData;
+            bool flag2 = (tsCopySeparator.Visible = ComicEditMode.CanEditProperties());
+            bool flag4 = (toolStripMenuItem3.Visible = flag2);
+            bool visible = (toolStripMenuItem2.Visible = flag4);
+            toolStripMenuItem.Visible = visible;
+            ToolStripSeparator toolStripSeparator = toolStripRemoveSeparator;
+            visible = (miRemove.Visible = ComicEditMode.CanDeleteComics());
+            toolStripSeparator.Visible = visible;
+        }
+
+        private void lvGroupHeaders_ColumnClick(object sender, ColumnClickEventArgs e)
+        {
+            itemView.GroupSortingOrder = ItemView.FlipSortOrder(itemView.GroupSortingOrder);
+        }
+
+        private void lvGroupHeaders_ClientSizeChanged(object sender, EventArgs e)
+        {
+            int num = lvGroupHeaders.ClientRectangle.Width - (lvGroupsCount.Width + 2);
+            if (num > 0)
+            {
+                lvGroupsName.Width = num;
+            }
+        }
+
+        private void browserContainer_DoubleClick(object sender, EventArgs e)
+        {
+            ShowGroupHeaders = !ShowGroupHeaders;
+        }
+
+        private void OpenBooksChanged(object sender, BookEventArgs e)
+        {
+            UpdateBookMarkers();
+        }
+
+        private void btCloseStack_Click(object sender, EventArgs e)
+        {
+            CloseStack(withUpdate: true);
+        }
+
+        private void btPrevStack_Click(object sender, EventArgs e)
+        {
+            CoverViewItem oldItem = stackItem as CoverViewItem;
+            CloseStack(withUpdate: true);
+            CoverViewItem[] array = itemView.DisplayedItems.OfType<CoverViewItem>().ToArray();
+            int num = array.FindIndex((CoverViewItem ci) => (from sci in itemView.GetStackItems(ci).OfType<CoverViewItem>()
+                                                             select sci.Comic).Contains(oldItem.Comic)) - 1;
+            if (num < 0)
+            {
+                num = array.Length - 1;
+            }
+            try
+            {
+                OpenStack(array[num]);
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        private void btNextStack_Click(object sender, EventArgs e)
+        {
+            CoverViewItem oldItem = stackItem as CoverViewItem;
+            CloseStack(withUpdate: true);
+            CoverViewItem[] array = itemView.DisplayedItems.OfType<CoverViewItem>().ToArray();
+            int num = array.FindIndex((CoverViewItem ci) => (from sci in itemView.GetStackItems(ci).OfType<CoverViewItem>()
+                                                             select sci.Comic).Contains(oldItem.Comic)) + 1;
+            if (num >= array.Length)
+            {
+                num = 0;
+            }
+            try
+            {
+                OpenStack(array[num]);
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        private void btDisplayAll_Click(object sender, EventArgs e)
+        {
+            ShowOnlyDuplicates = false;
+            ShowOptionType = ComicBookAllPropertiesMatcher.ShowOptionType.All;
+            ShowComicType = ComicBookAllPropertiesMatcher.ShowComicType.All;
+        }
+
+        private void itemView_MouseWheel(object sender, MouseEventArgs e)
+        {
+            if ((Control.ModifierKeys & Keys.Control) != 0 && itemView.ItemViewMode != ItemViewMode.Detail)
+            {
+                ItemSizeInfo itemSize = GetItemSize();
+                SetItemSize(itemSize.Value + e.Delta / SystemInformation.MouseWheelScrollDelta * 16);
+            }
+        }
+
+        private void tbbSort_DropDownOpening(object sender, EventArgs e)
+        {
+            FormUtility.SafeToolStripClear(tbbSort.DropDownItems);
+            itemView.CreateArrangeMenu(tbbSort.DropDownItems);
+        }
+
+        private void tbbGroup_DropDownOpening(object sender, EventArgs e)
+        {
+            FormUtility.SafeToolStripClear(tbbGroup.DropDownItems);
+            itemView.CreateGroupMenu(tbbGroup.DropDownItems);
+        }
+
+        private void tbbGroup_ButtonClick(object sender, EventArgs e)
+        {
+            itemView.GroupSortingOrder = ItemView.FlipSortOrder(itemView.GroupSortingOrder);
+        }
+
+        private void tbbStack_ButtonClick(object sender, EventArgs e)
+        {
+            itemView.ItemStacker = ((itemView.ItemStacker != null) ? null : oldStacker);
+        }
+
+        private void tbbStack_DropDownOpening(object sender, EventArgs e)
+        {
+            FormUtility.SafeToolStripClear(tbbStack.DropDownItems);
+            itemView.CreateStackMenu(tbbStack.DropDownItems);
+        }
+
+        private void tbbSort_ButtonClick(object sender, EventArgs e)
+        {
+            itemView.ItemSortOrder = ItemView.FlipSortOrder(itemView.ItemSortOrder);
+        }
+
+        private void tbbView_ButtonClick(object sender, EventArgs e)
+        {
+            ItemViewMode itemViewMode = itemView.ItemViewMode;
+            switch (itemViewMode)
+            {
+                case ItemViewMode.Thumbnail:
+                    itemViewMode = ItemViewMode.Tile;
+                    break;
+                case ItemViewMode.Tile:
+                    itemViewMode = ItemViewMode.Detail;
+                    break;
+                case ItemViewMode.Detail:
+                    itemViewMode = ItemViewMode.Thumbnail;
+                    break;
+            }
+            itemView.ItemViewMode = itemViewMode;
+        }
+
+        private void tsQuickSearch_TextChanged(object sender, EventArgs e)
+        {
+            QuickSearch = tsQuickSearch.TextBox.Text;
+        }
+
+        private void bookList_BookListRefreshed(object sender, EventArgs e)
+        {
+            OnCurrentBookListChanged();
+        }
+
+        private void bookSelectorPanel_FilterChanged(object sender, EventArgs e)
+        {
+            bookListDirty = true;
+        }
+
+        protected override void OnIdle()
+        {
+            if (base.DesignMode || !base.Visible)
+            {
+                return;
+            }
+            UpdatePending();
+            if (updateGroupList)
+            {
+                updateGroupList = false;
+                FillGroupList();
+            }
+            if (newGroupListWidth != 0 && showGroupHeaders)
+            {
+                int num = browserContainer.ClientRectangle.Width - newGroupListWidth;
+                if (num > 0)
+                {
+                    browserContainer.SplitterDistance = num;
+                }
+                newGroupListWidth = 0;
+            }
+            if (quickSearchCueTexts == null)
+            {
+                quickSearchCueTexts = new string[6]
+                {
+                    miSearchAll.Text,
+                    miSearchSeries.Text,
+                    miSearchWriter.Text,
+                    miSearchArtists.Text,
+                    miSearchDescriptive.Text,
+                    miSearchFile.Text
+                };
+                for (int i = 0; i < quickSearchCueTexts.Length; i++)
+                {
+                    quickSearchCueTexts[i] = TR.Default["Search", "Search"] + " " + quickSearchCueTexts[i].Replace("&", string.Empty);
+                }
+            }
+            tsQuickSearch.TextBox.SetCueText(quickSearchCueTexts[(int)QuickSearchType]);
+            tbSidebar.Visible = !HideNavigation && base.Main != null && base.Main.Control.FindActiveService<ISidebar>() != null;
+            ToolStripSeparator toolStripSeparator = tbBrowseSeparator;
+            ToolStripButton toolStripButton = btBrowseNext;
+            bool flag2 = (btBrowsePrev.Visible = !HideNavigation && base.Main != null && base.Main.Control.FindActiveService<IBrowseHistory>() != null);
+            bool visible = (toolStripButton.Visible = flag2);
+            toolStripSeparator.Visible = visible;
+            tbbSort.Enabled = itemView.Columns.Count != 0;
+            tbbSort.Text = ((itemView.SortColumn != null) ? itemView.SortColumn.Text : noneText);
+            tbbSort.ToolTipText = ((itemView.SortColumn != null) ? StringUtility.Format(arrangedByText, tbbSort.Text) : notArrangedText);
+            tbbGroup.Enabled = itemView.Columns.Count != 0;
+            tbbGroup.Text = ((itemView.GroupColumn != null) ? itemView.GroupColumn.Text : noneText);
+            tbbGroup.ToolTipText = ((itemView.GroupColumn != null) ? StringUtility.Format(groupedByText, tbbGroup.Text) : notGroupedText);
+            openStackPanel.Visible = stackFilter is StackMatcher;
+            if (openStackPanel.Visible)
+            {
+                currentStackName = ((StackMatcher)stackFilter).Caption;
+                lblOpenStackText.Text = currentStackName;
+            }
+            tbbStack.Visible = itemView.ItemViewMode != ItemViewMode.Detail && !openStackPanel.Visible;
+            if (tbbStack.Visible)
+            {
+                tbbStack.Enabled = itemView.Columns.Count != 0;
+                tbbStack.Text = ((itemView.StackColumn != null) ? itemView.StackColumn.Text : noneText);
+                tbbStack.ToolTipText = ((itemView.StackColumn != null) ? StringUtility.Format(stackedByText, tbbStack.Text) : notStackedText);
+            }
+            if (itemView.ItemStacker != null)
+            {
+                oldStacker = itemView.ItemStacker;
+            }
+            tbbSort.Image = ((itemView.ItemSortOrder == SortOrder.Ascending) ? sortUp : sortDown);
+            tbbGroup.Image = ((itemView.GroupSortingOrder == SortOrder.Ascending) ? groupDown : groupUp);
+            if (tbUndo.Visible)
+            {
+                if (tbUndo.Tag == null)
+                {
+                    tbUndo.Tag = tbUndo.Text;
+                }
+                string undoLabel = Program.Database.Undo.UndoLabel;
+                tbUndo.ToolTipText = (string)tbUndo.Tag + (string.IsNullOrEmpty(undoLabel) ? string.Empty : (": " + undoLabel));
+                if (tbRedo.Tag == null)
+                {
+                    tbRedo.Tag = tbRedo.Text;
+                }
+                string text = Program.Database.Undo.RedoEntries.FirstOrDefault();
+                tbRedo.ToolTipText = (string)tbRedo.Tag + (string.IsNullOrEmpty(text) ? string.Empty : (": " + text));
+            }
+            OptimizeToolstripDisplay();
+        }
+
+        private void UpdatePending()
+        {
+            if (bookListDirty)
+            {
+                bookListDirty = false;
+                FillBookList();
+            }
+        }
+
+        private void itemView_ItemActivate(object sender, EventArgs e)
+        {
+            IViewableItem focusedItem = itemView.FocusedItem;
+            if (!itemView.IsStack(focusedItem) || itemView.GetStackCount(focusedItem) == 1)
+            {
+                CoverViewItem coverViewItem = focusedItem as CoverViewItem;
+                if (coverViewItem != null && coverViewItem.Comic.IsLinked)
+                {
+                    OpenComic();
+                }
+                else
+                {
+                    base.Main.ShowInfo();
+                }
+            }
+            else
+            {
+                OpenStack(focusedItem);
+            }
+        }
+
+        private void itemView_PostPaint(object sender, PaintEventArgs e)
+        {
+            e.Graphics.DrawShadow(itemView.DisplayRectangle, 8, Color.Black, 0.125f, BlurShadowType.Inside, BlurShadowParts.Edges);
+        }
+
+        private void searchBrowserContainer_ExpandedChanged(object sender, EventArgs e)
+        {
+            SearchBrowserVisible = searchBrowserContainer.Expanded;
+        }
+
+        private void itemView_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            selectedSize = itemView.SelectedItems.Cast<CoverViewItem>().Sum((CoverViewItem cvi) => Math.Max(cvi.Comic.FileSize, 0L));
+        }
+
+        private void BookInListChanged(object sender, PropertyChangedEventArgs e)
+        {
+            string propertyName = e.PropertyName;
+            if (propertyName == "OpenedTime")
+            {
+                UpdateBookMarkers();
+            }
+        }
+
+        private void itemView_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Delete)
+            {
+                RemoveBooks();
+            }
+        }
+
+        private void contextMenuItems_Opened(object sender, EventArgs e)
+        {
+            contextMenuMouseLocation = Cursor.Position;
+        }
+
+        private void contextMenuItems_Closed(object sender, ToolStripDropDownClosedEventArgs e)
+        {
+            contextMenuCloseTime = Machine.Ticks;
+        }
+
+        private void quickSearchTimer_Tick(object sender, EventArgs e)
+        {
+            quickSearchTimer.Stop();
+            UpdateSearch();
+        }
+
+        private void itemView_ProcessStack(object sender, ItemView.StackEventArgs e)
+        {
+            if (stacksConfig == null)
+            {
+                return;
+            }
+            StacksConfig.StackConfigItem stackConfigItem = stacksConfig.FindItem(e.Stack.Text);
+            if (stackConfigItem == null)
+            {
+                return;
+            }
+            if (!string.IsNullOrEmpty(stackConfigItem.ThumbnailKey))
+            {
+                ISetCustomThumbnail setCustomThumbnail = e.Stack.Items.FirstOrDefault() as ISetCustomThumbnail;
+                if (setCustomThumbnail != null)
+                {
+                    setCustomThumbnail.CustomThumbnailKey = ThumbnailKey.GetResource(ThumbnailKey.CustomKey, stackConfigItem.ThumbnailKey);
+                }
+            }
+            Guid id = stackConfigItem.TopId;
+            if (id != Guid.Empty)
+            {
+                int num = e.Stack.Items.FindIndex((IViewableItem item) => ((CoverViewItem)item).Comic.Id == id);
+                if (num != -1)
+                {
+                    IViewableItem item2 = e.Stack.Items[num];
+                    e.Stack.Items.RemoveAt(num);
+                    e.Stack.Items.Insert(0, item2);
+                }
+            }
+        }
+
+        private void tsQuickSearch_Enter(object sender, EventArgs e)
+        {
+            oldQuickWidth = tsQuickSearch.Width;
+            tsQuickSearch.AutoSize = false;
+            tsQuickSearch.Width *= 2;
+        }
+
+        private void tsQuickSearch_Leave(object sender, EventArgs e)
+        {
+            tsQuickSearch.AutoSize = true;
+            tsQuickSearch.Width = oldQuickWidth;
+        }
+
+        private void itemView_GroupDisplayChanged(object sender, EventArgs e)
+        {
+            updateGroupList = true;
+        }
+
+        private void itemView_ItemDisplayChanged(object sender, EventArgs e)
+        {
+            updateGroupList = true;
+        }
+
+        private void lvGroupHeaders_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (lvGroupHeaders.SelectedIndices.Count != 0)
+            {
+                string text = lvGroupHeaders.SelectedItems[0].Text;
+                IViewableItem firstGroupItem = itemView.GetFirstGroupItem(text);
+                if (firstGroupItem != null)
+                {
+                    itemView.ExpandGroups(expand: true, text);
+                    itemView.EnsureGroupVisible(text);
+                }
+            }
+        }
+
+        private void SetCustomColumns()
+        {
+            Dictionary<int, ItemViewColumn> dictionary = null;
+            if (Library != null && Program.Settings.ShowCustomBookFields)
+            {
+                dictionary = (from customKey in Library.CustomValues
+                              where Program.ExtendedSettings.ShowCustomScriptValues || !customKey.Contains('.')
+                              select new
+                              {
+                                  Id = 10000 + Math.Abs(customKey.GetHashCode()),
+                                  Prop = "{" + customKey + "}",
+                                  Key = customKey
+                              } into customField
+                              select new ItemViewColumn(customField.Id, customField.Key, 100, new ComicListField(customField.Prop, customFieldDescription.SafeFormat(customField.Key), customField.Prop), new CoverViewItemPropertyComparer(customField.Prop), new CoverViewItemPropertyGrouper(customField.Prop), visible: false)).ToDictionary((ItemViewColumn item) => item.Id);
+            }
+            for (int num = itemView.Columns.Count - 1; num >= 0; num--)
+            {
+                int id = itemView.Columns[num].Id;
+                if (id >= 10000)
+                {
+                    if (dictionary != null && dictionary.ContainsKey(id))
+                    {
+                        dictionary.Remove(id);
+                    }
+                    else
+                    {
+                        itemView.Columns.RemoveAt(num);
+                    }
+                }
+            }
+            if (dictionary == null)
+            {
+                return;
+            }
+            foreach (ItemViewColumn value in dictionary.Values)
+            {
+                value.TooltipText = ((ComicListField)value.Tag).Description;
+                itemView.Columns.Add(value);
+            }
+        }
+
+        private void SetVirtualTagColumns()
+        {
+            //Send the settings to the Collection.
+            VirtualTagsCollection.RegisterSettings(Program.Settings);
+
+            //Create the list of columns that we want to show, based on our Virtual Tags settings
+            Dictionary<int, ItemViewColumn> dictionary = new Dictionary<int, ItemViewColumn>();
+            foreach (var vtag in VirtualTagsCollection.Tags.Values)
+            {
+                int id = 300 + vtag.ID;
+
+                if (vtag.IsEnabled)
+                {
+                    dictionary[id] = new ItemViewColumn(id, vtag.Name, 100,
+                                            new ComicListField(vtag.PropertyName, vtag.Description),
+                                                new CoverViewItemPropertyComparer(vtag.PropertyName),
+                                                new CoverViewItemPropertyGrouper(vtag.PropertyName),
+                                                visible: false);
+                }
+            }
+
+            //Check the existing columns and remove the ones that we don't need anymore, or the columns that already exists from our dictionary
+            for (int num = itemView.Columns.Count - 1; num >= 0; num--)
+            {
+                int id = itemView.Columns[num].Id;
+                if (id >= 300 && id < 10000)
+                {
+                    if (dictionary != null && dictionary.ContainsKey(id))
+                        dictionary.Remove(id);
+                    else
+                        itemView.Columns.RemoveAt(num);
+                }
+            }
+
+            if (dictionary is null)
+                return;
+
+            //Add the remaining columns to the interface
+            foreach (ItemViewColumn value in dictionary.Values)
+            {
+                value.TooltipText = ((ComicListField)value.Tag).Description;
+                itemView.Columns.Add(value);
+            }
+        }
+
+        private bool CanReorderList(bool mustBeOrdered = true)
+        {
+            IEditableComicBookListProvider editableComicBookListProvider = BookList.QueryService<IEditableComicBookListProvider>();
+            if (ComicEditMode.CanEditList() && editableComicBookListProvider != null && !editableComicBookListProvider.IsLibrary)
+            {
+                if (mustBeOrdered)
+                {
+                    return IsViewSortedByPosition();
+                }
+                return true;
+            }
+            return false;
+        }
+
+        private bool MoveBooks(IEnumerable<ComicBook> books, bool bottom)
+        {
+            if (!CanReorderList())
+            {
+                return false;
+            }
+            IEditableComicBookListProvider editableComicBookListProvider = BookList.QueryService<IEditableComicBookListProvider>();
+            ComicBook[] source = books.Where(editableComicBookListProvider.Remove).ToArray();
+            if (bottom)
+            {
+                foreach (ComicBook book in books)
+                {
+                    editableComicBookListProvider.Add(book);
+                }
+            }
+            else
+            {
+                foreach (ComicBook item in source.Reverse())
+                {
+                    editableComicBookListProvider.Insert(0, item);
+                }
+            }
+            return true;
+        }
+
+        private void ApplyBookOrder(IEnumerable<ComicBook> books)
+        {
+            if (!CanReorderList(mustBeOrdered: false))
+            {
+                return;
+            }
+            books = books.ToArray();
+            IEditableComicBookListProvider editableComicBookListProvider = BookList.QueryService<IEditableComicBookListProvider>();
+            ComicBook[] source = books.Where(editableComicBookListProvider.Remove).ToArray();
+            foreach (ComicBook item in source.Reverse())
+            {
+                editableComicBookListProvider.Insert(0, item);
+            }
+        }
+
+        private bool AllSelectedLinked()
+        {
+            return GetBookList(ComicBookFilterType.Selected).All((ComicBook cb) => cb.IsLinked);
+        }
+
+        private bool AnySelectedLinked()
+        {
+            return GetBookList(ComicBookFilterType.Selected).Any((ComicBook cb) => cb.IsLinked);
+        }
+
+        private void OptimizeToolstripDisplay()
+        {
+            IEnumerable<ToolStripItem> source = toolStrip.Items.OfType<ToolStripItem>();
+            int num = source.Sum((ToolStripItem n) => n.Width);
+            int num2 = toolStrip.Width - 20;
+            if (num2 == savedOptimizeToolstripRight && num == savedOptimizeToolstripWitdh)
+            {
+                return;
+            }
+            if (num > num2)
+            {
+                SaveStyleSet(ToolStripItemDisplayStyle.Image, tbbView, tbbGroup, tbbSort, tbbStack);
+            }
+            if (num < num2)
+            {
+                SaveStyleSet(ToolStripItemDisplayStyle.ImageAndText, tbbView, tbbGroup, tbbSort, tbbStack);
+                num = source.Sum((ToolStripItem n) => n.Width);
+                if (num > num2)
+                {
+                    SaveStyleSet(ToolStripItemDisplayStyle.Image, tbbView, tbbGroup, tbbSort, tbbStack);
+                }
+            }
+            savedOptimizeToolstripRight = num2;
+            savedOptimizeToolstripWitdh = source.Sum((ToolStripItem n) => n.Width);
+        }
+
+        private static void SaveStyleSet(ToolStripItemDisplayStyle style, params ToolStripItem[] items)
+        {
+            foreach (ToolStripItem toolStripItem in items)
+            {
+                if (toolStripItem.DisplayStyle != style)
+                {
+                    toolStripItem.DisplayStyle = style;
+                }
+            }
+        }
+
+        private void SetSelectedComicAsListBackground()
+        {
+            ComicBook comicBook = GetBookList(ComicBookFilterType.Selected).FirstOrDefault();
+            if (comicBook != null)
+            {
+                SetListBackgroundImage(comicBook);
+            }
+        }
+
+        private void ResetListBackgroundImage()
+        {
+            SetListBackgroundImage((string)null);
+        }
+
+        private void SetTopOfStack()
+        {
+            ComicBook comicBook = GetBookList(ComicBookFilterType.Selected).FirstOrDefault();
+            if (comicBook != null)
+            {
+                if (stacksConfig == null)
+                {
+                    stacksConfig = new StacksConfig();
+                }
+                stacksConfig.SetStackTop(currentStackName, comicBook);
+            }
+        }
+
+        private void SetStackThumbnail()
+        {
+            IViewableItem viewableItem = itemView.SelectedItems.FirstOrDefault();
+            if (viewableItem == null || !itemView.IsStack(viewableItem))
+            {
+                return;
+            }
+            viewableItem = itemView.GetStackItems(viewableItem).FirstOrDefault();
+            string text = Program.LoadCustomThumbnail(null, this, miSetStackThumbnail.Text.Replace("&", string.Empty));
+            if (text != null)
+            {
+                if (stacksConfig == null)
+                {
+                    stacksConfig = new StacksConfig();
+                }
+                stacksConfig.SetStackThumbnailKey(itemView.GetStackCaption(viewableItem), text);
+                FillBookList();
+            }
+        }
+
+        private void RemoveStackThumbnail()
+        {
+            IViewableItem viewableItem = itemView.SelectedItems.FirstOrDefault();
+            if (viewableItem != null && itemView.IsStack(viewableItem))
+            {
+                stacksConfig.SetStackThumbnailKey(itemView.GetStackCaption(viewableItem), null);
+                FillBookList();
+            }
+        }
+
+        private void CloseStack(bool withUpdate)
+        {
+            using (new WaitCursor(this))
+            {
+                if (stackFilter == null)
+                {
+                    return;
+                }
+                stackItem = null;
+                if (withUpdate)
+                {
+                    ItemView.BeginUpdate();
+                    try
+                    {
+                        if (stacksConfig != null)
+                        {
+                            stacksConfig.SetStackViewConfig(Program.Settings.CommonListStackLayout ? BookList.Name : currentStackName, itemView.ViewConfig);
+                        }
+                        itemView.StackDisplayEnabled = true;
+                        if (preStackConfig != null)
+                        {
+                            itemView.ViewConfig = preStackConfig;
+                        }
+                        stackFilter = null;
+                        FillBookList();
+                    }
+                    finally
+                    {
+                        itemView.EndUpdate();
+                        itemView.ScrollPosition = preStackScrollPosition;
+                    }
+                }
+                else
+                {
+                    itemView.ItemStacker = ((StackMatcher)stackFilter).Grouper;
+                    stackFilter = null;
+                }
+            }
+        }
+
+        private void OpenStack(IViewableItem item)
+        {
+            OpenStack(item, storeConfig: true);
+        }
+
+        private void OpenStack(IViewableItem item, bool storeConfig)
+        {
+            using (new WaitCursor(this))
+            {
+                if (item == null)
+                {
+                    return;
+                }
+                itemView.BeginUpdate();
+                try
+                {
+                    stackItem = item;
+                    HashSet<ComicBook> hashSet = new HashSet<ComicBook>();
+                    IViewableItem[] stackItems = itemView.GetStackItems(item);
+                    for (int i = 0; i < stackItems.Length; i++)
+                    {
+                        CoverViewItem coverViewItem = (CoverViewItem)stackItems[i];
+                        hashSet.Add(coverViewItem.Comic);
+                    }
+                    string stackCaption = itemView.GetStackCaption(item);
+                    stackFilter = new StackMatcher(itemView.ItemStacker, stackCaption, hashSet);
+                    if (storeConfig)
+                    {
+                        preStackConfig = itemView.ViewConfig;
+                        preStackScrollPosition = itemView.ScrollPosition;
+                        preStackFocusedId = GetFocusedId();
+                    }
+                    itemView.ItemStacker = null;
+                    if (stacksConfig == null)
+                    {
+                        stacksConfig = new StacksConfig();
+                    }
+                    ItemViewConfig stackViewConfig = stacksConfig.GetStackViewConfig(Program.Settings.CommonListStackLayout ? BookList.Name : stackCaption);
+                    if (stackViewConfig != null)
+                    {
+                        itemView.ViewConfig = stackViewConfig;
+                    }
+                    itemView.StackDisplayEnabled = false;
+                    FillBookList();
+                }
+                finally
+                {
+                    itemView.EndUpdate();
+                }
+            }
+        }
+
+        private void RegisterBookList()
+        {
+            if (bookList == null)
+            {
+                return;
+            }
+            IDisplayListConfig displayListConfig = bookList.QueryService<IDisplayListConfig>();
+            ResetListBackgroundImage();
+            if (displayListConfig != null && displayListConfig.Display != null)
+            {
+                stacksConfig = CloneUtility.Clone(displayListConfig.Display.StackConfig);
+                itemView.ViewConfig = displayListConfig.Display.View;
+                ThumbnailConfig = displayListConfig.Display.Thumbnail;
+                if (Program.Settings.LocalQuickSearch)
+                {
+                    blockQuickSearchUpdate = true;
+                    ShowOptionType = displayListConfig.Display.ShowOptionType;
+                    ShowComicType = displayListConfig.Display.ShowComicType;
+                    ShowOnlyDuplicates = displayListConfig.Display.ShowOnlyDuplicates;
+                    QuickSearchType = displayListConfig.Display.QuickSearchType;
+                    QuickSearch = displayListConfig.Display.QuickSearch;
+                    blockQuickSearchUpdate = false;
+                    ShowGroupHeaders = displayListConfig.Display.ShowGroupHeaders;
+                    newGroupListWidth = displayListConfig.Display.ShowGroupHeadersWidth;
+                }
+                UpdateQuickFilter();
+                if (displayListConfig.Display.View == null && bookList.QueryService<IEditableComicBookListProvider>() != null)
+                {
+                    itemView.ItemGrouper = null;
+                    itemView.SortColumn = itemView.Columns.FindById(100);
+                }
+                SetListBackgroundImage(displayListConfig.Display.BackgroundImageSource);
+            }
+            bookList.BookListChanged += bookList_BookListRefreshed;
+        }
+
+        private void UnregisterBookList()
+        {
+            itemView.FocusedItem = null;
+            StoreWorkspace(null);
+            CloseStack(withUpdate: true);
+            if (bookList != null)
+            {
+                bookList.BookListChanged -= bookList_BookListRefreshed;
+            }
+        }
+
+        private void FillBookSelector()
+        {
+            FillBookSelector(GetCurrentList(withSelector: false), updateNow: true);
+        }
+
+        private void FillBookSelector(IEnumerable<ComicBook> books, bool updateNow)
+        {
+            bookSelectorPanel.Books.Clear();
+            if (searchBrowserVisible && BookList != null)
+            {
+                bookSelectorPanel.Books.AddRange(books);
+            }
+            if (updateNow)
+            {
+                bookSelectorPanel.UpdateLists();
+            }
+        }
+
+        private IEnumerable<ComicBook> GetCurrentList(bool withSelector)
+        {
+            if (BookList == null)
+            {
+                return Enumerable.Empty<ComicBook>();
+            }
+            ComicBookGroupMatcher currentMatcher = GetCurrentMatcher(withStack: true, withSelector);
+            IEnumerable<ComicBook> books = BookList.GetBooks();
+            if (currentMatcher != null)
+            {
+                return currentMatcher.Match(books);
+            }
+            return books;
+        }
+
+        private ComicBookGroupMatcher GetCurrentMatcher(bool withStack, bool withSelector)
+        {
+            ComicBookGroupMatcher comicBookGroupMatcher = new ComicBookGroupMatcher();
+            if (stackFilter != null && withStack)
+            {
+                comicBookGroupMatcher.Matchers.Add(stackFilter);
+            }
+            if (quickFilter != null)
+            {
+                comicBookGroupMatcher.Matchers.Add(quickFilter);
+            }
+            if (bookSelectorPanel.CurrentMatcher != null && withSelector)
+            {
+                comicBookGroupMatcher.Matchers.Add(bookSelectorPanel.CurrentMatcher);
+            }
+            if (ShowOnlyDuplicates)
+            {
+                comicBookGroupMatcher.Matchers.Add(new ComicBookDuplicateMatcher());
+            }
+            return comicBookGroupMatcher;
+        }
+
+        private void FillBookList()
+        {
+            IViewableItem focusedItem = itemView.FocusedItem;
+            int num = itemView.FocusedItemDisplayIndex;
+            ComicBookGroupMatcher currentMatcher = GetCurrentMatcher(withStack: true, withSelector: false);
+            ComicBookMatcher currentMatcher2 = bookSelectorPanel.CurrentMatcher;
+            ComicBook comicBook = ((focusedItem != null) ? ((CoverViewItem)focusedItem).Comic : null);
+            itemView.BeginUpdate();
+            try
+            {
+                int num2 = 1;
+                itemView.Items.Clear();
+                totalCount = 0;
+                totalSize = 0L;
+                selectedSize = 0L;
+                if (BookList != null)
+                {
+                    ComicBook[] array = BookList.GetBooks().ToArray();
+                    IComicBookStatsProvider statsProvider = BookList as IComicBookStatsProvider;
+                    IEnumerable<ComicBook> enumerable = currentMatcher.Match(array).ToArray();
+                    totalCount = array.Length;
+                    FillBookSelector(enumerable, updateNow: true);
+                    if (currentMatcher2 != null)
+                    {
+                        enumerable = currentMatcher2.Match(enumerable);
+                    }
+                    foreach (ComicBook item in enumerable)
+                    {
+                        CoverViewItem coverViewItem = CoverViewItem.Create(item, num2++, statsProvider);
+                        coverViewItem.BookChanged += BookInListChanged;
+                        itemView.Items.Add(coverViewItem);
+                        totalSize += Math.Max(item.FileSize, 0L);
+                    }
+                    UpdateBookMarkers();
+                }
+                if (comicBook == null || itemView.Items.Count == 0)
+                {
+                    return;
+                }
+                foreach (CoverViewItem displayedItem in itemView.DisplayedItems)
+                {
+                    IViewableItem[] stackItems = itemView.GetStackItems(displayedItem);
+                    for (int i = 0; i < stackItems.Length; i++)
+                    {
+                        CoverViewItem coverViewItem3 = (CoverViewItem)stackItems[i];
+                        if (coverViewItem3.Comic == comicBook)
+                        {
+                            displayedItem.Selected = true;
+                            displayedItem.Focused = true;
+                            itemView.EnsureItemVisible(displayedItem);
+                            return;
+                        }
+                    }
+                }
+                if (num < 0)
+                {
+                    return;
+                }
+                if (num >= itemView.DisplayedItems.Count())
+                {
+                    num = itemView.DisplayedItems.Count() - 1;
+                }
+                foreach (CoverViewItem displayedItem2 in itemView.DisplayedItems)
+                {
+                    if (num == 0)
+                    {
+                        displayedItem2.Selected = true;
+                        displayedItem2.Focused = true;
+                        itemView.EnsureItemVisible(displayedItem2);
+                        break;
+                    }
+                    num--;
+                }
+            }
+            catch (Exception)
+            {
+            }
+            finally
+            {
+                itemView.EndUpdate();
+                updateGroupList = true;
+            }
+        }
+
+        private void FillGroupList()
+        {
+            if (showGroupHeaders && itemView.AreGroupsVisible)
+            {
+                lvGroupHeaders.BeginUpdate();
+                IColumn column = itemView.Columns.FirstOrDefault((IColumn c) => c.ColumnGrouper == itemView.ItemGrouper);
+                lvGroupsName.Text = ((column == null) ? string.Empty : column.Text);
+                lvGroupHeaders.Items.Clear();
+                foreach (string displayedGroup in itemView.DisplayedGroups)
+                {
+                    lvGroupHeaders.Items.Add(displayedGroup).SubItems.Add(itemView.GetGroupSizeFromCaption(displayedGroup).ToString());
+                }
+                lvGroupHeaders.EndUpdate();
+                browserContainer.Panel2Collapsed = false;
+            }
+            else
+            {
+                browserContainer.Panel2Collapsed = true;
+            }
+        }
+
+        public IEnumerable<ComicBook> GetOpenBooks()
+        {
+            try
+            {
+                return from nav in base.Main.OpenBooks.Slots
+                       where nav != null
+                       select nav.Comic;
+            }
+            catch (NullReferenceException)
+            {
+                return Enumerable.Empty<ComicBook>();
+            }
+        }
+
+        private void UpdateBookMarkers()
+        {
+            DateTime t = DateTime.MinValue;
+            ComicBook comicBook = null;
+            foreach (CoverViewItem item in itemView.Items)
+            {
+                if (t < item.Comic.OpenedTime)
+                {
+                    t = item.Comic.OpenedTime;
+                    comicBook = item.Comic;
+                }
+            }
+            IEnumerable<ComicBook> openBooks = GetOpenBooks();
+            foreach (CoverViewItem item2 in itemView.Items)
+            {
+                item2.Marker = ((item2.Comic == comicBook) ? MarkerType.IsLast : MarkerType.None);
+                item2.Marker = (openBooks.Contains(item2.Comic) ? MarkerType.IsOpen : item2.Marker);
+            }
+        }
+
+        private void AddFilesToLibrary()
+        {
+            Program.Scanner.ScanFilesOrFolders(from cb in GetBookList(ComicBookFilterType.NotInLibrary | ComicBookFilterType.IsNotFileless | ComicBookFilterType.Selected, asArray: true)
+                                               select cb.FilePath, all: false, removeMissing: false);
+        }
+
+        private void DuplicateList(ComicListItemFolder clif = null)
+        {
+            if (Library == null || !Library.EditMode.CanEditList())
+            {
+                return;
+            }
+            ComicBookGroupMatcher currentMatcher = GetCurrentMatcher(withStack: false, withSelector: true);
+            if (currentMatcher == null || currentMatcher.Matchers.Count == 0)
+            {
+                return;
+            }
+            string name = string.Empty;
+            ComicSmartListItem comicSmartListItem = new ComicSmartListItem("")
+            {
+                BaseListId = BookList.Id,
+                MatcherMode = currentMatcher.MatcherMode
+            };
+            foreach (ComicBookMatcher matcher in currentMatcher.Matchers)
+            {
+                comicSmartListItem.Matchers.Add(matcher.Clone() as ComicBookMatcher);
+            }
+            foreach (ComicBookValueMatcher item in comicSmartListItem.Matchers.Recurse<ComicBookValueMatcher>((object cbm) => (!(cbm is ComicBookGroupMatcher)) ? null : ((ComicBookGroupMatcher)cbm).Matchers))
+            {
+                string text = item.MatchValue.Trim();
+                if (!string.IsNullOrEmpty(text))
+                {
+                    if (!string.IsNullOrEmpty(name))
+                    {
+                        name += "/";
+                    }
+                    name += text;
+                }
+            }
+            if (string.IsNullOrEmpty(name))
+            {
+                name = NumberedString.StripNumber(BookList.Name);
+            }
+            int number = NumberedString.MaxNumber(from cli in Library.ComicLists.GetItems<ComicListItem>()
+                                                  where NumberedString.StripNumber(cli.Name) == name
+                                                  select cli.Name);
+            comicSmartListItem.Name = NumberedString.Format(name, number);
+            if (clif == null)
+            {
+                Library.TemporaryFolder.Items.Add(comicSmartListItem);
+            }
+            else
+            {
+                clif.Items.Add(comicSmartListItem);
+            }
+        }
+
+        private void SetListBackgroundImage(ComicBook cb)
+        {
+            SetListBackgroundImage(cb?.Id.ToString());
+        }
+
+        private void SetListBackgroundImage(string source)
+        {
+            backgroundImageSource = source;
+            try
+            {
+                ThreadUtility.RunInBackground("Create library backdrop", delegate
+                {
+                    bool flag = false;
+                    try
+                    {
+                        if (!base.IsDisposed && source != null)
+                        {
+                            ComicBook comicBook = Library.Books[new Guid(source)];
+                            if (comicBook != null)
+                            {
+                                using (IItemLock<ThumbnailImage> itemLock = Program.ImagePool.GetThumbnail(comicBook.GetFrontCoverThumbnailKey(), comicBook))
+                                {
+                                    Bitmap bitmap = ComicBox3D.CreateDefaultBook(itemLock.Item.Bitmap, null, EngineConfiguration.Default.ListCoverSize, comicBook.PageCount);
+                                    bitmap.ChangeAlpha(EngineConfiguration.Default.ListCoverAlpha);
+                                    SetListBackgroundImage(bitmap);
+                                    flag = true;
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception)
+                    {
+                    }
+                    finally
+                    {
+                        if (!flag)
+                        {
+                            SetListBackgroundImage();
+                        }
+                    }
+                });
+            }
+            catch
+            {
+                SetListBackgroundImage();
+            }
+        }
+
+        private void SetListBackgroundImage(Image image)
+        {
+            if (!itemView.BeginInvokeIfRequired(delegate
+            {
+                SetListBackgroundImage(image);
+            }) && itemView.BackgroundImage != image)
+            {
+                if (itemView.BackgroundImage != null && itemView.BackgroundImage != ListBackgroundImage)
+                {
+                    Image backgroundImage = itemView.BackgroundImage;
+                    itemView.BackgroundImage = null;
+                    backgroundImage.Dispose();
+                }
+                if (image != null && itemView.BackColor.GetBrightness() >= 0.95f)
+                {
+                    itemView.BackgroundImage = image;
+                    itemView.BackgroundImageAlignment = System.Drawing.ContentAlignment.BottomRight;
+                }
+            }
+        }
+
+        private void SetListBackgroundImage()
+        {
+            SetListBackgroundImage(ListBackgroundImage);
+        }
+
+        private void bookSelectorPanel_ItemDrag(object sender, ItemDragEventArgs e)
+        {
+            if (ComicEditMode.CanEditList())
+            {
+                Control control = (Control)sender;
+                control.DoDragDrop(e.Item, DragDropEffects.Copy);
+            }
+        }
+
+        private void DragGiveDragCursorFeedback(object sender, GiveFeedbackEventArgs e)
+        {
+            if (dragCursor != null && !(dragCursor.Cursor == null))
+            {
+                e.UseDefaultCursors = false;
+                dragCursor.OverlayCursor = ((e.Effect == DragDropEffects.None) ? Cursors.No : Cursors.Default);
+                dragCursor.OverlayEffect = ((e.Effect == DragDropEffects.Copy) ? BitmapCursorOverlayEffect.Plus : BitmapCursorOverlayEffect.None);
+                Cursor.Current = dragCursor.Cursor;
+            }
+        }
+
+        private void DragQueryContinueDrag(object sender, QueryContinueDragEventArgs e)
+        {
+            if (e.Action == DragAction.Drop)
+            {
+                Cursor.Current = Cursors.WaitCursor;
+            }
+        }
+
+        private void itemView_ItemDrag(object sender, ItemDragEventArgs e)
+        {
+            if (!ComicEditMode.CanEditList())
+            {
+                return;
+            }
+            ComicBookContainer comicBookContainer = new ComicBookContainer();
+            ComicBookGroupMatcher comicBookGroupMatcher = new ComicBookGroupMatcher();
+            comicBookContainer.Books.AddRange(GetBookList(ComicBookFilterType.Selected));
+            if (comicBookContainer.Books.Count == 0)
+            {
+                return;
+            }
+            if (itemView.IsStacked)
+            {
+                IViewableItem[] array = itemView.SelectedItems.Where((IViewableItem si) => itemView.IsStack(si)).ToArray();
+                comicBookContainer.Name = array.Select((IViewableItem si) => itemView.GetStackCaption(si)).FirstOrDefault();
+                SingleComicGrouper[] array2 = (from bg in itemView.ItemStacker.GetGroupers().OfType<IBookGrouper>()
+                                               select bg.BookGrouper).OfType<SingleComicGrouper>().ToArray();
+                IViewableItem[] array3 = array;
+                foreach (IViewableItem item in array3)
+                {
+                    ComicBookGroupMatcher comicBookGroupMatcher2 = new ComicBookGroupMatcher
+                    {
+                        MatcherMode = MatcherMode.And
+                    };
+                    IGroupInfo stackGroupInfo = itemView.GetStackGroupInfo(item);
+                    IEnumerable<IGroupInfo> source;
+                    if (!(stackGroupInfo is ICompoundGroupInfo))
+                    {
+                        source = ListExtensions.AsEnumerable<IGroupInfo>(stackGroupInfo);
+                    }
+                    else
+                    {
+                        IEnumerable<IGroupInfo> infos = ((ICompoundGroupInfo)stackGroupInfo).Infos;
+                        source = infos;
+                    }
+                    IGroupInfo[] array4 = source.ToArray();
+                    for (int j = 0; j < array2.Length; j++)
+                    {
+                        ComicBookMatcher comicBookMatcher = array2[j].CreateMatcher(array4[j]);
+                        if (comicBookMatcher != null)
+                        {
+                            comicBookGroupMatcher2.Matchers.Add(comicBookMatcher);
+                        }
+                    }
+                    if (comicBookGroupMatcher2.Matchers.Count > 1)
+                    {
+                        comicBookGroupMatcher.Matchers.Add(comicBookGroupMatcher2);
+                    }
+                    else if (comicBookGroupMatcher2.Matchers.Count == 1)
+                    {
+                        comicBookGroupMatcher.Matchers.Add(comicBookGroupMatcher2.Matchers[0]);
+                    }
+                }
+            }
+            dragCursor = itemView.GetDragCursor(Program.ExtendedSettings.DragDropCursorAlpha);
+            try
+            {
+                IEditableComicBookListProvider editableComicBookListProvider = BookList.QueryService<IEditableComicBookListProvider>();
+                bool flag = editableComicBookListProvider != null;
+                bool flag2 = editableComicBookListProvider?.IsLibrary ?? false;
+                bool flag3 = !flag2 && flag;
+                DragDropEffects dragDropEffects = DragDropEffects.Copy;
+                itemView.AllowDrop = !flag2 && flag && IsViewSortedByPosition();
+                if (flag3)
+                {
+                    dragDropEffects |= DragDropEffects.Move;
+                }
+                DataObject dataObject = new DataObject();
+                dataObject.SetData(comicBookContainer);
+                StringCollection stringCollection = new StringCollection();
+                stringCollection.AddRange(comicBookContainer.GetBookFiles().ToArray());
+                dataObject.SetFileDropList(stringCollection);
+                if (comicBookGroupMatcher.Matchers.Count > 0)
+                {
+                    dataObject.SetData(ComicBookMatcher.ClipboardFormat, (comicBookGroupMatcher.Matchers.Count == 1) ? comicBookGroupMatcher.Matchers[0] : comicBookGroupMatcher);
+                }
+                ownDrop = false;
+                DragDropEffects dragDropEffects2 = itemView.DoDragDrop(dataObject, dragDropEffects);
+                if (dragDropEffects2 != DragDropEffects.Move || editableComicBookListProvider == null || ownDrop)
+                {
+                    return;
+                }
+                foreach (ComicBook book in comicBookContainer.Books)
+                {
+                    editableComicBookListProvider.Remove(book);
+                }
+            }
+            finally
+            {
+                if (dragCursor != null)
+                {
+                    dragCursor.Dispose();
+                    dragCursor = null;
+                }
+                itemView.AllowDrop = true;
+            }
+        }
+
+        private bool CreateDragContainter(DragEventArgs e)
+        {
+            if (dragBookContainer == null)
+            {
+                dragBookContainer = DragDropContainer.Create(e.Data);
+            }
+            return dragBookContainer.IsValid;
+        }
+
+        private void InsertBooksIntoToList(IEditableComicBookListProvider list, int index)
+        {
+            if (list == null)
+            {
+                return;
+            }
+            if (list.IsLibrary && dragBookContainer.IsFilesContainer)
+            {
+                Program.Scanner.ScanFilesOrFolders(dragBookContainer.FilesOrFolders, all: true, removeMissing: false);
+            }
+            else
+            {
+                if (!dragBookContainer.IsBookContainer)
+                {
+                    return;
+                }
+                foreach (ComicBook book in dragBookContainer.Books.GetBooks())
+                {
+                    ComicBook comicBook = Program.BookFactory.Create(book.FilePath, CreateBookOption.AddToStorage);
+                    if (comicBook != null)
+                    {
+                        if (index != -1)
+                        {
+                            index = list.Insert(index, comicBook) + 1;
+                        }
+                        else
+                        {
+                            list.Add(comicBook);
+                        }
+                    }
+                }
+                FillBookList();
+            }
+        }
+
+        private bool IsViewSortedByPosition()
+        {
+            if (itemView.SortColumn != null && itemView.SortColumn.Id == 100 && itemView.ItemSortOrder == SortOrder.Ascending && itemView.GroupColumn == null)
+            {
+                return !itemView.IsStacked;
+            }
+            return false;
+        }
+
+        private void SetDropEffects(DragEventArgs e)
+        {
+            IEditableComicBookListProvider editableComicBookListProvider = BookList.QueryService<IEditableComicBookListProvider>();
+            e.Effect = DragDropEffects.None;
+            if (ComicEditMode.CanEditList() && editableComicBookListProvider != null && CreateDragContainter(e))
+            {
+                if (dragCursor != null && IsViewSortedByPosition())
+                {
+                    e.Effect = DragDropEffects.Move;
+                }
+                else if (editableComicBookListProvider.IsLibrary && dragBookContainer.IsFilesContainer)
+                {
+                    e.Effect = DragDropEffects.Link;
+                }
+                else
+                {
+                    e.Effect = e.AllowedEffect;
+                }
+            }
+            if (e.Effect == DragDropEffects.None)
+            {
+                itemView.MarkerVisible = false;
+                return;
+            }
+            Point pt = itemView.PointToClient(new Point(e.X, e.Y));
+            CoverViewItem coverViewItem = itemView.ItemHitTest(pt) as CoverViewItem;
+            if (coverViewItem != null && IsViewSortedByPosition() && dragBookContainer.IsBookContainer)
+            {
+                itemView.MarkerItem = coverViewItem;
+                itemView.MarkerVisible = true;
+            }
+            else
+            {
+                itemView.MarkerVisible = false;
+            }
+        }
+
+        private void itemView_DragEnter(object sender, DragEventArgs e)
+        {
+            SetDropEffects(e);
+        }
+
+        private void itemView_DragOver(object sender, DragEventArgs e)
+        {
+            SetDropEffects(e);
+        }
+
+        private void itemView_DragDrop(object sender, DragEventArgs e)
+        {
+            Point pt = itemView.PointToClient(new Point(e.X, e.Y));
+            CoverViewItem coverViewItem = itemView.ItemHitTest(pt) as CoverViewItem;
+            int index = -1;
+            if (coverViewItem != null && IsViewSortedByPosition())
+            {
+                index = coverViewItem.Position - 1;
+            }
+            InsertBooksIntoToList(BookList.QueryService<IEditableComicBookListProvider>(), index);
+            itemView.MarkerVisible = false;
+            dragBookContainer = null;
+            ownDrop = true;
+        }
+
+        private void itemView_DragLeave(object sender, EventArgs e)
+        {
+            itemView.MarkerVisible = false;
+            dragBookContainer = null;
+        }
+
+        public virtual ItemSizeInfo GetItemSize()
+        {
+            switch (itemView.ItemViewMode)
+            {
+                case ItemViewMode.Thumbnail:
+                    return new ItemSizeInfo(FormUtility.ScaleDpiY(Program.MinThumbHeight), FormUtility.ScaleDpiY(Program.MaxThumbHeight), itemView.ItemThumbSize.Height);
+                case ItemViewMode.Tile:
+                    return new ItemSizeInfo(FormUtility.ScaleDpiY(Program.MinTileHeight), FormUtility.ScaleDpiY(Program.MaxTileHeight), itemView.ItemTileSize.Height);
+                case ItemViewMode.Detail:
+                    return new ItemSizeInfo(FormUtility.ScaleDpiY(Program.MinRowHeight), FormUtility.ScaleDpiY(Program.MaxRowHeight), itemView.ItemRowHeight);
+                default:
+                    return null;
+            }
+        }
+
+        public void SetItemSize(int height)
+        {
+            switch (itemView.ItemViewMode)
+            {
+                case ItemViewMode.Thumbnail:
+                    height = height.Clamp(FormUtility.ScaleDpiY(Program.MinThumbHeight), FormUtility.ScaleDpiY(Program.MaxThumbHeight));
+                    itemView.ItemThumbSize = new Size(height, height);
+                    break;
+                case ItemViewMode.Tile:
+                    height = height.Clamp(FormUtility.ScaleDpiY(Program.MinTileHeight), FormUtility.ScaleDpiY(Program.MaxTileHeight));
+                    itemView.ItemTileSize = new Size(height * 2, height);
+                    break;
+                case ItemViewMode.Detail:
+                    height = height.Clamp(FormUtility.ScaleDpiY(Program.MinRowHeight), FormUtility.ScaleDpiY(Program.MaxRowHeight));
+                    itemView.ItemRowHeight = height;
+                    break;
+            }
+        }
+
+        public Guid GetBookListId()
+        {
+            if (BookList != null)
+            {
+                return BookList.Id;
+            }
+            return Guid.Empty;
+        }
+
+        public void RefreshInformation()
+        {
+            IEnumerable<CoverViewItem> enumerable = from CoverViewItem cvi in new List<IViewableItem>(itemView.SelectedItems)
+                                                    where cvi.Comic.IsInContainer
+                                                    select cvi;
+            foreach (CoverViewItem item in enumerable)
+            {
+                if (item.Comic.IsDynamicSource)
+                {
+                    base.Main.UpdateWebComic(item.Comic, fullRefresh: true);
+                }
+                else
+                {
+                    item.RefreshImage();
+                }
+            }
+            if (ComicEditMode.CanScan())
+            {
+                Program.Scanner.ScanFilesOrFolders(enumerable.Select((CoverViewItem cvi) => cvi.Comic.FilePath), all: false, removeMissing: false);
+            }
+        }
+
+        public void MarkSelectedRead()
+        {
+            foreach (ComicBook book in GetBookList(ComicBookFilterType.Library | ComicBookFilterType.Selected, asArray: true))
+            {
+                book.MarkAsRead();
+            }
+        }
+
+        public void MarkSelectedNotRead()
+        {
+            foreach (ComicBook book in GetBookList(ComicBookFilterType.Library | ComicBookFilterType.Selected, asArray: true))
+            {
+                book.MarkAsNotRead();
+            }
+        }
+
+        public void MarkSelectedChecked()
+        {
+            foreach (ComicBook book in GetBookList(ComicBookFilterType.Library | ComicBookFilterType.Selected, asArray: true))
+            {
+                book.Checked = true;
+            }
+        }
+
+        public void MarkSelectedUnchecked()
+        {
+            foreach (ComicBook book in GetBookList(ComicBookFilterType.Library | ComicBookFilterType.Selected, asArray: true))
+            {
+                book.Checked = false;
+            }
+        }
+
+        public void ShowWeb()
+        {
+            CoverViewItem coverViewItem = itemView.FocusedItem as CoverViewItem;
+            if (coverViewItem != null && !string.IsNullOrEmpty(coverViewItem.Comic.Web))
+            {
+                Program.StartDocument(coverViewItem.Comic.Web);
+            }
+        }
+
+        public void OpenComic()
+        {
+            CoverViewItem coverViewItem = itemView.FocusedItem as CoverViewItem;
+            if (coverViewItem != null && base.Main != null)
+            {
+                coverViewItem.Comic.LastOpenedFromListId = BookList.Id;
+                base.Main.OpenBooks.Open(coverViewItem.Comic, Program.Settings.OpenInNewTab ^ ((Control.ModifierKeys & Keys.Control) != 0 || (itemView.ActivateButton & MouseButtons.Middle) != 0));
+            }
+        }
+
+        public void OpenComicNewTab()
+        {
+            CoverViewItem coverViewItem = itemView.FocusedItem as CoverViewItem;
+            if (coverViewItem != null && base.Main != null)
+            {
+                coverViewItem.Comic.LastOpenedFromListId = BookList.Id;
+                base.Main.OpenBooks.Open(coverViewItem.Comic, inNewSlot: true);
+            }
+        }
+
+        public void EditItem()
+        {
+            if (itemView.LabelEdit && itemView.ItemViewMode == ItemViewMode.Detail && itemView.SelectedCount != 0)
+            {
+                if (Machine.Ticks - contextMenuCloseTime < 250)
+                {
+                    itemView.EditItem(contextMenuMouseLocation);
+                }
+                else
+                {
+                    itemView.EditItem(itemView.SelectedItems.FirstOrDefault());
+                }
+            }
+        }
+
+        public void CopyListSetup()
+        {
+            Clipboard.SetDataObject(new DisplayListConfig(ViewConfig, ThumbnailConfig, null, stacksConfig, backgroundImageSource));
+        }
+
+        public void PasteListSetup()
+        {
+            try
+            {
+                IDataObject dataObject = Clipboard.GetDataObject();
+                if (dataObject != null)
+                {
+                    DisplayListConfig displayListConfig = dataObject.GetData(typeof(DisplayListConfig)) as DisplayListConfig;
+                    if (displayListConfig != null)
+                    {
+                        itemView.ViewConfig = displayListConfig.View;
+                        ThumbnailConfig = displayListConfig.Thumbnail;
+                        stacksConfig = displayListConfig.StackConfig;
+                        FillBookList();
+                        SetListBackgroundImage(displayListConfig.BackgroundImageSource);
+                    }
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        public void RevealInExplorer()
+        {
+            ComicBook comicBook = GetBookList(ComicBookFilterType.IsNotFileless | ComicBookFilterType.Selected).FirstOrDefault();
+            if (comicBook != null)
+            {
+                Program.ShowExplorer(comicBook.FilePath);
+            }
+        }
+
+        public void ShowBook(ComicBook comicBook)
+        {
+            foreach (CoverViewItem item in itemView.Items)
+            {
+                if (item.Comic == comicBook)
+                {
+                    item.Selected = true;
+                    item.Focused = true;
+                    item.EnsureVisible();
+                    break;
+                }
+            }
+        }
+
+        public void UpdateQuickFilter()
+        {
+            quickFilter = null;
+            if (QuickSearchType == ComicBookAllPropertiesMatcher.MatcherOption.All)
+            {
+                try
+                {
+                    string text = QuickSearch?.Trim() ?? "";
+                    if (text.StartsWith("NOT", StringComparison.OrdinalIgnoreCase) || text.StartsWith("MATCH", StringComparison.OrdinalIgnoreCase))
+                    {
+                        quickFilter = ComicBookGroupMatcher.CreateMatcherFromQuery(ComicSmartListItem.TokenizeQuery(text));
+                    }
+                }
+                catch
+                {
+                }
+            }
+            if (quickFilter == null)
+            {
+                quickFilter = ComicBookAllPropertiesMatcher.Create(QuickSearch, 3, QuickSearchType, ShowOptionType, ShowComicType);
+            }
+        }
+
+        public void UpdateSearch()
+        {
+            UpdateQuickFilter();
+            FillBookList();
+            displayOptionPanel.Visible = ShowOptionType != 0 || ShowComicType != 0 || ShowOnlyDuplicates;
+        }
+
+        public void RemoveBooks(IEnumerable<ComicBook> books)
+        {
+            IRemoveBooks removeBooks = BookList.QueryService<IRemoveBooks>();
+            if (removeBooks != null)
+            {
+                ItemView.BeginUpdate();
+                try
+                {
+                    removeBooks.RemoveBooks(books, Control.ModifierKeys != Keys.Control);
+                }
+                finally
+                {
+                    ItemView.EndUpdate();
+                }
+            }
+        }
+
+        private bool CanRemoveBooks()
+        {
+            if (itemView.InplaceEditItem == null && ComicEditMode.CanDeleteComics() && BookList != null)
+            {
+                return BookList.QueryService<IRemoveBooks>() != null;
+            }
+            return false;
+        }
+
+        private void RemoveBooks()
+        {
+            RemoveBooks(GetBookList(ComicBookFilterType.Selected, asArray: true));
+        }
+
+        public void CopyComicData()
+        {
+            try
+            {
+                ((CoverViewItem)itemView.SelectedItems.First()).Comic.ToClipboard();
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        public void ClearComicData()
+        {
+            if (Program.AskQuestion(this, TR.Messages["AskClearComicData", "Do you want to remove all entered data from the selected Books (can be reverted with Undo)?"], TR.Default["Clear"], HiddenMessageBoxes.AskClearData, null, TR.Default["No"]))
+            {
+                Program.Database.Undo.SetMarker(miClearData.Text);
 				GetBookList(ComicBookFilterType.Selected).ForEachProgress(delegate(ComicBook cb)
-				{
-					cb.ResetProperties();
-				}, this, TR.Messages["ClearComicData", "Clear Books"], TR.Messages["ClearComicDataText", "Removing all entered data from the Books"]);
-			}
-		}
+                {
+                    cb.ResetProperties();
+                }, this, TR.Messages["ClearComicData", "Clear Books"], TR.Messages["ClearComicDataText", "Removing all entered data from the Books"]);
+            }
+        }
 
-		public void UpdateFiles()
-		{
+        public void UpdateFiles()
+        {
 			GetBookList(ComicBookFilterType.IsNotFileless | ComicBookFilterType.Selected).ForEach(delegate(ComicBook cb)
-			{
-				Program.QueueManager.AddBookToFileUpdate(cb, alwaysWrite: true);
-			});
-		}
+            {
+                Program.QueueManager.AddBookToFileUpdate(cb, alwaysWrite: true);
+            });
+        }
 
         private bool isPasteComicDataEnabled()
         {
@@ -2666,27 +2712,27 @@ namespace cYo.Projects.ComicRack.Viewer.Views
         }
 
         public void PasteComicData()
-		{
-			try
-			{
-				ComicBook comicBook = Clipboard.GetData(ComicBook.ClipboardFormat) as ComicBook;
-				IEnumerable<ComicBook> enumerable = GetBookList(ComicBookFilterType.Selected, asArray: true);
-				if (comicBook != null && !enumerable.IsEmpty())
-				{
-					ComicDataPasteDialog.ShowAndPaste(this, comicBook, enumerable);
-				}
-			}
-			catch
-			{
-			}
-		}
+        {
+            try
+            {
+                ComicBook comicBook = Clipboard.GetData(ComicBook.ClipboardFormat) as ComicBook;
+                IEnumerable<ComicBook> enumerable = GetBookList(ComicBookFilterType.Selected, asArray: true);
+                if (comicBook != null && !enumerable.IsEmpty())
+                {
+                    ComicDataPasteDialog.ShowAndPaste(this, comicBook, enumerable);
+                }
+            }
+            catch
+            {
+            }
+        }
 
-		private void tsListLayouts_DropDownOpening(object sender, EventArgs e)
-		{
-			base.Main.UpdateListConfigMenus(tsListLayouts.DropDownItems);
-		}
+        private void tsListLayouts_DropDownOpening(object sender, EventArgs e)
+        {
+            base.Main.UpdateListConfigMenus(tsListLayouts.DropDownItems);
+        }
 
-		private void contextMenuItems_Opening(object sender, CancelEventArgs e)
+        private void contextMenuItems_Opening(object sender, CancelEventArgs e)
         {
             IEnumerable<ComicBook> enumerable = GetBookList(ComicBookFilterType.Selected);
             IEnumerable<ComicBook> enumerable2 = GetBookList(ComicBookFilterType.Library | ComicBookFilterType.Selected);
@@ -2751,488 +2797,489 @@ namespace cYo.Projects.ComicRack.Viewer.Views
         }
 
         private void LayoutMenuOpening(object sender, CancelEventArgs e)
-		{
-			try
-			{
-				IDataObject dataObject = Clipboard.GetDataObject();
-				miPasteListSetup.Enabled = dataObject?.GetDataPresent(typeof(DisplayListConfig)) ?? false;
-			}
-			catch
-			{
-				miPasteListSetup.Enabled = false;
-			}
-		}
+        {
+            try
+            {
+                IDataObject dataObject = Clipboard.GetDataObject();
+                miPasteListSetup.Enabled = dataObject?.GetDataPresent(typeof(DisplayListConfig)) ?? false;
+            }
+            catch
+            {
+                miPasteListSetup.Enabled = false;
+            }
+        }
 
-		private void contextExport_Opening(object sender, CancelEventArgs e)
-		{
-			while (contextExport.Items.Count > 2)
-			{
-				ToolStripItem toolStripItem = contextExport.Items[2];
-				contextExport.Items.RemoveAt(2);
-				toolStripItem.Dispose();
-			}
-			bool enabled = AllSelectedLinked();
-			AddConverterEntries(Program.ExportComicRackPresets, enabled);
-			AddConverterEntries(Program.Settings.ExportUserPresets, enabled);
-		}
+        private void contextExport_Opening(object sender, CancelEventArgs e)
+        {
+            while (contextExport.Items.Count > 2)
+            {
+                ToolStripItem toolStripItem = contextExport.Items[2];
+                contextExport.Items.RemoveAt(2);
+                toolStripItem.Dispose();
+            }
+            bool enabled = AllSelectedLinked();
+            AddConverterEntries(Program.ExportComicRackPresets, enabled);
+            AddConverterEntries(Program.Settings.ExportUserPresets, enabled);
+        }
 
-		private void AddConverterEntries(ICollection<ExportSetting> converterSettingCollection, bool enabled)
-		{
-			if (converterSettingCollection.Count == 0)
-			{
-				return;
-			}
-			contextExport.Items.Add(new ToolStripSeparator());
-			foreach (ExportSetting item in converterSettingCollection)
-			{
-				ExportSetting copy = item;
-				contextExport.Items.Add(item.Name, null, delegate
-				{
-					base.Main.ConvertComic(GetBookList(ComicBookFilterType.Selected, asArray: true), copy);
-				}).Enabled = enabled;
-			}
-		}
+        private void AddConverterEntries(ICollection<ExportSetting> converterSettingCollection, bool enabled)
+        {
+            if (converterSettingCollection.Count == 0)
+            {
+                return;
+            }
+            contextExport.Items.Add(new ToolStripSeparator());
+            foreach (ExportSetting item in converterSettingCollection)
+            {
+                ExportSetting copy = item;
+                contextExport.Items.Add(item.Name, null, delegate
+                {
+                    base.Main.ConvertComic(GetBookList(ComicBookFilterType.Selected, asArray: true), copy);
+                }).Enabled = enabled;
+            }
+        }
 
-		private void miAddList_DropDownOpening(object sender, EventArgs e)
-		{
-			int listMenuSize = Program.ExtendedSettings.ListMenuSize;
-			ToolStripMenuItem toolStripMenuItem = (ToolStripMenuItem)sender;
-			int num = 0;
-			IEnumerable<ComicBook> selectedBooks = GetBookList(ComicBookFilterType.Library | ComicBookFilterType.Selected);
-			ComicLibrary comicLibrary = selectedBooks.Select((ComicBook cb) => cb.Container as ComicLibrary).FirstOrDefault();
-			if (comicLibrary == null || !comicLibrary.EditMode.CanEditList())
-			{
-				return;
-			}
-			FormUtility.SafeToolStripClear(toolStripMenuItem.DropDownItems);
-			foreach (ComicIdListItem item in from l in comicLibrary.ComicLists.GetItems<ComicIdListItem>()
-				where l != BookList
-				select l)
-			{
-				if (++num == listMenuSize + 1)
-				{
-					break;
-				}
-				ComicIdListItem li = item;
-				int childLevel = comicLibrary.ComicLists.GetChildLevel((ComicListItem)li);
-				string str = new string(' ', childLevel * 4);
-				if (num == listMenuSize)
-				{
-					toolStripMenuItem.DropDownItems.Add(new ToolStripMenuItem("...")
-					{
-						Enabled = false
-					});
-				}
-				else
-				{
-					toolStripMenuItem.DropDownItems.Add(str + li.Name, GetComicListImage(li), delegate
-					{
-						li.AddRange(selectedBooks);
-					});
-				}
-			}
-			AddNoneEntry(toolStripMenuItem.DropDownItems);
-		}
+        private void miAddList_DropDownOpening(object sender, EventArgs e)
+        {
+            int listMenuSize = Program.ExtendedSettings.ListMenuSize;
+            ToolStripMenuItem toolStripMenuItem = (ToolStripMenuItem)sender;
+            int num = 0;
+            IEnumerable<ComicBook> selectedBooks = GetBookList(ComicBookFilterType.Library | ComicBookFilterType.Selected);
+            ComicLibrary comicLibrary = selectedBooks.Select((ComicBook cb) => cb.Container as ComicLibrary).FirstOrDefault();
+            if (comicLibrary == null || !comicLibrary.EditMode.CanEditList())
+            {
+                return;
+            }
+            FormUtility.SafeToolStripClear(toolStripMenuItem.DropDownItems);
+            foreach (ComicIdListItem item in from l in comicLibrary.ComicLists.GetItems<ComicIdListItem>()
+                                             where l != BookList
+                                             select l)
+            {
+                if (++num == listMenuSize + 1)
+                {
+                    break;
+                }
+                ComicIdListItem li = item;
+                int childLevel = comicLibrary.ComicLists.GetChildLevel((ComicListItem)li);
+                string str = new string(' ', childLevel * 4);
+                if (num == listMenuSize)
+                {
+                    toolStripMenuItem.DropDownItems.Add(new ToolStripMenuItem("...")
+                    {
+                        Enabled = false
+                    });
+                }
+                else
+                {
+                    toolStripMenuItem.DropDownItems.Add(str + li.Name, GetComicListImage(li), delegate
+                    {
+                        li.AddRange(selectedBooks);
+                    });
+                }
+            }
+            AddNoneEntry(toolStripMenuItem.DropDownItems);
+        }
 
-		private void tbbDuplicateList_DropDownOpening(object sender, EventArgs e)
-		{
-			if (Library == null)
-			{
-				return;
-			}
-			ToolStripDropDownItem toolStripDropDownItem = (ToolStripDropDownItem)sender;
-			FormUtility.SafeToolStripClear(toolStripDropDownItem.DropDownItems);
-			foreach (ComicListItemFolder item in Library.ComicLists.GetItems<ComicListItemFolder>())
-			{
-				ComicListItemFolder li = item;
-				int childLevel = Library.ComicLists.GetChildLevel((ComicListItem)li);
-				string str = new string(' ', childLevel * 4);
-				toolStripDropDownItem.DropDownItems.Add(str + li.Name, GetComicListImage(li), delegate
-				{
-					DuplicateList(li);
-				});
-			}
-			AddNoneEntry(toolStripDropDownItem.DropDownItems);
-		}
+        private void tbbDuplicateList_DropDownOpening(object sender, EventArgs e)
+        {
+            if (Library == null)
+            {
+                return;
+            }
+            ToolStripDropDownItem toolStripDropDownItem = (ToolStripDropDownItem)sender;
+            FormUtility.SafeToolStripClear(toolStripDropDownItem.DropDownItems);
+            foreach (ComicListItemFolder item in Library.ComicLists.GetItems<ComicListItemFolder>())
+            {
+                ComicListItemFolder li = item;
+                int childLevel = Library.ComicLists.GetChildLevel((ComicListItem)li);
+                string str = new string(' ', childLevel * 4);
+                toolStripDropDownItem.DropDownItems.Add(str + li.Name, GetComicListImage(li), delegate
+                {
+                    DuplicateList(li);
+                });
+            }
+            AddNoneEntry(toolStripDropDownItem.DropDownItems);
+        }
 
-		private void miShowInList_DropDownOpening(object sender, EventArgs e)
-		{
-			if (Library == null)
-			{
-				return;
-			}
-			int maxLists = Program.ExtendedSettings.ListMenuSize;
-			ToolStripMenuItem menu = (ToolStripMenuItem)sender;
-			ComicBook cb = GetBookList(ComicBookFilterType.Selected).FirstOrDefault();
-			if (cb == null)
-			{
-				return;
-			}
-			try
-			{
-				buildMenuThread.Join(5000);
-			}
-			catch
-			{
-			}
-			FormUtility.SafeToolStripClear(menu.DropDownItems);
-			ToolStripItem dummy = menu.DropDownItems.Add(TR.Load(base.Name)["SearchingLists", "Searching list..."]);
-			dummy.Enabled = false;
-			abortBuildMenu.Reset();
-			buildMenuThread = ThreadUtility.RunInBackground("Build list menu", delegate
-			{
-				try
-				{
-					Library.ComicListsLocked = true;
-					int count = 0;
-					foreach (ComicListItem item in from l in Library.ComicLists.GetItems<ComicListItem>()
-						where l.GetBooks().Contains(cb)
-						select l)
-					{
-						if (abortBuildMenu.WaitOne(0))
-							return;
+        private void miShowInList_DropDownOpening(object sender, EventArgs e)
+        {
+            if (Library == null)
+            {
+                return;
+            }
+            int maxLists = Program.ExtendedSettings.ListMenuSize;
+            ToolStripMenuItem menu = (ToolStripMenuItem)sender;
+            ComicBook cb = GetBookList(ComicBookFilterType.Selected).FirstOrDefault();
+            if (cb == null)
+            {
+                return;
+            }
+            try
+            {
+                buildMenuThread.Join(5000);
+            }
+            catch
+            {
+            }
+            FormUtility.SafeToolStripClear(menu.DropDownItems);
+            ToolStripItem dummy = menu.DropDownItems.Add(TR.Load(base.Name)["SearchingLists", "Searching list..."]);
+            dummy.Enabled = false;
+            abortBuildMenu.Reset();
+            buildMenuThread = ThreadUtility.RunInBackground("Build list menu", delegate
+            {
+                try
+                {
+                    Library.ComicListsLocked = true;
+                    int count = 0;
+                    foreach (ComicListItem item in from l in Library.ComicLists.GetItems<ComicListItem>()
+                                                   where l.GetBooks().Contains(cb)
+                                                   select l)
+                    {
+                        if (abortBuildMenu.WaitOne(0))
+                            return;
 
                         if (++count == maxLists + 1)
-							break;
+                            break;
 
                         ComicListItem li = item;
                         string prefix = new string(' ', Library.ComicLists.GetChildLevel(li) * 4);
-						this.Invoke(delegate
-						{
+                        this.Invoke(delegate
+                        {
                             ToolStripMenuItem value = ((count != maxLists) 
                                 ? new ToolStripMenuItem(prefix + li.Name, GetComicListImage(li), delegate{ ShowBookInList(li, cb); }) 
                                 : new ToolStripMenuItem("...") { Enabled = false });
-							menu.DropDownItems.Insert(menu.DropDownItems.Count - 1, value);
-						});
-					}
-					this.Invoke(delegate
-					{
-						menu.DropDownItems.Remove(dummy);
-					});
-				}
-				catch (Exception)
-				{
-				}
-				finally
-				{
-					Library.ComicListsLocked = false;
-				}
-			});
-		}
+                            menu.DropDownItems.Insert(menu.DropDownItems.Count - 1, value);
+                        });
+                    }
+                    this.Invoke(delegate
+                    {
+                        menu.DropDownItems.Remove(dummy);
+                    });
+                }
+                catch (Exception)
+                {
+                }
+                finally
+                {
+                    Library.ComicListsLocked = false;
+                }
+            });
+        }
 
-		private void miShowInList_DropDownClosed(object sender, EventArgs e)
-		{
-			abortBuildMenu.Set();
-		}
+        private void miShowInList_DropDownClosed(object sender, EventArgs e)
+        {
+            abortBuildMenu.Set();
+        }
 
-		private void ShowBookInList(ComicListItem list, ComicBook cb)
-		{
-			if (base.Main != null)
-			{
-				base.Main.ShowBookInList(Library, list, cb, switchToList: true);
-			}
-		}
+        private void ShowBookInList(ComicListItem list, ComicBook cb)
+        {
+            if (base.Main != null)
+            {
+                base.Main.ShowBookInList(Library, list, cb, switchToList: true);
+            }
+        }
 
-		private void AddNoneEntry(ToolStripItemCollection ic)
-		{
-			if (ic.Count == 0)
-			{
-				ic.Add(TR.Default["None", "None"]).Enabled = false;
-			}
-		}
+        private void AddNoneEntry(ToolStripItemCollection ic)
+        {
+            if (ic.Count == 0)
+            {
+                ic.Add(TR.Default["None", "None"]).Enabled = false;
+            }
+        }
 
-		private Image GetComicListImage(ComicListItem cli)
-		{
-			switch (cli.ImageKey)
-			{
-			case "Library":
-				return Resources.Library;
-			case "Folder":
-				return Resources.SearchFolder;
-			case "Search":
-				return Resources.SearchDocument;
-			case "List":
-				return Resources.List;
-			case "TempFolder":
-				return Resources.TempFolder;
-			default:
-				return null;
-			}
-		}
+        private Image GetComicListImage(ComicListItem cli)
+        {
+            switch (cli.ImageKey)
+            {
+                case "Library":
+                    return Resources.Library;
+                case "Folder":
+                    return Resources.SearchFolder;
+                case "Search":
+                    return Resources.SearchDocument;
+                case "List":
+                    return Resources.List;
+                case "TempFolder":
+                    return Resources.TempFolder;
+                default:
+                    return null;
+            }
+        }
 
-		public IEnumerable<ComicBook> GetBookList(ComicBookFilterType cbft, bool asArray)
-		{
-			if (asArray)
-			{
-				cbft |= ComicBookFilterType.AsArray;
-			}
-			return GetBookList(cbft);
-		}
+        public IEnumerable<ComicBook> GetBookList(ComicBookFilterType cbft, bool asArray)
+        {
+            if (asArray)
+            {
+                cbft |= ComicBookFilterType.AsArray;
+            }
+            return GetBookList(cbft);
+        }
 
-		protected virtual void OnCurrentBookListChanged()
-		{
-			bookSelectorPanel.ClearNot();
-			bookListDirty = true;
-			if (this.CurrentBookListChanged != null)
-			{
-				this.CurrentBookListChanged(this, EventArgs.Empty);
-			}
-		}
+        protected virtual void OnCurrentBookListChanged()
+        {
+            bookSelectorPanel.ClearNot();
+            bookListDirty = true;
+            if (this.CurrentBookListChanged != null)
+            {
+                this.CurrentBookListChanged(this, EventArgs.Empty);
+            }
+        }
 
-		protected virtual void OnQuickSearchChanged()
-		{
-			if (tsQuickSearch.TextBox.Text != quickSearch)
-			{
-				tsQuickSearch.TextBox.Text = quickSearch;
-			}
-			if (!blockQuickSearchUpdate)
-			{
-				quickSearchTimer.Stop();
-				quickSearchTimer.Start();
-				if (this.QuickSearchChanged != null)
-				{
-					this.QuickSearchChanged(this, EventArgs.Empty);
-				}
-			}
-		}
+        protected virtual void OnQuickSearchChanged()
+        {
+            if (tsQuickSearch.TextBox.Text != quickSearch)
+            {
+                tsQuickSearch.TextBox.Text = quickSearch;
+            }
+            if (!blockQuickSearchUpdate)
+            {
+                quickSearchTimer.Stop();
+                quickSearchTimer.Start();
+                if (this.QuickSearchChanged != null)
+                {
+                    this.QuickSearchChanged(this, EventArgs.Empty);
+                }
+            }
+        }
 
-		protected virtual void OnSearchBrowserVisibleChanged()
-		{
-			IMatcher<ComicBook> currentMatcher = bookSelectorPanel.CurrentMatcher;
-			if (searchBrowserContainer.Expanded)
-			{
-				searchBrowserContainer.Expanded = SearchBrowserVisible;
-			}
-			FillBookSelector();
-			if (!searchBrowserContainer.Expanded)
-			{
-				searchBrowserContainer.Expanded = SearchBrowserVisible;
-			}
-			FillBookList();
-			if (this.SearchBrowserVisibleChanged != null)
-			{
-				this.SearchBrowserVisibleChanged(this, EventArgs.Empty);
-			}
-		}
+        protected virtual void OnSearchBrowserVisibleChanged()
+        {
+            IMatcher<ComicBook> currentMatcher = bookSelectorPanel.CurrentMatcher;
+            if (searchBrowserContainer.Expanded)
+            {
+                searchBrowserContainer.Expanded = SearchBrowserVisible;
+            }
+            FillBookSelector();
+            if (!searchBrowserContainer.Expanded)
+            {
+                searchBrowserContainer.Expanded = SearchBrowserVisible;
+            }
+            FillBookList();
+            if (this.SearchBrowserVisibleChanged != null)
+            {
+                this.SearchBrowserVisibleChanged(this, EventArgs.Empty);
+            }
+        }
 
-		private void toolTip_Popup(object sender, PopupEventArgs e)
-		{
-			e.ToolTipSize = new Size(360, 120);
-			e.Cancel = !Program.Settings.ShowToolTips || toolTipItem == null || itemView.ItemViewMode == ItemViewMode.Tile;
-		}
+        private void toolTip_Popup(object sender, PopupEventArgs e)
+        {
+            e.ToolTipSize = new Size(360, 120);
+            e.Cancel = !Program.Settings.ShowToolTips || toolTipItem == null || itemView.ItemViewMode == ItemViewMode.Tile;
+        }
 
-		private void toolTip_Draw(object sender, DrawToolTipEventArgs e)
-		{
-			if (toolTipItem == null)
-			{
-				return;
-			}
-			using (IItemLock<ThumbnailImage> itemLock = toolTipItem.GetThumbnail(memoryOnly: true))
-			{
-				ComicBook comic = toolTipItem.Comic;
-				VisualStyleElement normal = VisualStyleElement.ToolTip.Standard.Normal;
-				if (VisualStyleRenderer.IsSupported && VisualStyleRenderer.IsElementDefined(normal))
-				{
-					VisualStyleRenderer visualStyleRenderer = new VisualStyleRenderer(normal);
-					visualStyleRenderer.DrawBackground(e.Graphics, e.Bounds);
-				}
-				else
-				{
-					e.DrawBackground();
-					e.DrawBorder();
-				}
-				Rectangle bounds = e.Bounds;
-				bounds.Inflate(-10, -10);
-				ThumbTileRenderer.DrawTile(e.Graphics, bounds, itemLock.Item.GetThumbnail(bounds.Height), comic, FC.GetRelative(Font, 1.2f), SystemColors.InfoText, Color.Transparent, ThumbnailDrawingOptions.DefaultWithoutBackground, ComicTextElements.DefaultComic, threeD: false);
-			}
-		}
+        private void toolTip_Draw(object sender, DrawToolTipEventArgs e)
+        {
+            if (toolTipItem == null)
+            {
+                return;
+            }
+            using (IItemLock<ThumbnailImage> itemLock = toolTipItem.GetThumbnail(memoryOnly: true))
+            {
+                ComicBook comic = toolTipItem.Comic;
+                VisualStyleElement normal = VisualStyleElement.ToolTip.Standard.Normal;
+                if (VisualStyleRenderer.IsSupported && VisualStyleRenderer.IsElementDefined(normal))
+                {
+                    VisualStyleRenderer visualStyleRenderer = new VisualStyleRenderer(normal);
+                    visualStyleRenderer.DrawBackground(e.Graphics, e.Bounds);
+                }
+                else
+                {
+                    e.DrawBackground();
+                    e.DrawBorder();
+                }
+                Rectangle bounds = e.Bounds;
+                bounds.Inflate(-10, -10);
+                ThumbTileRenderer.DrawTile(e.Graphics, bounds, itemLock.Item.GetThumbnail(bounds.Height), comic, FC.GetRelative(Font, 1.2f), SystemColors.InfoText, Color.Transparent, ThumbnailDrawingOptions.DefaultWithoutBackground, ComicTextElements.DefaultComic, threeD: false);
+            }
+        }
 
-		private void foundView_MouseLeave(object sender, EventArgs e)
-		{
-			toolTip.SetToolTip(this, null);
-		}
+        private void foundView_MouseLeave(object sender, EventArgs e)
+        {
+            toolTip.SetToolTip(this, null);
+        }
 
-		private void foundView_MouseHover(object sender, EventArgs e)
-		{
-			Point point = itemView.PointToClient(Cursor.Position);
-			toolTipItem = itemView.ItemHitTest(point.X, point.Y) as CoverViewItem;
-			if (toolTipItem != null && toolTipItem.Comic != null)
-			{
-				string text = toolTipItem.Comic.Id.ToString();
-				if (toolTip.GetToolTip(itemView) != text && Program.Settings.ShowToolTips)
-				{
-					toolTip.SetToolTip(itemView, text);
-				}
-			}
-		}
+        private void foundView_MouseHover(object sender, EventArgs e)
+        {
+            Point point = itemView.PointToClient(Cursor.Position);
+            toolTipItem = itemView.ItemHitTest(point.X, point.Y) as CoverViewItem;
+            if (toolTipItem != null && toolTipItem.Comic != null)
+            {
+                string text = toolTipItem.Comic.Id.ToString();
+                if (toolTip.GetToolTip(itemView) != text && Program.Settings.ShowToolTips)
+                {
+                    toolTip.SetToolTip(itemView, text);
+                }
+            }
+        }
 
-		private void foundView_MouseMove(object sender, MouseEventArgs e)
-		{
-			itemView.ResetMouse();
-		}
+        private void foundView_MouseMove(object sender, MouseEventArgs e)
+        {
+            itemView.ResetMouse();
+        }
 
-		public void RefreshDisplay()
-		{
-			AutomaticProgressDialog.Process(this, TR.Messages["GettingList", "Getting Books List"], TR.Messages["GettingListText", "Retrieving all Books from the selected folder"], 1000, BookList.Refresh, AutomaticProgressDialogOptions.EnableCancel);
-			FillBookList();
-		}
+        public void RefreshDisplay()
+        {
+            AutomaticProgressDialog.Process(this, TR.Messages["GettingList", "Getting Books List"], TR.Messages["GettingListText", "Retrieving all Books from the selected folder"], 1000, BookList.Refresh, AutomaticProgressDialogOptions.EnableCancel);
+            FillBookList();
+        }
 
-		public void SettingsChanged()
-		{
-			SetCustomColumns();
-			FillBookList();
-		}
+        public void SettingsChanged()
+        {
+            SetCustomColumns();
+            SetVirtualTagColumns();
+            FillBookList();
+        }
 
-		public void FocusQuickSearch()
-		{
-			tsQuickSearch.TextBox.Focus();
-		}
+        public void FocusQuickSearch()
+        {
+            tsQuickSearch.TextBox.Focus();
+        }
 
-		public void SetWorkspace(DisplayWorkspace ws)
-		{
-			tsQuickSearch.TextBox.AutoCompleteList.AddRange(Program.Settings.QuickSearchList.ToArray());
-		}
+        public void SetWorkspace(DisplayWorkspace ws)
+        {
+            tsQuickSearch.TextBox.AutoCompleteList.AddRange(Program.Settings.QuickSearchList.ToArray());
+        }
 
-		public void StoreWorkspace(DisplayWorkspace ws)
-		{
-			if (bookList == null)
-			{
-				return;
-			}
-			UpdateViewConfig();
-			if (!base.Disposing && tsQuickSearch.TextBox != null)
-			{
-				try
-				{
-					HashSet<string> collection = new HashSet<string>(tsQuickSearch.TextBox.AutoCompleteList.Cast<string>());
-					Program.Settings.QuickSearchList.Clear();
-					Program.Settings.QuickSearchList.AddRange(collection);
-				}
-				catch
-				{
-				}
-			}
-		}
+        public void StoreWorkspace(DisplayWorkspace ws)
+        {
+            if (bookList == null)
+            {
+                return;
+            }
+            UpdateViewConfig();
+            if (!base.Disposing && tsQuickSearch.TextBox != null)
+            {
+                try
+                {
+                    HashSet<string> collection = new HashSet<string>(tsQuickSearch.TextBox.AutoCompleteList.Cast<string>());
+                    Program.Settings.QuickSearchList.Clear();
+                    Program.Settings.QuickSearchList.AddRange(collection);
+                }
+                catch
+                {
+                }
+            }
+        }
 
-		private void UpdateViewConfig()
-		{
-			if (DisableViewConfigUpdate)
-			{
-				return;
-			}
-			IDisplayListConfig displayListConfig = bookList.QueryService<IDisplayListConfig>();
-			if (displayListConfig != null)
-			{
-				CoverViewItem coverViewItem = stackItem as CoverViewItem;
-				if (coverViewItem != null)
-				{
-					displayListConfig.Display = new DisplayListConfig(preStackConfig, ThumbnailConfig, null, stacksConfig, backgroundImageSource)
-					{
-						ScrollPosition = preStackScrollPosition,
-						FocusedComicId = preStackFocusedId,
-						StackedComicId = coverViewItem.Comic.Id,
-						StackScrollPosition = itemView.ScrollPosition,
-						StackFocusedComicId = GetFocusedId()
-					};
-				}
-				else
-				{
-					displayListConfig.Display = new DisplayListConfig(itemView.ViewConfig, ThumbnailConfig, null, stacksConfig, backgroundImageSource)
-					{
-						ScrollPosition = itemView.ScrollPosition,
-						FocusedComicId = GetFocusedId()
-					};
-				}
-				displayListConfig.Display.QuickSearch = QuickSearch;
-				displayListConfig.Display.QuickSearchType = QuickSearchType;
-				displayListConfig.Display.ShowOptionType = ShowOptionType;
-				displayListConfig.Display.ShowComicType = ShowComicType;
-				displayListConfig.Display.ShowOnlyDuplicates = ShowOnlyDuplicates;
-				displayListConfig.Display.ShowGroupHeaders = ShowGroupHeaders;
-				displayListConfig.Display.ShowGroupHeadersWidth = ((newGroupListWidth != 0) ? newGroupListWidth : (browserContainer.ClientRectangle.Width - browserContainer.SplitterDistance));
-			}
-		}
+        private void UpdateViewConfig()
+        {
+            if (DisableViewConfigUpdate)
+            {
+                return;
+            }
+            IDisplayListConfig displayListConfig = bookList.QueryService<IDisplayListConfig>();
+            if (displayListConfig != null)
+            {
+                CoverViewItem coverViewItem = stackItem as CoverViewItem;
+                if (coverViewItem != null)
+                {
+                    displayListConfig.Display = new DisplayListConfig(preStackConfig, ThumbnailConfig, null, stacksConfig, backgroundImageSource)
+                    {
+                        ScrollPosition = preStackScrollPosition,
+                        FocusedComicId = preStackFocusedId,
+                        StackedComicId = coverViewItem.Comic.Id,
+                        StackScrollPosition = itemView.ScrollPosition,
+                        StackFocusedComicId = GetFocusedId()
+                    };
+                }
+                else
+                {
+                    displayListConfig.Display = new DisplayListConfig(itemView.ViewConfig, ThumbnailConfig, null, stacksConfig, backgroundImageSource)
+                    {
+                        ScrollPosition = itemView.ScrollPosition,
+                        FocusedComicId = GetFocusedId()
+                    };
+                }
+                displayListConfig.Display.QuickSearch = QuickSearch;
+                displayListConfig.Display.QuickSearchType = QuickSearchType;
+                displayListConfig.Display.ShowOptionType = ShowOptionType;
+                displayListConfig.Display.ShowComicType = ShowComicType;
+                displayListConfig.Display.ShowOnlyDuplicates = ShowOnlyDuplicates;
+                displayListConfig.Display.ShowGroupHeaders = ShowGroupHeaders;
+                displayListConfig.Display.ShowGroupHeadersWidth = ((newGroupListWidth != 0) ? newGroupListWidth : (browserContainer.ClientRectangle.Width - browserContainer.SplitterDistance));
+            }
+        }
 
-		private Guid GetFocusedId()
-		{
-			return ((itemView.FocusedItem ?? itemView.SelectedItems.FirstOrDefault()) as CoverViewItem)?.Comic.Id ?? Guid.Empty;
-		}
+        private Guid GetFocusedId()
+        {
+            return ((itemView.FocusedItem ?? itemView.SelectedItems.FirstOrDefault()) as CoverViewItem)?.Comic.Id ?? Guid.Empty;
+        }
 
-		private void SetFocusedItem(Guid id)
-		{
-			if (!(id == Guid.Empty))
-			{
-				CoverViewItem coverViewItem = itemView.DisplayedItems.OfType<CoverViewItem>().FirstOrDefault((CoverViewItem ci) => ci.Comic.Id == id);
-				if (coverViewItem != null)
-				{
-					coverViewItem.Focused = true;
-					coverViewItem.Selected = true;
-					coverViewItem.EnsureVisible();
-				}
-			}
-		}
+        private void SetFocusedItem(Guid id)
+        {
+            if (!(id == Guid.Empty))
+            {
+                CoverViewItem coverViewItem = itemView.DisplayedItems.OfType<CoverViewItem>().FirstOrDefault((CoverViewItem ci) => ci.Comic.Id == id);
+                if (coverViewItem != null)
+                {
+                    coverViewItem.Focused = true;
+                    coverViewItem.Selected = true;
+                    coverViewItem.EnsureVisible();
+                }
+            }
+        }
 
-		public bool SelectComic(ComicBook comic)
-		{
-			CloseStack(withUpdate: true);
-			CoverViewItem coverViewItem = itemView.DisplayedItems.OfType<CoverViewItem>().FirstOrDefault((CoverViewItem c) => (!itemView.IsStack(c)) ? (c.Comic == comic) : (itemView.GetStackItems(c).OfType<CoverViewItem>().FirstOrDefault((CoverViewItem sc) => sc.Comic == comic) != null));
-			if (coverViewItem == null)
-			{
-				if (string.IsNullOrEmpty(QuickSearch) && ShowOptionType == ComicBookAllPropertiesMatcher.ShowOptionType.All && ShowComicType == ComicBookAllPropertiesMatcher.ShowComicType.All && !ShowOnlyDuplicates)
-				{
-					return false;
-				}
-				QuickSearch = string.Empty;
-				ShowOptionType = ComicBookAllPropertiesMatcher.ShowOptionType.All;
-				ShowComicType = ComicBookAllPropertiesMatcher.ShowComicType.All;
-				ShowOnlyDuplicates = false;
-				UpdateSearch();
-				return SelectComic(comic);
-			}
-			if (itemView.IsStack(coverViewItem))
-			{
-				OpenStack(coverViewItem);
-				coverViewItem = itemView.DisplayedItems.OfType<CoverViewItem>().FirstOrDefault((CoverViewItem c) => c.Comic == comic);
-			}
-			itemView.SelectAll(selectionState: false);
-			if (coverViewItem != null)
-			{
-				coverViewItem.Selected = true;
-				coverViewItem.Focused = true;
-				coverViewItem.EnsureVisible();
-			}
-			return true;
-		}
+        public bool SelectComic(ComicBook comic)
+        {
+            CloseStack(withUpdate: true);
+            CoverViewItem coverViewItem = itemView.DisplayedItems.OfType<CoverViewItem>().FirstOrDefault((CoverViewItem c) => (!itemView.IsStack(c)) ? (c.Comic == comic) : (itemView.GetStackItems(c).OfType<CoverViewItem>().FirstOrDefault((CoverViewItem sc) => sc.Comic == comic) != null));
+            if (coverViewItem == null)
+            {
+                if (string.IsNullOrEmpty(QuickSearch) && ShowOptionType == ComicBookAllPropertiesMatcher.ShowOptionType.All && ShowComicType == ComicBookAllPropertiesMatcher.ShowComicType.All && !ShowOnlyDuplicates)
+                {
+                    return false;
+                }
+                QuickSearch = string.Empty;
+                ShowOptionType = ComicBookAllPropertiesMatcher.ShowOptionType.All;
+                ShowComicType = ComicBookAllPropertiesMatcher.ShowComicType.All;
+                ShowOnlyDuplicates = false;
+                UpdateSearch();
+                return SelectComic(comic);
+            }
+            if (itemView.IsStack(coverViewItem))
+            {
+                OpenStack(coverViewItem);
+                coverViewItem = itemView.DisplayedItems.OfType<CoverViewItem>().FirstOrDefault((CoverViewItem c) => c.Comic == comic);
+            }
+            itemView.SelectAll(selectionState: false);
+            if (coverViewItem != null)
+            {
+                coverViewItem.Selected = true;
+                coverViewItem.Focused = true;
+                coverViewItem.EnsureVisible();
+            }
+            return true;
+        }
 
-		public bool SelectComics(IEnumerable<ComicBook> books)
-		{
-			bool flag = true;
-			HashSet<ComicBook> hashSet = new HashSet<ComicBook>(books);
-			UpdatePending();
-			itemView.SelectAll(selectionState: false);
-			foreach (CoverViewItem displayedItem in itemView.DisplayedItems)
-			{
-				displayedItem.Selected = hashSet.Contains(displayedItem.Comic);
-				if (flag && displayedItem.Selected)
-				{
-					displayedItem.EnsureVisible();
-				}
-				flag = false;
-			}
-			return true;
-		}
+        public bool SelectComics(IEnumerable<ComicBook> books)
+        {
+            bool flag = true;
+            HashSet<ComicBook> hashSet = new HashSet<ComicBook>(books);
+            UpdatePending();
+            itemView.SelectAll(selectionState: false);
+            foreach (CoverViewItem displayedItem in itemView.DisplayedItems)
+            {
+                displayedItem.Selected = hashSet.Contains(displayedItem.Comic);
+                if (flag && displayedItem.Selected)
+                {
+                    displayedItem.EnsureVisible();
+                }
+                flag = false;
+            }
+            return true;
+        }
 
-		public IEnumerable<ComicBook> GetBookList(ComicBookFilterType cbft)
-		{
-			IEnumerable<ComicBook> books = ((!cbft.HasFlag(ComicBookFilterType.Selected)) ? (from CoverViewItem vi in itemView.DisplayedItems
-				select vi.Comic) : (from CoverViewItem vi in itemView.SelectedItems
-				select vi.Comic));
-			books = ComicBookCollection.Filter(cbft, books);
-			if (cbft.HasFlag(ComicBookFilterType.Sorted) && itemView.ItemSortOrder == SortOrder.Descending)
-			{
-				books = books.Reverse();
-			}
-			return books;
-		}
+        public IEnumerable<ComicBook> GetBookList(ComicBookFilterType cbft)
+        {
+            IEnumerable<ComicBook> books = ((!cbft.HasFlag(ComicBookFilterType.Selected)) ? (from CoverViewItem vi in itemView.DisplayedItems
+                                                                                             select vi.Comic) : (from CoverViewItem vi in itemView.SelectedItems
+                                                                                                                 select vi.Comic));
+            books = ComicBookCollection.Filter(cbft, books);
+            if (cbft.HasFlag(ComicBookFilterType.Sorted) && itemView.ItemSortOrder == SortOrder.Descending)
+            {
+                books = books.Reverse();
+            }
+            return books;
+        }
     }
 }


### PR DESCRIPTION
## Before testing this version. [BACKUP](https://github.com/maforget/cr-backup-manager/releases/download/v1.1/CR.Backup.Manager_v1.1.crplugin) your `Config.xml` & `ComicDb.xml` (Do a Full Backup with the Backup Manager). I suggest testing it in portable mode first.

**You need to login to Github to download the link below:**

A Little test version for the new Virtual Tags (or Fields feature). Set it up in the Preferences => Library (at the bottom). There are 10 available Virtual Tags. They can be used as sorting, grouping, stacking and Smart Lists. It uses the feature that sets the caption in the `ComicRack.ini`. 

You can format numbers refer to [this page](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-numeric-format-strings) on Microsoft's site. In the documentation linked you will see something like `{0:000}`, you basically just need to enter the `000`. The rest is auto inserted, so you could technically pretty much do all the formatting that is linked.

### Known Problem:
The reason I stated to **backup** before hand, is that if the new columns & smart lists are saved inside your Database & Settings file. If for example you create a smart list containing one of the new Virtual TAG and decide to go back to the OG version, an older release or simply an non test version without this feature **it will reset your database**. If you ever want to go back you don't have any smart lists that contains the Virtual Tags.

### Syntax:
```
So the syntax is:
[ prefix { fieldName } suffix ]

For numbering:
[ prefix { fieldName:numberFormat } suffix ]
```

Here are some examples from the `ComicRack.ini` file:

**Format of eComic captions**
`[{format} ][{series}][ - {title}][ {volume}][ #{number}][ ({year}[/{month}])]`

**Same as above but with numbering format**
`[{format} ][{series}][ - {title}][ V{volumeonly:00000}][ #{numberonly:000} [of {count}]][ ({year}[/{month}])]`

**Export File Naming**
`[{format} ][{series}][ {volume}][ #{number}][ ({year}[/{month}])]`

You can embed a field inside another or even insert a reference to another Virtual Tag. **Just don't reference a tag inside itself, it will crash the program.** I did add a small protection so you can't save it or add it. 