### PR TITLE
FIX for issue #74 - Re-export a comic with WEBP images, changes the images to JPEG

### DIFF
--- a/ComicRack.Engine/ComicBookNavigator.cs
+++ b/ComicRack.Engine/ComicBookNavigator.cs
@@ -663,15 +663,15 @@ namespace cYo.Projects.ComicRack.Engine
 			return provider.GetByteImage(index);
 		}
 
-        public byte[] GetByteImageForExport(int index)
-        {
-            if (provider == null)
-            {
-                return null;
-            }
-            return provider.GetByteImageForExport(index);
-        }
-        
+		public ExportImageContainer GetByteImageForExport(int index)
+		{
+			if (provider == null)
+			{
+				return null;
+			}
+			return provider.GetByteImageForExport(index);
+		}
+
 		public ProviderImageInfo GetImageInfo(int index)
 		{
 			if (provider == null)

--- a/ComicRack.Engine/ComicBookNavigator.cs
+++ b/ComicRack.Engine/ComicBookNavigator.cs
@@ -663,6 +663,15 @@ namespace cYo.Projects.ComicRack.Engine
 			return provider.GetByteImage(index);
 		}
 
+        public byte[] GetByteImageForExport(int index)
+        {
+            if (provider == null)
+            {
+                return null;
+            }
+            return provider.GetByteImageForExport(index);
+        }
+        
 		public ProviderImageInfo GetImageInfo(int index)
 		{
 			if (provider == null)

--- a/ComicRack.Engine/ComicRack.Engine.csproj
+++ b/ComicRack.Engine/ComicRack.Engine.csproj
@@ -61,6 +61,7 @@
     <Compile Include="CacheManager.cs" />
     <Compile Include="ComicBook.cs" />
     <Compile Include="Database\RecursionCache.cs" />
+    <Compile Include="IO\Provider\ExportImageContainer.cs" />
     <Compile Include="IO\Provider\Pdfium.cs" />
     <Compile Include="IO\Provider\Readers\Pdf\PdfiumReaderEngine.cs" />
     <Compile Include="Metadata\ComicBook\Comparer\ComicBookAddedComparer.cs" />

--- a/ComicRack.Engine/IO/ComicBookImageProvider.cs
+++ b/ComicRack.Engine/IO/ComicBookImageProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Drawing;
 using cYo.Common.ComponentModel;
+using cYo.Common.Threading;
 using cYo.Projects.ComicRack.Engine.IO.Provider;
 
 namespace cYo.Projects.ComicRack.Engine.IO
@@ -61,7 +62,13 @@ namespace cYo.Projects.ComicRack.Engine.IO
 			return provider.GetByteImage(index);
 		}
 
-		public ProviderImageInfo GetImageInfo(int index)
+        public byte[] GetByteImageForExport(int index)
+        {
+            CheckProvider();
+            return provider.GetByteImageForExport(index);
+        }
+
+        public ProviderImageInfo GetImageInfo(int index)
 		{
 			CheckProvider();
 			return provider.GetImageInfo(index);

--- a/ComicRack.Engine/IO/ComicBookImageProvider.cs
+++ b/ComicRack.Engine/IO/ComicBookImageProvider.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Drawing;
 using cYo.Common.ComponentModel;
-using cYo.Common.Threading;
 using cYo.Projects.ComicRack.Engine.IO.Provider;
 
 namespace cYo.Projects.ComicRack.Engine.IO
@@ -62,13 +61,13 @@ namespace cYo.Projects.ComicRack.Engine.IO
 			return provider.GetByteImage(index);
 		}
 
-        public byte[] GetByteImageForExport(int index)
-        {
-            CheckProvider();
-            return provider.GetByteImageForExport(index);
-        }
+		public ExportImageContainer GetByteImageForExport(int index)
+		{
+			CheckProvider();
+			return provider.GetByteImageForExport(index);
+		}
 
-        public ProviderImageInfo GetImageInfo(int index)
+		public ProviderImageInfo GetImageInfo(int index)
 		{
 			CheckProvider();
 			return provider.GetImageInfo(index);

--- a/ComicRack.Engine/IO/PageImage.cs
+++ b/ComicRack.Engine/IO/PageImage.cs
@@ -12,7 +12,9 @@ namespace cYo.Projects.ComicRack.Engine.IO
 
 		public static bool MemoryOptimized = true;
 
-		public Color BackgrounColor
+		public bool Merged { get; set; } = false;
+
+        public Color BackgrounColor
 		{
 			get;
 			set;
@@ -73,5 +75,12 @@ namespace cYo.Projects.ComicRack.Engine.IO
 		{
 			return new PageImage(bmp.ImageToJpegBytes());
 		}
-	}
+
+        public static PageImage CreateFromMerged(Bitmap bmp)
+        {
+            PageImage newPageImage = CreateFrom(bmp);
+			newPageImage.Merged = true;
+			return newPageImage;
+        }
+    }
 }

--- a/ComicRack.Engine/IO/Provider/ExportImageContainer.cs
+++ b/ComicRack.Engine/IO/Provider/ExportImageContainer.cs
@@ -1,0 +1,20 @@
+﻿using cYo.Common.Drawing;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace cYo.Projects.ComicRack.Engine.IO.Provider
+{
+    public class ExportImageContainer
+    {
+        public required byte[] Data { get; init; }
+
+        public Bitmap Bitmap => BitmapExtensions.BitmapFromBytes(Data);
+
+        public required bool NeedsToConvert { get; init; }
+
+    }
+}

