### PR TITLE
Used newer API for moving to the recycle bin.

### DIFF
--- a/ComicRack/Config/ExtendedSettings.cs
+++ b/ComicRack/Config/ExtendedSettings.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using cYo.Common.Mathematics;
 using cYo.Common.Runtime;
+using cYo.Common.Win32.FileOperations;
 using cYo.Projects.ComicRack.Engine.Database;
 using cYo.Projects.ComicRack.Engine.IO.Network;
 
@@ -448,6 +449,13 @@ namespace cYo.Projects.ComicRack.Viewer.Config
 			set;
 		}
 
+		[DefaultValue(FileOperationsAPI.IFileOperation)]
+		public FileOperationsAPI DeleteAPI
+		{
+			get;
+			set;
+		}
+
 		public ExtendedSettings()
 		{
 			AnamorphicScalingTolerance = 0.25f;
@@ -467,6 +475,7 @@ namespace cYo.Projects.ComicRack.Viewer.Config
 			MacCompatibleScanning = true;
 			SortNetworkFolders = true;
 			StartHidden = false;
-        }
+			DeleteAPI = FileOperationsAPI.IFileOperation;
+		}
 	}
 }

--- a/ComicRack/Output/ComicRack.ini
+++ b/ComicRack/Output/ComicRack.ini
@@ -113,6 +113,10 @@
 ; Set to false to disable sorting of network folders in the folder browser
 ; SortNetworkFolders = true
 
+; Which API will be used to move to the recycle bin. Note that NetFramework does not move to the recycle bin, it simply deletes the file.
+; Valid values are IFileOperation (default for Vista+), SHFileOperation (legacy, previous default), NetFramework, Shell, VisualBasic (uses SHFileOperation)
+; DeleteAPI = IFileOperation
+
 ; ------------------------------------------------------------------
 ; Quicklist Settings
 

--- a/ComicRack/Program.cs
+++ b/ComicRack/Program.cs
@@ -736,6 +736,7 @@ namespace cYo.Projects.ComicRack.Viewer
 			CommandLineParser.Parse(ImageDisplayControl.HardwareSettings);
 			Application.EnableVisualStyles();
 			Application.SetCompatibleTextRenderingDefault(defaultValue: false);
+			ShellFile.DeleteAPI = ExtendedSettings.DeleteAPI;
 			DatabaseManager.FirstDatabaseAccess += delegate
 			{
 				StartupProgress(TR.Messages["OpenDatabase", "Opening Database"], -1);

--- a/cYo.Common/Win32/FileOperations/FileOperation.cs
+++ b/cYo.Common/Win32/FileOperations/FileOperation.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Windows.Forms;
+
+namespace cYo.Common.Win32.FileOperations
+{
+	internal abstract class FileOperation : IDisposable
+	{
+		private bool disposedValue;
+		protected ShellFileDeleteOptions _options;
+
+		protected FileOperation(ShellFileDeleteOptions options)
+		{
+			_options = options;
+		}
+
+		public static FileOperation GetFileOperationAPI(IWin32Window window, FileOperationsAPI api, ShellFileDeleteOptions options)
+		{
+			return api switch
+			{
+				FileOperationsAPI.Shell => new Shell(options),
+				FileOperationsAPI.SHFileOperation => new SHFileOperation(window, options),
+				FileOperationsAPI.NetFramework => new NetFramework(),
+				FileOperationsAPI.VisualBasic => new VisualBasic(options),
+				_ => new IFileOperation(new IFileOperation.FileOperationProgressSink(), window, options),
+			};
+		}
+
+		internal FileOperationFlags GetDeleteFileFlags()
+		{
+			FileOperationFlags fFlags = FileOperationFlags.FOF_SILENT | FileOperationFlags.FOF_NOERRORUI;
+			if (!_options.HasFlag(ShellFileDeleteOptions.NoRecycleBin))
+			{
+				fFlags |= FileOperationFlags.FOF_ALLOWUNDO;
+			}
+			if (!_options.HasFlag(ShellFileDeleteOptions.Confirmation))
+			{
+				fFlags |= FileOperationFlags.FOF_NOCONFIRMATION;
+			}
+
+			return fFlags;
+		}
+
+		public abstract void DeleteFile(string file);
+
+		protected virtual void VerifyFile(string file)
+		{
+			if (string.IsNullOrWhiteSpace(file) || !System.IO.File.Exists(file))
+				throw new ArgumentException("Invalid file path");
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!disposedValue)
+			{
+				if (disposing)
+				{
+					// TODO: dispose managed state (managed objects)
+				}
+
+				// TODO: free unmanaged resources (unmanaged objects) and override finalizer
+				// TODO: set large fields to null
+				disposedValue = true;
+			}
+		}
+
+		// // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+		// ~FileOperation()
+		// {
+		//     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+		//     Dispose(disposing: false);
+		// }
+
+		public virtual void Dispose()
+		{
+			// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+			Dispose(disposing: true);
+			GC.SuppressFinalize(this);
+		}
+	}
+}

