### PR TITLE
Disabled the Dialog for saving changes to Non-DB files if AutoUpdateComicFiles is active

### DIFF
--- a/ComicRack/MainForm.cs
+++ b/ComicRack/MainForm.cs
@@ -1072,7 +1072,7 @@ namespace cYo.Projects.ComicRack.Viewer
 				e.Cancel = true;
 				return;
 			}
-			if (Program.Settings.UpdateComicFiles)
+			if (Program.Settings.UpdateComicFiles && !Program.Settings.AutoUpdateComicsFiles)
 			{
 				IEnumerable<ComicBook> dirtyTempList = Program.BookFactory.TemporaryBooks.Where((ComicBook cb) => cb.ComicInfoIsDirty);
 				int dirtyCount = dirtyTempList.Count();


### PR DESCRIPTION
Disabled the Dialog for saving changes to Non-DB files if AutoUpdateComicFiles is active.

This should fix issue:
https://github.com/maforget/ComicRackCE/issues/45