--- a/ComicRack.Engine/IO/Provider/IImageProvider.cs
+++ b/ComicRack.Engine/IO/Provider/IImageProvider.cs
@@ -24,10 +24,10 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 
 		byte[] GetByteImage(int index);
 
-        byte[] GetByteImageForExport(int index);
+        ExportImageContainer GetByteImageForExport(int index);
 
         ProviderImageInfo GetImageInfo(int index);
 
 		ThumbnailImage GetThumbnail(int index);
-	}
+    }
 }

--- a/ComicRack.Engine/IO/Provider/IImageProvider.cs
+++ b/ComicRack.Engine/IO/Provider/IImageProvider.cs
@@ -24,7 +24,9 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 
 		byte[] GetByteImage(int index);
 
-		ProviderImageInfo GetImageInfo(int index);
+        byte[] GetByteImageForExport(int index);
+
+        ProviderImageInfo GetImageInfo(int index);
 
 		ThumbnailImage GetThumbnail(int index);
 	}

--- a/ComicRack.Engine/IO/Provider/ImageProvider.cs
+++ b/ComicRack.Engine/IO/Provider/ImageProvider.cs
@@ -139,7 +139,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
             {
                 return new ExportImageContainer()
 				{
-					Data = RetrieveSourceByteImageKeepSource(index),
+					Data = RetrieveSourceByteImage(index, keepSourceFormat: true),
                     NeedsToConvert = false
 				};
             }
@@ -241,7 +241,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 			}
 		}
 
-		private byte[] RetrieveSourceByteImage(int n)
+		private byte[] RetrieveSourceByteImage(int n, bool keepSourceFormat = false)
 		{
 			if (n < 0 || n >= Count)
 			{
@@ -253,8 +253,11 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 				try
 				{
 					array = OnRetrieveSourceByteImage(n);
-					array = DjVuImage.ConvertToJpeg(array);
-					array = WebpImage.ConvertToJpeg(array);
+					if(!keepSourceFormat)
+					{
+						array = DjVuImage.ConvertToJpeg(array);
+						array = WebpImage.ConvertToJpeg(array);
+					}
 					return array;
 				}
 				catch (Exception)
@@ -263,27 +266,6 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 				}
 			}
 		}
-
-        private byte[] RetrieveSourceByteImageKeepSource(int n)
-        {
-            if (n < 0 || n >= Count)
-            {
-                return null;
-            }
-            byte[] array = null;
-            using (LockSource(readOnly: true))
-            {
-                try
-                {
-                    array = OnRetrieveSourceByteImage(n);
-                    return array;
-                }
-                catch (Exception)
-                {
-                    return array;
-                }
-            }
-        }
 
         private ThumbnailImage RetrieveThumbnailImage(int n)
 		{

--- a/ComicRack.Engine/IO/Provider/ImageProvider.cs
+++ b/ComicRack.Engine/IO/Provider/ImageProvider.cs
@@ -133,11 +133,15 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 			}
 		}
 
-        public byte[] GetByteImageForExport(int index)
+        public ExportImageContainer GetByteImageForExport(int index)
         {
             using (ItemMonitor.Lock(workLock))
             {
-                return RetrieveSourceByteImageKeepSource(index);
+                return new ExportImageContainer()
+				{
+					Data = RetrieveSourceByteImageKeepSource(index),
+                    NeedsToConvert = false
+				};
             }
         }
 
@@ -440,5 +444,5 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 				}
 			}
 		}
-	}
+    }
 }

--- a/ComicRack.Engine/IO/Provider/ImageProvider.cs
+++ b/ComicRack.Engine/IO/Provider/ImageProvider.cs
@@ -133,7 +133,15 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 			}
 		}
 
-		public ThumbnailImage GetThumbnail(int index)
+        public byte[] GetByteImageForExport(int index)
+        {
+            using (ItemMonitor.Lock(workLock))
+            {
+                return RetrieveSourceByteImageKeepSource(index);
+            }
+        }
+
+        public ThumbnailImage GetThumbnail(int index)
 		{
 			using (ItemMonitor.Lock(workLock))
 			{
@@ -252,7 +260,28 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 			}
 		}
 