--- a/cYo.Common/Win32/FileOperations/FileOperationFlags.cs
+++ b/cYo.Common/Win32/FileOperations/FileOperationFlags.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.VisualBasic.FileIO;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices.ComTypes;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace cYo.Common.Win32.FileOperations
+{
+	[Flags]
+	internal enum FileOperationFlags : uint
+	{
+		FOF_MULTIDESTFILES = 0x0001,
+		FOF_CONFIRMMOUSE = 0x0002,
+		FOF_SILENT = 0x0004,  // Do not show a dialog during the process
+		FOF_RENAMEONCOLLISION = 0x0008,
+		FOF_NOCONFIRMATION = 0x0010,  // Do not ask the user to confirm selection
+		FOF_WANTMAPPINGHANDLE = 0x0020,  // Fill in SHFILEOPSTRUCT.hNameMappings
+										 // Must be freed using SHFreeNameMappings
+		FOF_ALLOWUNDO = 0x0040,  // Delete the file to the recycle bin.  (Required flag to send a file to the bin
+		FOF_FILESONLY = 0x0080,  // on *.*, do only files
+		FOF_SIMPLEPROGRESS = 0x0100, // Do not show the names of the files or folders that are being recycled.
+		FOF_NOCONFIRMMKDIR = 0x0200,  // don't confirm making any needed dirs
+		FOF_NOERRORUI = 0x0400,  // don't put up error UI
+		FOF_NOCOPYSECURITYATTRIBS = 0x0800,  // dont copy NT file Security Attributes
+		FOF_NORECURSION = 0x1000,  // don't recurse into directories.
+		FOF_NO_CONNECTED_ELEMENTS = 0x2000,  // don't operate on connected file elements.
+		FOF_WANTNUKEWARNING = 0x4000,  // during delete operation, warn if nuking instead of recycling (partially overrides FOF_NOCONFIRMATION)
+		FOF_NORECURSEREPARSE = 0x8000,  // treat reparse points as objects, not containers
+
+		FOFX_NOSKIPJUNCTIONS = 0x00010000,  // Don't avoid binding to junctions (like Task folder, Recycle-Bin)
+		FOFX_PREFERHARDLINK = 0x00020000,  // Create hard link if possible
+		FOFX_SHOWELEVATIONPROMPT = 0x00040000,  // Show elevation prompts when error UI is disabled (use with FOF_NOERRORUI)
+		FOFX_EARLYFAILURE = 0x00100000,  // Fail operation as soon as a single error occurs rather than trying to process other items (applies only when using FOF_NOERRORUI)
+		FOFX_PRESERVEFILEEXTENSIONS = 0x00200000,  // Rename collisions preserve file extns (use with FOF_RENAMEONCOLLISION)
+		FOFX_KEEPNEWERFILE = 0x00400000,  // Keep newer file on naming conflicts
+		FOFX_NOCOPYHOOKS = 0x00800000,  // Don't use copy hooks
+		FOFX_NOMINIMIZEBOX = 0x01000000,  // Don't allow minimizing the progress dialog
+		FOFX_MOVEACLSACROSSVOLUMES = 0x02000000,  // Copy security information when performing a cross-volume move operation
+		FOFX_DONTDISPLAYSOURCEPATH = 0x04000000,  // Don't display the path of source file in progress dialog
+		FOFX_DONTDISPLAYDESTPATH = 0x08000000,  // Don't display the path of destination file in progress dialog
+	}
+}

--- a/cYo.Common/Win32/FileOperations/FileOperationsAPI.cs
+++ b/cYo.Common/Win32/FileOperations/FileOperationsAPI.cs
@@ -1,0 +1,11 @@
+﻿namespace cYo.Common.Win32.FileOperations
+{
+	public enum FileOperationsAPI
+	{
+		Shell,
+		IFileOperation,
+		SHFileOperation,
+		NetFramework,
+		VisualBasic
+	}
+}

