### PR TITLE
Adds winget publish to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,3 +67,20 @@ jobs:
         allowUpdates: true
         updateOnlyUnreleased: true
         removeArtifacts: true
+    
+  publish:
+    runs-on: ubuntu-latest
+    needs: build  # Ensure this runs after the build job
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Publish Winget manifest
+      uses: vedantmgoyal2009/winget-releaser@v2
+      with:
+        identifier: maforget.ComicRackCE.Nightly
+        version: nightly-${{ steps.vars.outputs.sha_short }}  # Use the short 7-digit commit SHA for the version
+        max-versions-to-keep: 5  # keep only latest 5 versions (recommended to reduce clutter since Nightly)
+        token: ${{ secrets.WINGET_TOKEN }}
+


### PR DESCRIPTION
## Do not post the secret here

As explained by the title this will start automatically creating winget manifests for you when a new version is published on GitHub.

A few things are needed, so follow these steps or else the workflow will not run:

1. Go on your account and go to your account settings from the top-right:

![image](https://github.com/user-attachments/assets/e1ff0afc-f4ef-45f2-8158-47f897cbdf11)

2. Bottom-left go to `Developer Settings`

![image](https://github.com/user-attachments/assets/18390b0b-8034-489d-b950-5125159247f6)

3. Then go to `Personal Access Tokens` and then `Tokens (classic)`:

![image](https://github.com/user-attachments/assets/1bc1e75d-3e44-4745-b3ce-bdefa6a9bfc3)

4. Then click `Generate new-token`, and go on `Generate new token (classic)`:

![image](https://github.com/user-attachments/assets/35229a13-32e9-4674-b49b-00852572673c)

5. Here as Note put: `ComicRackCE Nightly Winget Releaser`, Expiration set it to `No Expiration` (If you want to create an expiration date go ahead, but this would mean repeating this process at the end of its lifetime), and scope select the following:

![image](https://github.com/user-attachments/assets/4ee2e687-4bea-4d41-8397-bda89354d2af)

Then just scroll down and hit `Generate token`, after just copy the token and keep it handy

6. Then come back to this repository and click `Settings`:

![image](https://github.com/user-attachments/assets/a4011a36-817b-4655-8920-e56a8c5a3d3a)

7. Then go to `Secrets and Variables` and click on `Actions`:

![image](https://github.com/user-attachments/assets/fccd0731-d465-461a-9cac-5cec7dfbf563)

8. Then click `New repository secret`:

![image](https://github.com/user-attachments/assets/686bcefc-a4be-4e2c-b1be-5545bd890811)


9. Name should be: `WINGET_TOKEN` and Secret should be the one you copied from before, then just click `Add Secret`