-		private ThumbnailImage RetrieveThumbnailImage(int n)
+        private byte[] RetrieveSourceByteImageKeepSource(int n)
+        {
+            if (n < 0 || n >= Count)
+            {
+                return null;
+            }
+            byte[] array = null;
+            using (LockSource(readOnly: true))
+            {
+                try
+                {
+                    array = OnRetrieveSourceByteImage(n);
+                    return array;
+                }
+                catch (Exception)
+                {
+                    return array;
+                }
+            }
+        }
+
+        private ThumbnailImage RetrieveThumbnailImage(int n)
 		{
 			if (n < 0 || n >= Count)
 			{

--- a/ComicRack.Engine/IO/Provider/Readers/CombinedComics.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/CombinedComics.cs
@@ -56,7 +56,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 			public Bitmap GetImage(int index)
 			{
 				Provider provider = GetProvider(ref index);
-				if (PagePool != null && provider.ImageProvider.IsSlow)
+				if (PagePool != null)
 				{
 					using (IItemLock<PageImage> itemLock = PagePool.GetPage(new PageKey(provider.KeyProvider.GetImageKey(index)), onlyMemory: false))
 					{

--- a/ComicRack.Engine/IO/Provider/Readers/CombinedComics.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/CombinedComics.cs
@@ -85,20 +85,24 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 				return provider.ImageProvider.GetByteImage(index);
 			}
 
-            public byte[] GetByteImageForExport(int index)
+            public ExportImageContainer GetByteImageForExport(int index)
             {
                 Provider provider = GetProvider(ref index);
                 if (PagePool != null)
                 {
                     using (IItemLock<PageImage> itemLock = PagePool.GetPage(new PageKey(provider.KeyProvider.GetImageKey(index)), onlyMemory: false))
                     {
-                        if (itemLock != null && itemLock.Item != null)
+                        if (itemLock != null && itemLock.Item != null && itemLock.Item.Merged)
                         {
-                            return provider.ImageProvider.GetByteImageForExport(index);
+							return new ExportImageContainer()
+							{
+								Data = itemLock.Item.Data,
+								NeedsToConvert = true
+							};
                         }
                     }
                 }
-                return provider.ImageProvider.GetByteImageForExport(index);
+				return provider.ImageProvider.GetByteImageForExport(index);
             }
 
             protected override void Dispose(bool disposing)

--- a/ComicRack.Engine/IO/Provider/Readers/CombinedComics.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/CombinedComics.cs
@@ -85,7 +85,23 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 				return provider.ImageProvider.GetByteImage(index);
 			}
 
-			protected override void Dispose(bool disposing)
+            public byte[] GetByteImageForExport(int index)
+            {
+                Provider provider = GetProvider(ref index);
+                if (PagePool != null)
+                {
+                    using (IItemLock<PageImage> itemLock = PagePool.GetPage(new PageKey(provider.KeyProvider.GetImageKey(index)), onlyMemory: false))
+                    {
+                        if (itemLock != null && itemLock.Item != null)
+                        {
+                            return provider.ImageProvider.GetByteImageForExport(index);
+                        }
+                    }
+                }
+                return provider.ImageProvider.GetByteImageForExport(index);
+            }
+
+            protected override void Dispose(bool disposing)
 			{
 				foreach (Provider provider in providers)
 				{

--- a/ComicRack.Engine/IO/Provider/StorageProvider.cs
+++ b/ComicRack.Engine/IO/Provider/StorageProvider.cs
@@ -189,7 +189,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 			};
 		}
 
-		public static PageResult[] GetImages(IImageProvider provider, ComicPageInfo cpi, string ext, StorageSetting setting, bool reverseSplit, bool createThumbnail)
+		public static PageResult[] GetImages(IImageProvider provider, ComicPageInfo cpi, string ext, StorageSetting setting, bool reverseSplit, bool createThumbnail, bool forExport = false)
 		{
 			byte[] array = null;
 			if (setting.RemovePages && cpi.IsTypeOf(setting.RemovePageFilter))
@@ -214,6 +214,12 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 						}
 					}
 				}
+
+				if (forExport)
+				{
+					array = provider.GetByteImageForExport(cpi.ImageIndex);
+				}
+
 				if (array != null && array.Length != 0)
 				{
 					return new PageResult[1]

--- a/ComicRack.Engine/IO/Provider/StorageProvider.cs
+++ b/ComicRack.Engine/IO/Provider/StorageProvider.cs
@@ -11,391 +11,386 @@ using cYo.Common.Text;
 
 namespace cYo.Projects.ComicRack.Engine.IO.Provider
 {
-	public abstract class StorageProvider : FileProviderBase, IStorageProvider
-	{
-		public class PageResult
-		{
-			private readonly ComicPageInfo info;
+    public abstract class StorageProvider : FileProviderBase, IStorageProvider
+    {
+        public class PageResult
+        {
+            private readonly ComicPageInfo info;
 
-			private readonly string extension;
+            private readonly string extension;
 
-			private byte[] data;
+            private byte[] data;
 
-			private byte[] thumbnailData;
+            private byte[] thumbnailData;
 
-			private string dataStoragePath;
+            private string dataStoragePath;
 
-			public ComicPageInfo Info => info;
+            public ComicPageInfo Info => info;
 
-			public string Extension => extension;
+            public string Extension => extension;
 
-			public byte[] Data => data;
+            public byte[] Data => data;
 
-			public byte[] ThumbnailData => thumbnailData;
+            public byte[] ThumbnailData => thumbnailData;
 
-			public PageResult(byte[] data, byte[] thumbnailData, ComicPageInfo info, string extension)
-			{
-				this.data = data;
-				this.thumbnailData = thumbnailData;
-				this.info = info;
-				this.extension = extension;
-			}
+            public PageResult(byte[] data, byte[] thumbnailData, ComicPageInfo info, string extension)
+            {
+                this.data = data;
+                this.thumbnailData = thumbnailData;
+                this.info = info;
+                this.extension = extension;
+            }
 
-			public Bitmap GetImage()
-			{
-				return BitmapExtensions.BitmapFromBytes(DjVuImage.ConvertToJpeg(WebpImage.ConvertToJpeg(data)));
-			}
+            public Bitmap GetImage()
+            {
+                return BitmapExtensions.BitmapFromBytes(DjVuImage.ConvertToJpeg(WebpImage.ConvertToJpeg(data)));
+            }
 
-			public byte[] GetThumbnailData(StorageSetting setting)
-			{
-				if (ThumbnailData != null)
-				{
-					return thumbnailData;
-				}
-				using (Bitmap bmp = GetImage())
-				{
-					return CreateThumbnail(bmp, setting);
-				}
-			}
+            public byte[] GetThumbnailData(StorageSetting setting)
+            {
+                if (ThumbnailData != null)
+                {
+                    return thumbnailData;
+                }
+                using (Bitmap bmp = GetImage())
+                {
+                    return CreateThumbnail(bmp, setting);
+                }
+            }
 
-			public static byte[] CreateThumbnail(Bitmap bmp, StorageSetting setting)
-			{
-				using (Bitmap bitmap = bmp.Scale(setting.ThumbnailSize))
-				{
-					return (setting.PageType == StoragePageType.Webp) ? WebpImage.ConvertoToWebp(bitmap, setting.PageCompression) : bitmap.ImageToJpegBytes(setting.PageCompression);
-				}
-			}
+            public static byte[] CreateThumbnail(Bitmap bmp, StorageSetting setting)
+            {
+                using (Bitmap bitmap = bmp.Scale(setting.ThumbnailSize))
+                {
+                    return (setting.PageType == StoragePageType.Webp) ? WebpImage.ConvertoToWebp(bitmap, setting.PageCompression) : bitmap.ImageToJpegBytes(setting.PageCompression);
+                }
+            }
 
-			public void Store()
-			{
-				if (dataStoragePath == null && data != null)
-				{
-					dataStoragePath = Path.GetTempFileName();
-					try
-					{
-						File.WriteAllBytes(dataStoragePath, data);
-						data = null;
-					}
-					catch
-					{
-						FileUtility.SafeDelete(dataStoragePath);
-						dataStoragePath = null;
-					}
-				}
-			}
+            public void Store()
+            {
+                if (dataStoragePath == null && data != null)
+                {
+                    dataStoragePath = Path.GetTempFileName();
+                    try
+                    {
+                        File.WriteAllBytes(dataStoragePath, data);
+                        data = null;
+                    }
+                    catch
+                    {
+                        FileUtility.SafeDelete(dataStoragePath);
+                        dataStoragePath = null;
+                    }
+                }
+            }
 
-			public void Restore()
-			{
-				if (dataStoragePath != null)
-				{
-					try
-					{
-						data = File.ReadAllBytes(dataStoragePath);
-					}
-					finally
-					{
-						DeleteDataStorage();
-					}
-				}
-			}
+            public void Restore()
+            {
+                if (dataStoragePath != null)
+                {
+                    try
+                    {
+                        data = File.ReadAllBytes(dataStoragePath);
+                    }
+                    finally
+                    {
+                        DeleteDataStorage();
+                    }
+                }
+            }
 
-			public void Clear()
-			{
-				data = null;
-				thumbnailData = null;
-				DeleteDataStorage();
-			}
+            public void Clear()
+            {
+                data = null;
+                thumbnailData = null;
+                DeleteDataStorage();
+            }
 
-			private void DeleteDataStorage()
-			{
-				if (dataStoragePath != null)
-				{
-					FileUtility.SafeDelete(dataStoragePath);
-					dataStoragePath = null;
-				}
-			}
-		}
+            private void DeleteDataStorage()
+            {
+                if (dataStoragePath != null)
+                {
+                    FileUtility.SafeDelete(dataStoragePath);
+                    dataStoragePath = null;
+                }
+            }
+        }
 
-		public virtual string DefaultExtension => base.DefaultFileFormat.Extensions.FirstOrDefault();
+        public virtual string DefaultExtension => base.DefaultFileFormat.Extensions.FirstOrDefault();
 
-		public event EventHandler<StorageProgressEventArgs> Progress;
+        public event EventHandler<StorageProgressEventArgs> Progress;
 
-		public ComicInfo Store(IImageProvider provider, ComicInfo info, string target, StorageSetting setting)
-		{
-			if (provider == null || provider.Count <= 0)
-			{
-				throw new InvalidDataException(TR.Messages["SourceComicNotValid", "Source Book is not valid"]);
-			}
-			string destFileName = target;
-			string text = null;
-			try
-			{
-				if (string.Equals(provider.Source, target, StringComparison.OrdinalIgnoreCase))
-				{
-					target = (text = EngineConfiguration.Default.GetTempFileName());
-				}
-				ComicInfo result = OnStore(provider, info, target, setting);
-				if (text != null)
-				{
-					File.Copy(text, destFileName, overwrite: true);
-				}
-				return result;
-			}
-			finally
-			{
-				if (text != null)
-				{
-					FileUtility.SafeDelete(text);
-				}
-			}
-		}
+        public ComicInfo Store(IImageProvider provider, ComicInfo info, string target, StorageSetting setting)
+        {
+            if (provider == null || provider.Count <= 0)
+            {
+                throw new InvalidDataException(TR.Messages["SourceComicNotValid", "Source Book is not valid"]);
+            }
+            string destFileName = target;
+            string text = null;
+            try
+            {
+                if (string.Equals(provider.Source, target, StringComparison.OrdinalIgnoreCase))
+                {
+                    target = (text = EngineConfiguration.Default.GetTempFileName());
+                }
+                ComicInfo result = OnStore(provider, info, target, setting);
+                if (text != null)
+                {
+                    File.Copy(text, destFileName, overwrite: true);
+                }
+                return result;
+            }
+            finally
+            {
+                if (text != null)
+                {
+                    FileUtility.SafeDelete(text);
+                }
+            }
+        }
 
-		protected bool FireProgressEvent(int percent)
-		{
-			if (this.Progress == null)
-			{
-				return false;
-			}
-			StorageProgressEventArgs storageProgressEventArgs = new StorageProgressEventArgs(percent);
-			this.Progress(this, storageProgressEventArgs);
-			return storageProgressEventArgs.Cancel;
-		}
+        protected bool FireProgressEvent(int percent)
+        {
+            if (this.Progress == null)
+            {
+                return false;
+            }
+            StorageProgressEventArgs storageProgressEventArgs = new StorageProgressEventArgs(percent);
+            this.Progress(this, storageProgressEventArgs);
+            return storageProgressEventArgs.Cancel;
+        }
 
-		protected abstract ComicInfo OnStore(IImageProvider provider, ComicInfo info, string target, StorageSetting setting);
+        protected abstract ComicInfo OnStore(IImageProvider provider, ComicInfo info, string target, StorageSetting setting);
 
-		private static Bitmap[] GetSubPages(Bitmap bmp, bool splitDouble, bool reverseSplit)
-		{
-			if (splitDouble && bmp.Height <= bmp.Width)
-			{
-				Bitmap bitmap = bmp.CreateCopy(new Rectangle(0, 0, bmp.Width / 2, bmp.Height));
-				Bitmap bitmap2 = bmp.CreateCopy(new Rectangle(bmp.Width / 2, 0, bmp.Width / 2, bmp.Height));
-				if (reverseSplit)
-				{
-					return new Bitmap[2]
-					{
-						bitmap2,
-						bitmap
-					};
-				}
-				return new Bitmap[2]
-				{
-					bitmap,
-					bitmap2
-				};
-			}
-			return new Bitmap[1]
-			{
-				bmp
-			};
-		}
+        private static Bitmap[] GetSubPages(Bitmap bmp, bool splitDouble, bool reverseSplit)
+        {
+            if (splitDouble && bmp.Height <= bmp.Width)
+            {
+                Bitmap bitmap = bmp.CreateCopy(new Rectangle(0, 0, bmp.Width / 2, bmp.Height));
+                Bitmap bitmap2 = bmp.CreateCopy(new Rectangle(bmp.Width / 2, 0, bmp.Width / 2, bmp.Height));
+                if (reverseSplit)
+                {
+                    return new Bitmap[2]
+                    {
+                        bitmap2,
+                        bitmap
+                    };
+                }
+                return new Bitmap[2]
+                {
+                    bitmap,
+                    bitmap2
+                };
+            }
+            return new Bitmap[1]
+            {
+                bmp
+            };
+        }
 
-		public static PageResult[] GetImages(IImageProvider provider, ComicPageInfo cpi, string ext, StorageSetting setting, bool reverseSplit, bool createThumbnail, bool forExport = false)
-		{
-			byte[] array = null;
-			if (setting.RemovePages && cpi.IsTypeOf(setting.RemovePageFilter))
-			{
-				return new PageResult[0];
-			}
-			if (!string.IsNullOrEmpty(ext) && setting.PageResize == StoragePageResize.Original && (setting.PageType == StoragePageType.Original || setting.PageType == GetStoragePageTypeFromExtension(ext)) && cpi.Rotation == ImageRotation.None && setting.DoublePages == DoublePageHandling.Keep && setting.ImageProcessing.IsEmpty)
-			{
-				array = provider.GetByteImage(cpi.ImageIndex);
-				if (setting.PageType == StoragePageType.Jpeg)
-				{
-					using (MemoryStream s = new MemoryStream(array))
-					{
-						if (!JpegFile.GetImageSize(s, out var size))
-						{
-							array = null;
-						}
-						else
-						{
-							cpi.ImageWidth = size.Width;
-							cpi.ImageHeight = size.Height;
-						}
-					}
-				}
+        public static PageResult[] GetImages(IImageProvider provider, ComicPageInfo cpi, string ext, StorageSetting setting, bool reverseSplit, bool createThumbnail, bool forExport = false)
+        {
+            byte[] array = null;
+            if (setting.RemovePages && cpi.IsTypeOf(setting.RemovePageFilter))
+            {
+                return new PageResult[0];
+            }
 
-				if (forExport)
-				{
-					array = provider.GetByteImageForExport(cpi.ImageIndex);
-				}
+            StoragePageType storagePageType = (setting.PageType != StoragePageType.Original) ? setting.PageType : GetStoragePageTypeFromExtension(ext);
+            if (!string.IsNullOrEmpty(ext) && setting.PageResize == StoragePageResize.Original && (setting.PageType == StoragePageType.Original || setting.PageType == GetStoragePageTypeFromExtension(ext)) && cpi.Rotation == ImageRotation.None && setting.DoublePages == DoublePageHandling.Keep && setting.ImageProcessing.IsEmpty)
+            {
+                array = provider.GetByteImage(cpi.ImageIndex);
+                if (setting.PageType == StoragePageType.Jpeg)
+                {
+                    using (MemoryStream s = new MemoryStream(array))
+                    {
+                        if (!JpegFile.GetImageSize(s, out var size))
+                        {
+                            array = null;
+                        }
+                        else
+                        {
+                            cpi.ImageWidth = size.Width;
+                            cpi.ImageHeight = size.Height;
+                        }
+                    }
+                }
 
-				if (array != null && array.Length != 0)
-				{
-					return new PageResult[1]
-					{
-						new PageResult(array, null, cpi, ext)
-					};
-				}
-			}
-			Bitmap bitmap = provider.GetImage(cpi.ImageIndex);
-			if (bitmap == null)
-			{
-				if (setting.IgnoreErrorPages)
-				{
-					return new PageResult[0];
-				}
-				throw new InvalidOperationException(StringUtility.Format(TR.Messages["FailedToReadImage", "Failed to read Image {0}"], cpi.ImageIndex + 1));
-			}
-			if (array != null && !string.IsNullOrEmpty(ext) && setting.PageResize == StoragePageResize.Original && (setting.PageType == StoragePageType.Original || setting.PageType == GetStoragePageTypeFromExtension(ext)) && cpi.Rotation == ImageRotation.None && (setting.DoublePages == DoublePageHandling.Keep || bitmap.Height <= bitmap.Width) && !setting.ImageProcessing.IsEmpty)
-			{
-				bitmap.Dispose();
-				return new PageResult[1]
-				{
-					new PageResult(array, null, cpi, ext)
-				};
-			}
-			List<PageResult> list = new List<PageResult>();
-			Bitmap[] array2 = new Bitmap[0];
-			try
-			{
-				ImageRotation imageRotation = cpi.Rotation;
-				if (setting.DoublePages == DoublePageHandling.Rotate)
-				{
-					Size size2 = bitmap.Size.Rotate(imageRotation);
-					if (size2.Width > size2.Height)
-					{
-						imageRotation = imageRotation.RotateLeft();
-					}
-				}
-				if (imageRotation != 0)
-				{
-					Bitmap bitmap2 = bitmap.Rotate(imageRotation);
-					bitmap.Dispose();
-					bitmap = bitmap2;
-				}
-				array2 = GetSubPages(bitmap, setting.DoublePages == DoublePageHandling.Split, reverseSplit);
-				if (array2.Length > 1)
-				{
-					bitmap.Dispose();
-				}
-				bitmap = null;
-				for (int i = 0; i < array2.Length; i++)
-				{
-					Bitmap bitmap3 = null;
-					try
-					{
-						Bitmap bitmap4 = array2[i];
-						int num = (setting.DontEnlarge ? Math.Min(bitmap4.Width, setting.PageWidth) : setting.PageWidth);
-						int height = (setting.DontEnlarge ? Math.Min(bitmap4.Height, setting.PageHeight) : setting.PageHeight);
-						switch (setting.PageResize)
-						{
-						case StoragePageResize.WidthHeight:
-							bitmap3 = bitmap4.Scale(new Size(num, height), setting.Resampling, PixelFormat.Format24bppRgb);
-							break;
-						case StoragePageResize.Width:
-							if (setting.DoublePages == DoublePageHandling.AdaptWidth && bitmap4.Width > bitmap4.Height)
-							{
-								num *= 2;
-							}
-							bitmap3 = bitmap4.Scale(new Size(num, 0), setting.Resampling, PixelFormat.Format24bppRgb);
-							break;
-						case StoragePageResize.Height:
-							bitmap3 = bitmap4.Scale(new Size(0, height), setting.Resampling, PixelFormat.Format24bppRgb);
-							break;
-						}
-						if (bitmap3 != null)
-						{
-							array2[i].Dispose();
-							bitmap4 = (array2[i] = bitmap3);
-							bitmap3 = null;
-						}
-						cpi.ImageWidth = bitmap4.Width;
-						cpi.ImageHeight = bitmap4.Height;
-						if (!setting.ImageProcessing.IsEmpty)
-						{
-							try
-							{
-								Bitmap bitmap5 = bitmap4;
-								bitmap4 = (array2[i] = bitmap4.CreateAdjustedBitmap(setting.ImageProcessing, PixelFormat.Format24bppRgb, alwaysClone: true));
-								bitmap5.Dispose();
-							}
-							catch
-							{
-							}
-						}
-						StoragePageType storagePageType = ((setting.PageType != 0) ? setting.PageType : GetStoragePageTypeFromExtension(ext));
-						if ((storagePageType == StoragePageType.Bmp || storagePageType == StoragePageType.Png) && bitmap4.PixelFormat != PixelFormat.Format24bppRgb)
-						{
-							Bitmap bitmap6 = bitmap4;
-							bitmap4 = (array2[i] = bitmap4.CreateCopy(PixelFormat.Format24bppRgb));
-							if (bitmap4 != bitmap6)
-							{
-								bitmap6.Dispose();
-							}
-						}
-						switch (storagePageType)
-						{
-						case StoragePageType.Tiff:
-							array = bitmap4.ImageToBytes(ImageFormat.Tiff, 24);
-							ext = ".tif";
-							break;
-						case StoragePageType.Png:
-							array = bitmap4.ImageToBytes(ImageFormat.Png, 24);
-							ext = ".png";
-							break;
-						case StoragePageType.Bmp:
-							array = bitmap4.ImageToBytes(ImageFormat.Bmp, 24);
-							ext = ".bmp";
-							break;
-						case StoragePageType.Gif:
-							array = bitmap4.ImageToBytes(ImageFormat.Gif, 8);
-							ext = ".gif";
-							break;
-						case StoragePageType.Djvu:
-							array = DjVuImage.ConvertToDjVu(bitmap4);
-							ext = ".djvu";
-							break;
-						case StoragePageType.Webp:
-							array = WebpImage.ConvertoToWebp(bitmap4, setting.PageCompression);
-							ext = ".webp";
-							break;
-						default:
-							array = bitmap4.ImageToBytes(ImageFormat.Jpeg, 24, setting.PageCompression);
-							ext = ".jpg";
-							break;
-						}
-						cpi.ImageFileSize = array.Length;
-						list.Add(new PageResult(array, createThumbnail ? PageResult.CreateThumbnail(bitmap4, setting) : null, cpi, ext));
-					}
-					finally
-					{
-						bitmap3?.Dispose();
-					}
-				}
-			}
-			finally
-			{
-				for (int j = 0; j < array2.Length; j++)
-				{
-					if (array2[j] != null)
-					{
-						array2[j].Dispose();
-					}
-				}
-				bitmap?.Dispose();
-			}
-			return list.ToArray();
-		}
+                if (forExport)
+                {
+                    ExportImageContainer data = provider.GetByteImageForExport(cpi.ImageIndex);
+                    array = (data.NeedsToConvert) ? ConvertImage(storagePageType, data.Bitmap, setting) : data.Data;
+                }
 
-		private static StoragePageType GetStoragePageTypeFromExtension(string ext)
-		{
-			switch ((ext ?? string.Empty).ToLower())
-			{
-			case ".bmp":
-				return StoragePageType.Bmp;
-			case ".tif":
-			case ".tiff":
-				return StoragePageType.Tiff;
-			case ".png":
-				return StoragePageType.Png;
-			case ".djvu":
-				return StoragePageType.Djvu;
-			case ".webp":
-				return StoragePageType.Webp;
-			default:
-				return StoragePageType.Jpeg;
-			}
-		}
-	}
+                if (array != null && array.Length != 0)
+                {
+                    return new PageResult[1]
+                    {
+                        new PageResult(array, null, cpi, ext)
+                    };
+                }
+            }
+            Bitmap bitmap = provider.GetImage(cpi.ImageIndex);
+            if (bitmap == null)
+            {
+                if (setting.IgnoreErrorPages)
+                {
+                    return new PageResult[0];
+                }
+                throw new InvalidOperationException(StringUtility.Format(TR.Messages["FailedToReadImage", "Failed to read Image {0}"], cpi.ImageIndex + 1));
+            }
+            if (array != null && !string.IsNullOrEmpty(ext) && setting.PageResize == StoragePageResize.Original && (setting.PageType == StoragePageType.Original || setting.PageType == GetStoragePageTypeFromExtension(ext)) && cpi.Rotation == ImageRotation.None && (setting.DoublePages == DoublePageHandling.Keep || bitmap.Height <= bitmap.Width) && !setting.ImageProcessing.IsEmpty)
+            {
+                bitmap.Dispose();
+                return new PageResult[1]
+                {
+                    new PageResult(array, null, cpi, ext)
+                };
+            }
+            List<PageResult> list = new List<PageResult>();
+            Bitmap[] array2 = new Bitmap[0];
+            try
+            {
+                ImageRotation imageRotation = cpi.Rotation;
+                if (setting.DoublePages == DoublePageHandling.Rotate)
+                {
+                    Size size2 = bitmap.Size.Rotate(imageRotation);
+                    if (size2.Width > size2.Height)
+                    {
+                        imageRotation = imageRotation.RotateLeft();
+                    }
+                }
+                if (imageRotation != 0)
+                {
+                    Bitmap bitmap2 = bitmap.Rotate(imageRotation);
+                    bitmap.Dispose();
+                    bitmap = bitmap2;
+                }
+                array2 = GetSubPages(bitmap, setting.DoublePages == DoublePageHandling.Split, reverseSplit);
+                if (array2.Length > 1)
+                {
+                    bitmap.Dispose();
+                }
+                bitmap = null;
+                for (int i = 0; i < array2.Length; i++)
+                {
+                    Bitmap bitmap3 = null;
+                    try
+                    {
+                        Bitmap bitmap4 = array2[i];
+                        int num = (setting.DontEnlarge ? Math.Min(bitmap4.Width, setting.PageWidth) : setting.PageWidth);
+                        int height = (setting.DontEnlarge ? Math.Min(bitmap4.Height, setting.PageHeight) : setting.PageHeight);
+                        switch (setting.PageResize)
+                        {
+                            case StoragePageResize.WidthHeight:
+                                bitmap3 = bitmap4.Scale(new Size(num, height), setting.Resampling, PixelFormat.Format24bppRgb);
+                                break;
+                            case StoragePageResize.Width:
+                                if (setting.DoublePages == DoublePageHandling.AdaptWidth && bitmap4.Width > bitmap4.Height)
+                                {
+                                    num *= 2;
+                                }
+                                bitmap3 = bitmap4.Scale(new Size(num, 0), setting.Resampling, PixelFormat.Format24bppRgb);
+                                break;
+                            case StoragePageResize.Height:
+                                bitmap3 = bitmap4.Scale(new Size(0, height), setting.Resampling, PixelFormat.Format24bppRgb);
+                                break;
+                        }
+                        if (bitmap3 != null)
+                        {
+                            array2[i].Dispose();
+                            bitmap4 = (array2[i] = bitmap3);
+                            bitmap3 = null;
+                        }
+                        cpi.ImageWidth = bitmap4.Width;
+                        cpi.ImageHeight = bitmap4.Height;
+                        if (!setting.ImageProcessing.IsEmpty)
+                        {
+                            try
+                            {
+                                Bitmap bitmap5 = bitmap4;
+                                bitmap4 = (array2[i] = bitmap4.CreateAdjustedBitmap(setting.ImageProcessing, PixelFormat.Format24bppRgb, alwaysClone: true));
+                                bitmap5.Dispose();
+                            }
+                            catch
+                            {
+                            }
+                        }
+                        if ((storagePageType == StoragePageType.Bmp || storagePageType == StoragePageType.Png) && bitmap4.PixelFormat != PixelFormat.Format24bppRgb)
+                        {
+                            Bitmap bitmap6 = bitmap4;
+                            bitmap4 = (array2[i] = bitmap4.CreateCopy(PixelFormat.Format24bppRgb));
+                            if (bitmap4 != bitmap6)
+                            {
+                                bitmap6.Dispose();
+                            }
+                        }
+                        ext = GetExtensionFromStoragePageType(storagePageType);
+                        array = ConvertImage(storagePageType, bitmap4, setting);
+                        cpi.ImageFileSize = array.Length;
+                        list.Add(new PageResult(array, createThumbnail ? PageResult.CreateThumbnail(bitmap4, setting) : null, cpi, ext));
+                    }
+                    finally
+                    {
+                        bitmap3?.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                for (int j = 0; j < array2.Length; j++)
+                {
+                    if (array2[j] != null)
+                    {
+                        array2[j].Dispose();
+                    }
+                }
+                bitmap?.Dispose();
+            }
+            return list.ToArray();
+        }
+
+        private static StoragePageType GetStoragePageTypeFromExtension(string ext)
+        {
+            switch ((ext ?? string.Empty).ToLower())
+            {
+                case ".bmp":
+                    return StoragePageType.Bmp;
+                case ".tif":
+                case ".tiff":
+                    return StoragePageType.Tiff;
+                case ".png":
+                    return StoragePageType.Png;
+                case ".djvu":
+                    return StoragePageType.Djvu;
+                case ".webp":
+                    return StoragePageType.Webp;
+                default:
+                    return StoragePageType.Jpeg;
+            }
+        }
+
+        private static string GetExtensionFromStoragePageType(StoragePageType storagePageType) => storagePageType switch
+        {
+            StoragePageType.Tiff => ".tif",
+            StoragePageType.Png => ".png",
+            StoragePageType.Bmp => ".bmp",
+            StoragePageType.Gif => ".gif",
+            StoragePageType.Djvu => ".djvu",
+            StoragePageType.Webp => ".webp",
+            _ => ".jpg",
+        };
+
+        private static byte[] ConvertImage(StoragePageType storagePageType, Bitmap bitmap, StorageSetting setting) => storagePageType switch
+        {
+            StoragePageType.Tiff => bitmap.ImageToBytes(ImageFormat.Tiff, 24),
+            StoragePageType.Png => bitmap.ImageToBytes(ImageFormat.Png, 24),
+            StoragePageType.Bmp => bitmap.ImageToBytes(ImageFormat.Bmp, 24),
+            StoragePageType.Gif => bitmap.ImageToBytes(ImageFormat.Gif, 8),
+            StoragePageType.Djvu => DjVuImage.ConvertToDjVu(bitmap),
+            StoragePageType.Webp => WebpImage.ConvertoToWebp(bitmap, setting.PageCompression),
+            _ => bitmap.ImageToBytes(ImageFormat.Jpeg, 24, setting.PageCompression),
+        };
+    }
 }

--- a/ComicRack.Engine/IO/Provider/Writers/PackedStorageProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Writers/PackedStorageProvider.cs
@@ -75,7 +75,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Writers
 							ProviderImageInfo imageInfo = provider.GetImageInfo(page.ImageIndex);
 							string ext = ((imageInfo != null && !string.IsNullOrEmpty(imageInfo.Name)) ? Path.GetExtension(imageInfo.Name) : ".jpg");
 							int num2 = 0;
-							PageResult[] images = StorageProvider.GetImages(provider, page, ext, setting, info.Manga == MangaYesNo.YesAndRightToLeft, setting.CreateThumbnails);
+							PageResult[] images = StorageProvider.GetImages(provider, page, ext, setting, info.Manga == MangaYesNo.YesAndRightToLeft, setting.CreateThumbnails, true);
 							foreach (PageResult pageResult in images)
 							{
 								bool flag;

--- a/ComicRack/Controls/PagesView.cs
+++ b/ComicRack/Controls/PagesView.cs
@@ -819,7 +819,7 @@ namespace cYo.Projects.ComicRack.Viewer.Controls
             Program.ImagePool.Thumbs.RefreshImage(thumbKey);
 
             //Add pages to the ImagePool because if they aren't the Export will retrieve the original image instead
-            using IItemLock<PageImage> itemLock = Program.ImagePool.Pages.AddImage(pageKey, p => PageImage.CreateFrom(mergedImage));
+            using IItemLock<PageImage> itemLock = Program.ImagePool.Pages.AddImage(pageKey, p => PageImage.CreateFromMerged(mergedImage));
             using IItemLock<ThumbnailImage> itemLock2 = Program.ImagePool.Thumbs.AddImage(thumbKey, p => ThumbnailImage.CreateFrom(mergedImage, mergedImage.Size));
 
 			//Mark the second image as Deleted


### PR DESCRIPTION
Fix for WEBP files being converted back to JPEGs when re-exporting to WEBP format. This fix should also apply to DJVU formats as well.

close #74