--- a/cYo.Common/Win32/FileOperations/IFileOperation.cs
+++ b/cYo.Common/Win32/FileOperations/IFileOperation.cs
@@ -1,0 +1,423 @@
+﻿using System;
+using Microsoft.VisualBasic.FileIO;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices.ComTypes;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace cYo.Common.Win32.FileOperations
+{
+	internal class IFileOperation : FileOperation, IDisposable
+	{
+		//ref: https://github.com/RickStrahl/DeleteFiles/blob/master/DeleteFiles/ZetaLongPaths/Native/FileOperations/FileOperation.cs
+		private bool _disposed;
+		private readonly Native.IFileOperation _fileOperation;
+		private readonly FileOperationProgressSink _callbackSink;
+		private readonly uint _sinkCookie;
+
+		private static readonly Guid CLSID_FileOperation = new Guid("3ad05575-8857-4850-9277-11b85bdb8e09");
+		private static readonly Type _fileOperationType = Type.GetTypeFromCLSID(CLSID_FileOperation);
+		private static Guid _shellItemGuid = typeof(Native.IShellItem).GUID;
+
+		public static class Native
+		{
+			public enum HRESULT : uint
+			{
+				S_OK = 0,
+				S_FALSE = 1,
+				E_NOINTERFACE = 0x80004002,
+				E_NOTIMPL = 0x80004001,
+				E_FAIL = 0x80004005,
+				E_INVALIDARG = 0x80070057,
+				E_CANCELLED = 0x80070000 + ERROR_CANCELLED,
+				E_UNEXPECTED = 0x8000FFFF
+			}
+			public const uint ERROR_CANCELLED = 1223;
+
+			public enum SIGDN : uint
+			{
+				SIGDN_NORMALDISPLAY = 0x00000000,
+				SIGDN_PARENTRELATIVEPARSING = 0x80018001,
+				SIGDN_PARENTRELATIVEFORADDRESSBAR = 0x8001c001,
+				SIGDN_DESKTOPABSOLUTEPARSING = 0x80028000,
+				SIGDN_PARENTRELATIVEEDITING = 0x80031001,
+				SIGDN_DESKTOPABSOLUTEEDITING = 0x8004c000,
+				SIGDN_FILESYSPATH = 0x80058000,
+				SIGDN_URL = 0x80068000
+			}
+
+			public enum CopyEngineResult : uint
+			{
+				COPYENGINE_OK = 0x0,
+
+				COPYENGINE_S_YES = 0x00270001,
+				COPYENGINE_S_NOT_HANDLED = 0x00270003,
+				COPYENGINE_S_USER_RETRY = 0x00270004,
+				COPYENGINE_S_USER_IGNORED = 0x00270005,
+				COPYENGINE_S_MERGE = 0x00270006,
+				COPYENGINE_S_DONT_PROCESS_CHILDREN = 0x00270008,
+				COPYENGINE_S_ALREADY_DONE = 0x0027000A,
+				COPYENGINE_S_PENDING = 0x0027000B,
+				COPYENGINE_S_KEEP_BOTH = 0x0027000C,
+				COPYENGINE_S_CLOSE_PROGRAM = 0x0027000D, // Close the program using the current file
+
+				// Failure/Error codes
+				COPYENGINE_E_USER_CANCELLED = 0x80270000,  // User wants to canceled entire job
+				COPYENGINE_E_CANCELLED = 0x80270001,  // Engine wants to canceled entire job, don't set the CANCELLED bit
+				COPYENGINE_E_REQUIRES_ELEVATION = 0x80270002,  // Need to elevate the process to complete the operation
+
+				COPYENGINE_E_SAME_FILE = 0x80270003,  // Source and destination file are the same
+				COPYENGINE_E_DIFF_DIR = 0x80270004,  // Trying to rename a file into a different location, use move instead
+				COPYENGINE_E_MANY_SRC_1_DEST = 0x80270005,  // One source specified, multiple destinations
+
+				COPYENGINE_E_DEST_SUBTREE = 0x80270009,  // The destination is a sub-tree of the source
+				COPYENGINE_E_DEST_SAME_TREE = 0x8027000A,  // The destination is the same folder as the source
+
+				COPYENGINE_E_FLD_IS_FILE_DEST = 0x8027000B,  // Existing destination file with same name as folder
+				COPYENGINE_E_FILE_IS_FLD_DEST = 0x8027000C,  // Existing destination folder with same name as file
+
+				COPYENGINE_E_FILE_TOO_LARGE = 0x8027000D,  // File too large for destination file system
+				COPYENGINE_E_REMOVABLE_FULL = 0x8027000E,  // Destination device is full and happens to be removable
+
+				COPYENGINE_E_DEST_IS_RO_CD = 0x8027000F,  // Destination is a Read-Only CDRom, possibly unformatted
+				COPYENGINE_E_DEST_IS_RW_CD = 0x80270010,  // Destination is a Read/Write CDRom, possibly unformatted
+				COPYENGINE_E_DEST_IS_R_CD = 0x80270011,  // Destination is a Recordable (Audio, CDRom, possibly unformatted
+
+				COPYENGINE_E_DEST_IS_RO_DVD = 0x80270012,  // Destination is a Read-Only DVD, possibly unformatted
+				COPYENGINE_E_DEST_IS_RW_DVD = 0x80270013,  // Destination is a Read/Wrote DVD, possibly unformatted
+				COPYENGINE_E_DEST_IS_R_DVD = 0x80270014,  // Destination is a Recordable (Audio, DVD, possibly unformatted
+
+				COPYENGINE_E_SRC_IS_RO_CD = 0x80270015,  // Source is a Read-Only CDRom, possibly unformatted
+				COPYENGINE_E_SRC_IS_RW_CD = 0x80270016,  // Source is a Read/Write CDRom, possibly unformatted
+				COPYENGINE_E_SRC_IS_R_CD = 0x80270017,  // Source is a Recordable (Audio, CDRom, possibly unformatted
+
+				COPYENGINE_E_SRC_IS_RO_DVD = 0x80270018,  // Source is a Read-Only DVD, possibly unformatted
+				COPYENGINE_E_SRC_IS_RW_DVD = 0x80270019,  // Source is a Read/Wrote DVD, possibly unformatted
+				COPYENGINE_E_SRC_IS_R_DVD = 0x8027001A,  // Source is a Recordable (Audio, DVD, possibly unformatted
+
+				COPYENGINE_E_INVALID_FILES_SRC = 0x8027001B,  // Invalid source path
+				COPYENGINE_E_INVALID_FILES_DEST = 0x8027001C,  // Invalid destination path
+				COPYENGINE_E_PATH_TOO_DEEP_SRC = 0x8027001D,  // Source Files within folders where the overall path is longer than MAX_PATH
+				COPYENGINE_E_PATH_TOO_DEEP_DEST = 0x8027001E,  // Destination files would be within folders where the overall path is longer than MAX_PATH
+				COPYENGINE_E_ROOT_DIR_SRC = 0x8027001F,  // Source is a root directory, cannot be moved or renamed
+				COPYENGINE_E_ROOT_DIR_DEST = 0x80270020,  // Destination is a root directory, cannot be renamed
+				COPYENGINE_E_ACCESS_DENIED_SRC = 0x80270021,  // Security problem on source
+				COPYENGINE_E_ACCESS_DENIED_DEST = 0x80270022,  // Security problem on destination
+				COPYENGINE_E_PATH_NOT_FOUND_SRC = 0x80270023,  // Source file does not exist, or is unavailable
+				COPYENGINE_E_PATH_NOT_FOUND_DEST = 0x80270024,  // Destination file does not exist, or is unavailable
+				COPYENGINE_E_NET_DISCONNECT_SRC = 0x80270025,  // Source file is on a disconnected network location
+				COPYENGINE_E_NET_DISCONNECT_DEST = 0x80270026,  // Destination file is on a disconnected network location
+				COPYENGINE_E_SHARING_VIOLATION_SRC = 0x80270027,  // Sharing Violation on source
+				COPYENGINE_E_SHARING_VIOLATION_DEST = 0x80270028,  // Sharing Violation on destination
+
+				COPYENGINE_E_ALREADY_EXISTS_NORMAL = 0x80270029, // Destination exists, cannot replace
+				COPYENGINE_E_ALREADY_EXISTS_READONLY = 0x8027002A, // Destination with read-only attribute exists, cannot replace
+				COPYENGINE_E_ALREADY_EXISTS_SYSTEM = 0x8027002B, // Destination with system attribute exists, cannot replace
+				COPYENGINE_E_ALREADY_EXISTS_FOLDER = 0x8027002C, // Destination folder exists, cannot replace
+				COPYENGINE_E_STREAM_LOSS = 0x8027002D, // Secondary Stream information would be lost
+				COPYENGINE_E_EA_LOSS = 0x8027002E, // Extended Attributes would be lost
+				COPYENGINE_E_PROPERTY_LOSS = 0x8027002F, // Property would be lost
+				COPYENGINE_E_PROPERTIES_LOSS = 0x80270030, // Properties would be lost
+				COPYENGINE_E_ENCRYPTION_LOSS = 0x80270031, // Encryption would be lost
+				COPYENGINE_E_DISK_FULL = 0x80270032, // Entire operation likely won't fit
+				COPYENGINE_E_DISK_FULL_CLEAN = 0x80270033, // Entire operation likely won't fit, clean-up wizard available
+				COPYENGINE_E_CANT_REACH_SOURCE = 0x80270035, // Can't reach source folder")
+
+				COPYENGINE_E_RECYCLE_UNKNOWN_ERROR = 0x80270035, // ???
+				COPYENGINE_E_RECYCLE_FORCE_NUKE = 0x80270036, // Recycling not available (usually turned off,
+				COPYENGINE_E_RECYCLE_SIZE_TOO_BIG = 0x80270037, // Item is too large for the recycle-bin
+				COPYENGINE_E_RECYCLE_PATH_TOO_LONG = 0x80270038, // Folder is too deep to fit in the recycle-bin
+				COPYENGINE_E_RECYCLE_BIN_NOT_FOUND = 0x8027003A, // Recycle bin could not be found or is unavailable
+				COPYENGINE_E_NEWFILE_NAME_TOO_LONG = 0x8027003B, // Name of the new file being created is too long
+				COPYENGINE_E_NEWFOLDER_NAME_TOO_LONG = 0x8027003C, // Name of the new folder being created is too long
+				COPYENGINE_E_DIR_NOT_EMPTY = 0x8027003D, // The directory being processed is not empty
+
+				//  error codes without a more specific group use FACILITY_SHELL and 0x01 in the second lowest byte.
+				NETCACHE_E_NEGATIVE_CACHE = 0x80270100, // The item requested is in the negative net parsing cache
+				EXECUTE_E_LAUNCH_APPLICATION = 0x80270101, // for returned by command delegates to indicate that they did no work 
+				SHELL_E_WRONG_BITDEPTH = 0x80270102, // returned when trying to create a thumbnail extractor at too low a bitdepth for high fidelity
+			}
+
+			[ComImport]
+			[Guid("947aab5f-0a5c-4c13-b4d6-4bf7836fc9f8")]
+			[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+			internal interface IFileOperation
+			{
+				uint Advise(IFileOperationProgressSink pfops);
+				void Unadvise(uint dwCookie);
+				void SetOperationFlags(FileOperationFlags dwOperationFlags);
+				void SetProgressMessage([MarshalAs(UnmanagedType.LPWStr)] string pszMessage);
+				void SetProgressDialog([MarshalAs(UnmanagedType.Interface)] object popd);
+				void SetProperties([MarshalAs(UnmanagedType.Interface)] object pproparray);
+				void SetOwnerWindow(uint hwndParent);
+				void ApplyPropertiesToItem(IShellItem psiItem);
+				void ApplyPropertiesToItems([MarshalAs(UnmanagedType.Interface)] object punkItems);
+				void RenameItem(IShellItem psiItem, [MarshalAs(UnmanagedType.LPWStr)] string pszNewName, IFileOperationProgressSink pfopsItem);
+				void RenameItems([MarshalAs(UnmanagedType.Interface)] object pUnkItems, [MarshalAs(UnmanagedType.LPWStr)] string pszNewName);
+				void MoveItem(IShellItem psiItem, IShellItem psiDestinationFolder, [MarshalAs(UnmanagedType.LPWStr)] string pszNewName, IFileOperationProgressSink pfopsItem);
+				void MoveItems([MarshalAs(UnmanagedType.Interface)] object punkItems, IShellItem psiDestinationFolder);
+				void CopyItem(IShellItem psiItem, IShellItem psiDestinationFolder, [MarshalAs(UnmanagedType.LPWStr)] string pszCopyName, IFileOperationProgressSink pfopsItem);
+				void CopyItems([MarshalAs(UnmanagedType.Interface)] object punkItems, IShellItem psiDestinationFolder);
+				void DeleteItem(IShellItem psiItem, IFileOperationProgressSink pfopsItem);
+				void DeleteItems([MarshalAs(UnmanagedType.Interface)] object punkItems);
+				uint NewItem(IShellItem psiDestinationFolder, FileAttributes dwFileAttributes, [MarshalAs(UnmanagedType.LPWStr)] string pszName, [MarshalAs(UnmanagedType.LPWStr)] string pszTemplateName, IFileOperationProgressSink pfopsItem);
+				void PerformOperations(); [return: MarshalAs(UnmanagedType.Bool)] bool GetAnyOperationsAborted();
+			}
+
+			[ComImport]
+			[Guid("04b0f1a7-9490-44bc-96e1-4296a31252e2")]
+			[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+			public interface IFileOperationProgressSink
+			{
+				void StartOperations();
+				void FinishOperations(uint hrResult);
+				void PreRenameItem(uint dwFlags, IShellItem psiItem, [MarshalAs(UnmanagedType.LPWStr)] string pszNewName);
+				void PostRenameItem(uint dwFlags, IShellItem psiItem, [MarshalAs(UnmanagedType.LPWStr)] string pszNewName, uint hrRename, IShellItem psiNewlyCreated);
+				void PreMoveItem(uint dwFlags, IShellItem psiItem, IShellItem psiDestinationFolder, [MarshalAs(UnmanagedType.LPWStr)] string pszNewName);
+				void PostMoveItem(uint dwFlags, IShellItem psiItem, IShellItem psiDestinationFolder, [MarshalAs(UnmanagedType.LPWStr)] string pszNewName, uint hrMove, IShellItem psiNewlyCreated);
+				void PreCopyItem(uint dwFlags, IShellItem psiItem, IShellItem psiDestinationFolder, [MarshalAs(UnmanagedType.LPWStr)] string pszNewName);
+				void PostCopyItem(uint dwFlags, IShellItem psiItem, IShellItem psiDestinationFolder, [MarshalAs(UnmanagedType.LPWStr)] string pszNewName, uint hrCopy, IShellItem psiNewlyCreated);
+				void PreDeleteItem(uint dwFlags, IShellItem psiItem);
+				void PostDeleteItem(uint dwFlags, IShellItem psiItem, uint hrDelete, IShellItem psiNewlyCreated);
+				void PreNewItem(uint dwFlags, IShellItem psiDestinationFolder, [MarshalAs(UnmanagedType.LPWStr)] string pszNewName);
+				void PostNewItem(uint dwFlags, IShellItem psiDestinationFolder, [MarshalAs(UnmanagedType.LPWStr)] string pszNewName, [MarshalAs(UnmanagedType.LPWStr)] string pszTemplateName, uint dwFileAttributes, uint hrNew, IShellItem psiNewItem);
+				void UpdateProgress(uint iWorkTotal, uint iWorkSoFar); void ResetTimer(); void PauseTimer(); void ResumeTimer();
+			}
+
+			[ComImport]
+			[Guid("43826d1e-e718-42ee-bc55-a1e261c37bfe")]
+			[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+			public interface IShellItem
+			{
+				[return: MarshalAs(UnmanagedType.Interface)]
+				object BindToHandler(IBindCtx pbc, ref Guid bhid, ref Guid riid);
+
+				IShellItem GetParent();
+
+				[return: MarshalAs(UnmanagedType.LPWStr)]
+				string GetDisplayName(SIGDN sigdnName);
+
+				uint GetAttributes(uint sfgaoMask);
+
+				int Compare(IShellItem psi, uint hint);
+			}
+
+			[DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
+			public static extern void SHCreateItemFromParsingName(
+				[MarshalAs(UnmanagedType.LPWStr)] string pszPath,
+				IntPtr pbc,
+				ref Guid riid,
+				[MarshalAs(UnmanagedType.Interface)] out IShellItem ppv
+			);
+
+			//[DllImport("shell32.dll", SetLastError = true, CharSet = CharSet.Unicode, PreserveSig = false)]
+			//[return: MarshalAs(UnmanagedType.Interface)]
+			//public static extern object SHCreateItemFromParsingName(
+			//	[MarshalAs(UnmanagedType.LPWStr)] string pszPath,
+			//	IBindCtx pbc,
+			//	ref Guid riid);
+		}
+
+		public IFileOperation() : this(null)
+		{
+		}
+
+		public IFileOperation(FileOperationProgressSink callbackSink) : this(callbackSink, null, ShellFileDeleteOptions.None)
+		{
+		}
+
+		public IFileOperation(FileOperationProgressSink callbackSink, IWin32Window window, ShellFileDeleteOptions options) : base(options)
+		{
+			_callbackSink = callbackSink;
+			_fileOperation = (Native.IFileOperation)Activator.CreateInstance(_fileOperationType);
+			_fileOperation.SetOperationFlags(FileOperationFlags.FOF_NOCONFIRMMKDIR);
+
+			if (_callbackSink != null)
+				_sinkCookie = _fileOperation.Advise(_callbackSink);
+
+			IntPtr ownerHandle = window?.Handle ?? IntPtr.Zero;
+			if (ownerHandle != IntPtr.Zero)
+				_fileOperation.SetOwnerWindow((uint)ownerHandle);
+		}
+
+		private class ComReleaser<T> : IDisposable where T : class
+		{
+			private T _obj;
+
+			public ComReleaser(T obj)
+			{
+				if (obj == null)
+					throw new ArgumentNullException("obj");
+
+				if (!obj.GetType().IsCOMObject)
+					throw new ArgumentOutOfRangeException("obj");
+
+				_obj = obj;
+			}
+
+			public T Item { get { return _obj; } }
+
+			public void Dispose()
+			{
+				if (_obj != null)
+				{
+					Marshal.FinalReleaseComObject(_obj);
+					_obj = null;
+				}
+			}
+		}
+
+		private static ComReleaser<Native.IShellItem> CreateShellItem(string path)
+		{
+			Native.SHCreateItemFromParsingName(path, IntPtr.Zero, ref _shellItemGuid, out Native.IShellItem item);
+			return new ComReleaser<Native.IShellItem>(item);
+		}
+
+		public class FileOperationProgressSink : Native.IFileOperationProgressSink
+		{
+			public virtual void StartOperations()
+			{
+				TraceAction("StartOperations", "", 0);
+			}
+
+			public virtual void FinishOperations(uint hrResult)
+			{
+				TraceAction("FinishOperations", "", hrResult);
+			}
+
+			public virtual void PreRenameItem(uint dwFlags,
+				Native.IShellItem psiItem, string pszNewName)
+			{
+				TraceAction("PreRenameItem", psiItem, 0);
+			}
+
+			public virtual void PostRenameItem(uint dwFlags,
+				Native.IShellItem psiItem, string pszNewName,
+				uint hrRename, Native.IShellItem psiNewlyCreated)
+			{
+				TraceAction("PostRenameItem", psiNewlyCreated, hrRename);
+			}
+
+			public virtual void PreMoveItem(
+				uint dwFlags, Native.IShellItem psiItem,
+				Native.IShellItem psiDestinationFolder, string pszNewName)
+			{
+				TraceAction("PreMoveItem", psiItem, 0);
+			}
+
+			public virtual void PostMoveItem(
+				uint dwFlags, Native.IShellItem psiItem,
+				Native.IShellItem psiDestinationFolder,
+				string pszNewName, uint hrMove,
+				Native.IShellItem psiNewlyCreated)
+			{
+				TraceAction("PostMoveItem", psiNewlyCreated, hrMove);
+			}
+
+			public virtual void PreCopyItem(
+				uint dwFlags, Native.IShellItem psiItem,
+				Native.IShellItem psiDestinationFolder, string pszNewName)
+			{
+				TraceAction("PreCopyItem", psiItem, 0);
+			}
+
+			public virtual void PostCopyItem(
+				uint dwFlags, Native.IShellItem psiItem,
+				Native.IShellItem psiDestinationFolder, string pszNewName,
+				uint hrCopy, Native.IShellItem psiNewlyCreated)
+			{
+				TraceAction("PostCopyItem", psiNewlyCreated, hrCopy);
+			}
+
+			public virtual void PreDeleteItem(
+				uint dwFlags, Native.IShellItem psiItem)
+			{
+				TraceAction("PreDeleteItem", psiItem, 0);
+			}
+
+			public virtual void PostDeleteItem(
+				uint dwFlags, Native.IShellItem psiItem,
+				uint hrDelete, Native.IShellItem psiNewlyCreated)
+			{
+				TraceAction("PostDeleteItem", psiItem, hrDelete);
+			}
+
+			public virtual void PreNewItem(uint dwFlags,
+				Native.IShellItem psiDestinationFolder, string pszNewName)
+			{
+				TraceAction("PreNewItem", pszNewName, 0);
+			}
+
+			public virtual void PostNewItem(uint dwFlags,
+				Native.IShellItem psiDestinationFolder, string pszNewName,
+				string pszTemplateName, uint dwFileAttributes,
+				uint hrNew, Native.IShellItem psiNewItem)
+			{
+				TraceAction("PostNewItem", psiNewItem, hrNew);
+			}
+
+			public virtual void UpdateProgress(
+				uint iWorkTotal, uint iWorkSoFar)
+			{
+				Debug.WriteLine("UpdateProgress: " + iWorkSoFar + "/" + iWorkTotal);
+			}
+
+			public void ResetTimer() { }
+			public void PauseTimer() { }
+			public void ResumeTimer() { }
+
+			[Conditional("DEBUG")]
+			private static void TraceAction(string action, string item, uint hresult)
+			{
+				string message = $"{action} ({(Native.CopyEngineResult)hresult})";
+				if (!string.IsNullOrEmpty(item)) 
+					message += " : " + item;
+
+				Debug.WriteLine(message);
+			}
+
+			[Conditional("DEBUG")]
+			private static void TraceAction(
+				string action, Native.IShellItem item, uint hresult)
+			{
+				TraceAction(action,
+					item != null ? item.GetDisplayName(Native.SIGDN.SIGDN_NORMALDISPLAY) : null,
+					hresult);
+			}
+		}
+
+		public override void Dispose()
+		{
+			if (!_disposed)
+			{
+				_disposed = true;
+				if (_callbackSink != null) _fileOperation.Unadvise(_sinkCookie);
+				Marshal.FinalReleaseComObject(_fileOperation);
+			}
+		}
+
+		private void ThrowIfDisposed()
+		{
+			if (_disposed) throw new ObjectDisposedException(GetType().Name);
+		}
+
+		protected override void VerifyFile(string file)
+		{
+			ThrowIfDisposed();
+			base.VerifyFile(file);
+		}
+
+		public override void DeleteFile(string file)
+		{
+			VerifyFile(file);
+			using (ComReleaser<Native.IShellItem> item = CreateShellItem(file))
+			{
+				_fileOperation.SetOperationFlags(GetDeleteFileFlags());
+				_fileOperation.DeleteItem(item.Item, null);
+				_fileOperation.PerformOperations();
+			}
+		}
+	}
+}

--- a/cYo.Common/Win32/FileOperations/NetFramework.cs
+++ b/cYo.Common/Win32/FileOperations/NetFramework.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Microsoft.VisualBasic.FileIO;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices.ComTypes;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace cYo.Common.Win32.FileOperations
+{
+	internal class NetFramework : FileOperation
+	{
+		public NetFramework() : base(ShellFileDeleteOptions.None)
+		{
+		}
+
+		public override void DeleteFile(string file)
+		{
+			VerifyFile(file);
+			File.Delete(file);
+		}
+	}
+}

--- a/cYo.Common/Win32/FileOperations/SHFileOperation.cs
+++ b/cYo.Common/Win32/FileOperations/SHFileOperation.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Microsoft.VisualBasic.FileIO;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices.ComTypes;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace cYo.Common.Win32.FileOperations
+{
+	internal class SHFileOperation : FileOperation
+	{
+		private readonly IWin32Window window;
+
+		private static class Native
+		{
+			[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+			public struct SHFILEOPSTRUCT
+			{
+				public IntPtr hwnd;
+				public FileOperationType wFunc;
+				[MarshalAs(UnmanagedType.LPTStr)]
+				public string pFrom;
+				[MarshalAs(UnmanagedType.LPTStr)]
+				public string pTo;
+				public FileOperationFlags fFlags;
+				public bool fAnyOperationsAborted;
+				public IntPtr hNameMappings;
+				[MarshalAs(UnmanagedType.LPTStr)]
+				public string lpszProgressTitle;
+			}
+
+			/// <summary>
+			/// File Operation Function Type for SHFileOperation
+			/// </summary>
+			public enum FileOperationType : uint
+			{
+				/// <summary>
+				/// Move the objects
+				/// </summary>
+				FO_MOVE = 0x0001,
+				/// <summary>
+				/// Copy the objects
+				/// </summary>
+				FO_COPY = 0x0002,
+				/// <summary>
+				/// Delete (or recycle) the objects
+				/// </summary>
+				FO_DELETE = 0x0003,
+				/// <summary>
+				/// Rename the object(s)
+				/// </summary>
+				FO_RENAME = 0x0004,
+			}
+
+			[DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+			public static extern int SHFileOperation(ref SHFILEOPSTRUCT lpFileOp);
+		}
+
+		public SHFileOperation(IWin32Window window, ShellFileDeleteOptions options) : base(options)
+		{
+			this.window = window;
+		}
+
+		public override void DeleteFile(string file)
+		{
+			VerifyFile(file);
+
+			Native.SHFILEOPSTRUCT lpFileOp = default;
+			lpFileOp.hwnd = window?.Handle ?? IntPtr.Zero;
+			lpFileOp.wFunc = Native.FileOperationType.FO_DELETE;
+			lpFileOp.fFlags = GetDeleteFileFlags();
+			lpFileOp.pFrom = $"{file}\0\0";
+			lpFileOp.fAnyOperationsAborted = false;
+			lpFileOp.hNameMappings = IntPtr.Zero;
+			if (Native.SHFileOperation(ref lpFileOp) != 0)
+				throw new Win32Exception();
+		}
+	}
+}

--- a/cYo.Common/Win32/FileOperations/Shell.cs
+++ b/cYo.Common/Win32/FileOperations/Shell.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.VisualBasic.FileIO;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices.ComTypes;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace cYo.Common.Win32.FileOperations
+{
+	internal class Shell : FileOperation
+	{
+		public Shell(ShellFileDeleteOptions options) : base(options)
+		{
+		}
+
+		public override void DeleteFile(string file)
+		{
+			VerifyFile(file);
+
+			//ref: https://learn.microsoft.com/en-us/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants
+			//ref: https://learn.microsoft.com/en-us/windows/win32/shell/folder-movehere
+			const int ssfBITBUCKET = 0xa;
+			dynamic shell = Activator.CreateInstance(Type.GetTypeFromProgID("Shell.Application"));
+			var recycleBin = shell.Namespace(ssfBITBUCKET);
+			recycleBin.MoveHere(file, GetDeleteFileFlags());
+		}
+	}
+}

--- a/cYo.Common/Win32/FileOperations/VisualBasic.cs
+++ b/cYo.Common/Win32/FileOperations/VisualBasic.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.VisualBasic.FileIO;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices.ComTypes;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace cYo.Common.Win32.FileOperations
+{
+	internal class VisualBasic : FileOperation
+	{
+		public VisualBasic(ShellFileDeleteOptions options) : base(options)
+		{
+		}
+
+		public override void DeleteFile(string file)
+		{
+			VerifyFile(file);
+
+			bool sendToRecycle = !_options.HasFlag(ShellFileDeleteOptions.NoRecycleBin);
+			RecycleOption recycleOption = sendToRecycle ? RecycleOption.SendToRecycleBin : RecycleOption.DeletePermanently;
+			FileSystem.DeleteFile(file, UIOption.OnlyErrorDialogs, recycleOption);
+		}
+	}
+}

--- a/cYo.Common/Win32/ShellFile.cs
+++ b/cYo.Common/Win32/ShellFile.cs
@@ -1,77 +1,32 @@
 using System;
 using System.ComponentModel;
-using System.Runtime.InteropServices;
-using System.Text;
+using System.Diagnostics;
+using System.IO;
 using System.Windows.Forms;
+using cYo.Common.Win32.FileOperations;
 
 namespace cYo.Common.Win32
 {
 	public static class ShellFile
 	{
-		private static class UnsafeNativeMethods
-		{
-            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-            public struct SHFILEOPSTRUCT
-			{
-				public IntPtr hwnd;
-				public int wFunc;
-				public string pFrom;
-				public string pTo;
-				public short fFlags;
-				public bool fAnyOperationsAborted;
-				public IntPtr hNameMappings;
-				public string lpszProgressTitle;
-			}
-
-			public const int FO_DELETE = 3;
-			public const short FOF_SILENT = 4;
-			public const short FOF_ALLOWUNDO = 0x40;
-			public const short FOF_NOCONFIRMATION = 0x10;
-			public const short FOF_NOERRORUI = 0x400;
-
-			[DllImport("shell32.dll", CharSet = CharSet.Unicode)]
-			public static extern int SHFileOperation(ref SHFILEOPSTRUCT lpFileOp);
-		}
+		public static FileOperationsAPI DeleteAPI { get; set; } = FileOperationsAPI.IFileOperation;
 
 		public static void DeleteFile(IWin32Window window, ShellFileDeleteOptions options, params string[] files)
 		{
 			if (files == null || files.Length == 0)
-			{
 				return;
-			}
-			StringBuilder stringBuilder = new StringBuilder();
-			foreach (string value in files)
+
+			foreach (string file in files)
 			{
-				if (!string.IsNullOrEmpty(value))
+				if (string.IsNullOrEmpty(file) || !File.Exists(file))
+					continue;
+
+				using (FileOperation fileOperation = FileOperation.GetFileOperationAPI(window, DeleteAPI, options))
 				{
-					stringBuilder.Append(value);
-					stringBuilder.Append('\0');
+					fileOperation.DeleteFile(file);
 				}
 			}
-			if (stringBuilder.Length != 0)
-            {
-                stringBuilder.Append('\0');
-                UnsafeNativeMethods.SHFILEOPSTRUCT lpFileOp = default(UnsafeNativeMethods.SHFILEOPSTRUCT);
-                lpFileOp.hwnd = window?.Handle ?? IntPtr.Zero;
-                lpFileOp.wFunc = UnsafeNativeMethods.FO_DELETE;
-                lpFileOp.fFlags = UnsafeNativeMethods.FOF_SILENT | UnsafeNativeMethods.FOF_NOERRORUI;
-                if (!options.HasFlag(ShellFileDeleteOptions.NoRecycleBin))
-                {
-                    lpFileOp.fFlags |= UnsafeNativeMethods.FOF_ALLOWUNDO;
-                }
-                if (!options.HasFlag(ShellFileDeleteOptions.Confirmation))
-                {
-                    lpFileOp.fFlags |= UnsafeNativeMethods.FOF_NOCONFIRMATION;
-                }
-                lpFileOp.pFrom = stringBuilder.ToString();
-                lpFileOp.fAnyOperationsAborted = false;
-                lpFileOp.hNameMappings = IntPtr.Zero;
-                if (UnsafeNativeMethods.SHFileOperation(ref lpFileOp) != 0 || lpFileOp.fAnyOperationsAborted)
-                {
-					throw new Win32Exception();
-                }
-            }
-        }
+		}
 
 		public static void DeleteFile(ShellFileDeleteOptions options, params string[] files)
 		{

--- a/cYo.Common/cYo.Common.csproj
+++ b/cYo.Common/cYo.Common.csproj
@@ -17,6 +17,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Web.Services" />
   </ItemGroup>


### PR DESCRIPTION
The main change is that the main Delete API was replaced by the newer recommended API for windows. 

I've also added a setting in the `ComicRack.ini` that let's you change the API to test if there are effect. In the case where nothing works you will be able to replace it by the .NET Framework that we know works, but doesn't move to the recycle bin. 

Here are the possible APIs for `DeleteAPI`:

- `Shell`: Just uses windows function, you might have message box popup if the file is already in use.
- `IFileOperation`: The new Windows API recommend for Windows Vista+.
- `SHFileOperation`: The old Windows API that was the previous default. It works with all version of Windows.
- `NetFramework`: The standard delete function but doesn't move to the recycle bin, the one we have determined works.
- `VisualBasic`: The previous test I created, seems to use `SHFileOperation`.