### PR TITLE
Jpeg2000

### DIFF
--- a/ComicRack.Engine/ComicRack.Engine.csproj
+++ b/ComicRack.Engine/ComicRack.Engine.csproj
@@ -82,6 +82,7 @@
     <PackageReference Include="bblanchon.PDFium.Win32">
       <Version>135.0.7033</Version>
     </PackageReference>
+    <PackageReference Include="CSJ2K" Version="3.0.0" />
     <PackageReference Include="LibHeifSharp" Version="3.2.0" />
     <PackageReference Include="Microsoft.Bcl.Numerics" Version="9.0.2" />
     <PackageReference Include="MySqlConnector">

--- a/ComicRack.Engine/IO/Provider/ImageProvider.cs
+++ b/ComicRack.Engine/IO/Provider/ImageProvider.cs
@@ -258,7 +258,8 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 						array = DjVuImage.ConvertToJpeg(array);
 						array = WebpImage.ConvertToJpeg(array);
 						array = HeifAvifImage.ConvertToJpeg(array);
-                    }
+						array = Jpeg2000Image.ConvertToJpeg(array);
+					}
 					return array;
 				}
 				catch (Exception)

--- a/ComicRack.Engine/IO/Provider/Jpeg2000Image.cs
+++ b/ComicRack.Engine/IO/Provider/Jpeg2000Image.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using cYo.Common.Drawing;
+using cYo.Common.ComponentModel;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using System.Runtime.InteropServices;
+using cYo.Common.Collections;
+using CSJ2K;
+using CSJ2K.Util;
+using CSJ2K.j2k.util;
+
+namespace cYo.Projects.ComicRack.Engine.IO.Provider
+{
+	public static class Jpeg2000Image
+	{
+		static Jpeg2000Image()
+		{
+			BitmapImageCreator.Register();
+		}
+
+		public static byte[] ConvertToJpeg2000(Bitmap bmp, int quality = 40, bool isJp2 = true)
+		{
+			if (bmp == null)
+			{
+				return null;
+			}
+			Bitmap bitmap = null;
+			try
+			{
+				using (MemoryStream memoryStream = new MemoryStream())
+				{
+					bitmap = ((bmp.PixelFormat == PixelFormat.Format24bppRgb) ? bmp : bmp.CreateCopy(PixelFormat.Format24bppRgb));
+					Encode(bitmap, memoryStream, quality, isJp2);
+					return memoryStream.ToArray();
+				}
+			}
+			finally
+			{
+				if (bmp != bitmap)
+				{
+					bitmap.SafeDispose();
+				}
+			}
+		}
+
+		public static byte[] ConvertToJpeg(byte[] data)
+		{
+			if (!IsValidJpeg2000(data))
+			{
+				return data;
+			}
+			try
+			{
+				using (Bitmap image = DecodeFromBytes(data))
+				{
+					return image.ImageToJpegBytes();
+				}
+			}
+			catch (Exception)
+			{
+				return data;
+			}
+		}
+
+		private static bool IsValidJpeg2000(byte[] data)
+		{
+			if (data.Length >= 12)
+			{
+				// Check for JP2 header
+				byte[] jp2Signature = { 0x00, 0x00, 0x00, 0x0C, 0x6A, 0x50, 0x20, 0x20, 0x0D, 0x0A, 0x87, 0x0A };
+				if (data.Take(12).SequenceEqual(jp2Signature))
+					return true;
+			}
+
+			if (data.Length >= 2)
+			{
+				// Check for J2K codestream header
+				byte[] j2kSignature = { 0xFF, 0x4F };
+				if (data.Take(2).SequenceEqual(j2kSignature))
+					return true;
+			}
+
+			return false;
+		}
+
+
+		private static Bitmap DecodeFromBytes(byte[] data)
+		{
+			return J2kImage.FromBytes(data).As<Bitmap>();
+		}
+
+		private static void Encode(Bitmap bitmap, MemoryStream memoryStream, int? quality, bool isJP2 = true)
+		{
+			//Image Gamma is off.
+			ParameterList pList = J2kImage.GetDefaultEncoderParameterList(null);
+			if (!quality.HasValue)
+				pList["lossless"] = "on";
+			else
+				pList["rate"] = quality.ToString();
+
+			pList["file_format"] = isJP2 ? "on" : "off"; //Sets the format to jp2 when "on" or j2k if "off"
+
+			byte[] data = J2kImage.ToBytes(bitmap, pList);
+			memoryStream.Write(data, 0, data.Length);
+		}
+	}
+}

--- a/ComicRack.Engine/IO/Provider/Readers/ComicProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/ComicProvider.cs
@@ -24,7 +24,9 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 			"heic",
 			"heif",
 			"avif",
-			//"jxl"
+			"jp2",
+			"j2k",
+			//"jxl",
 		};
 
 		public bool UpdateEnabled => GetType().GetAttributes<FileFormatAttribute>().FirstOrDefault((FileFormatAttribute f) => f.Format.Supports(base.Source))?.EnableUpdate ?? false;

--- a/ComicRack.Engine/IO/Provider/StorageProvider.cs
+++ b/ComicRack.Engine/IO/Provider/StorageProvider.cs
@@ -47,7 +47,8 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
                 array = WebpImage.ConvertToJpeg(data);
                 array = DjVuImage.ConvertToJpeg(data);
                 array = HeifAvifImage.ConvertToJpeg(data);
-                return BitmapExtensions.BitmapFromBytes(array);
+				array = Jpeg2000Image.ConvertToJpeg(data);
+				return BitmapExtensions.BitmapFromBytes(array);
             }
 
             public byte[] GetThumbnailData(StorageSetting setting)
@@ -368,8 +369,9 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
             ".webp" => StoragePageType.Webp,
             ".heif" or ".heic" => StoragePageType.Heif,
             ".avif" => StoragePageType.Avif,
-            //".jxl" => StoragePageType.JpegXL,
-            _ => StoragePageType.Jpeg,
+			".jp2" or ".j2k" => StoragePageType.Jpeg2000,
+			//".jxl" => StoragePageType.JpegXL,
+			_ => StoragePageType.Jpeg,
         };
 
         private static string GetExtensionFromStoragePageType(StoragePageType storagePageType) => storagePageType switch
@@ -382,6 +384,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
             StoragePageType.Webp => ".webp",
             StoragePageType.Heif => ".heif",
             StoragePageType.Avif => ".avif",
+            StoragePageType.Jpeg2000 => ".jp2",
             //StoragePageType.JpegXL => ".jxl",
             _ => ".jpg",
         };
@@ -396,8 +399,9 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
             StoragePageType.Webp => WebpImage.ConvertoToWebp(bitmap, setting.PageCompression),
             StoragePageType.Heif => HeifAvifImage.ConvertToHeif(bitmap, setting.PageCompression, false),
             StoragePageType.Avif => HeifAvifImage.ConvertToHeif(bitmap, setting.PageCompression, true),
+            StoragePageType.Jpeg2000 => Jpeg2000Image.ConvertToJpeg2000(bitmap, setting.PageCompression, true),
             //StoragePageType.JpegXL => JpegXLImage.ConvertToJpegXL(bitmap),
-            _ => bitmap.ImageToBytes(ImageFormat.Jpeg, 24, setting.PageCompression),
+			_ => bitmap.ImageToBytes(ImageFormat.Jpeg, 24, setting.PageCompression),
         };
     }
 }

--- a/ComicRack.Engine/IO/Provider/StorageProvider.cs
+++ b/ComicRack.Engine/IO/Provider/StorageProvider.cs
@@ -369,7 +369,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
             ".webp" => StoragePageType.Webp,
             ".heif" or ".heic" => StoragePageType.Heif,
             ".avif" => StoragePageType.Avif,
-			".jp2" or ".j2k" => StoragePageType.Jpeg2000,
+			//".jp2" or ".j2k" => StoragePageType.Jpeg2000,
 			//".jxl" => StoragePageType.JpegXL,
 			_ => StoragePageType.Jpeg,
         };
@@ -384,7 +384,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
             StoragePageType.Webp => ".webp",
             StoragePageType.Heif => ".heif",
             StoragePageType.Avif => ".avif",
-            StoragePageType.Jpeg2000 => ".jp2",
+            //StoragePageType.Jpeg2000 => ".jp2",
             //StoragePageType.JpegXL => ".jxl",
             _ => ".jpg",
         };
@@ -399,9 +399,9 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
             StoragePageType.Webp => WebpImage.ConvertoToWebp(bitmap, setting.PageCompression),
             StoragePageType.Heif => HeifAvifImage.ConvertToHeif(bitmap, setting.PageCompression, false),
             StoragePageType.Avif => HeifAvifImage.ConvertToHeif(bitmap, setting.PageCompression, true),
-            StoragePageType.Jpeg2000 => Jpeg2000Image.ConvertToJpeg2000(bitmap, setting.PageCompression, true),
+            //StoragePageType.Jpeg2000 => Jpeg2000Image.ConvertToJpeg2000(bitmap, setting.PageCompression, true),
             //StoragePageType.JpegXL => JpegXLImage.ConvertToJpegXL(bitmap),
-			_ => bitmap.ImageToBytes(ImageFormat.Jpeg, 24, setting.PageCompression),
+            _ => bitmap.ImageToBytes(ImageFormat.Jpeg, 24, setting.PageCompression),
         };
     }
 }

--- a/ComicRack.Engine/IO/StoragePageType.cs
+++ b/ComicRack.Engine/IO/StoragePageType.cs
@@ -12,7 +12,7 @@ namespace cYo.Projects.ComicRack.Engine.IO
 		Webp,
 		Heif,
 		Avif,
-		Jpeg2000,
+		//Jpeg2000,
 		//JpegXL,
 	}
 }

--- a/ComicRack.Engine/IO/StoragePageType.cs
+++ b/ComicRack.Engine/IO/StoragePageType.cs
@@ -12,6 +12,7 @@ namespace cYo.Projects.ComicRack.Engine.IO
 		Webp,
 		Heif,
 		Avif,
-		//JpegXL
+		Jpeg2000,
+		//JpegXL,
 	}
 }

--- a/ComicRack/Dialogs/ExportComicsDialog.cs
+++ b/ComicRack/Dialogs/ExportComicsDialog.cs
@@ -160,7 +160,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 		{
 			LocalizeUtility.UpdateRightToLeft(this);
 			InitializeComponent();
-			if (Environment.Is64BitProcess) this.cbPageFormat.Items.AddRange(new object[] { "HEIF", "AVIF", "JPEG2000" });
+			if (Environment.Is64BitProcess) this.cbPageFormat.Items.AddRange(new object[] { "HEIF", "AVIF" });
 			LocalizeUtility.Localize(this, null);
 			foreach (ComboBox control in this.GetControls<ComboBox>())
 			{
@@ -197,7 +197,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 			checkBox.Enabled = enabled;
 			txCustomStartIndex.Enabled = setting.Naming == ExportNaming.Custom;
 			txCustomName.Enabled = setting.Naming == ExportNaming.Custom || setting.Naming == ExportNaming.Caption;
-			tbQuality.Enabled = setting.PageType == StoragePageType.Jpeg || setting.PageType == StoragePageType.Webp || setting.PageType == StoragePageType.Heif || setting.PageType == StoragePageType.Avif || setting.PageType == StoragePageType.Jpeg2000;
+			tbQuality.Enabled = setting.PageType == StoragePageType.Jpeg || setting.PageType == StoragePageType.Webp || setting.PageType == StoragePageType.Heif || setting.PageType == StoragePageType.Avif;
 			txWidth.Enabled = setting.PageResize != StoragePageResize.Height && setting.PageResize != StoragePageResize.Original;
 			txHeight.Enabled = setting.PageResize != StoragePageResize.Width && setting.PageResize != StoragePageResize.Original;
 			chkDontEnlarge.Enabled = setting.PageResize != StoragePageResize.Original;

--- a/ComicRack/Dialogs/ExportComicsDialog.cs
+++ b/ComicRack/Dialogs/ExportComicsDialog.cs
@@ -160,7 +160,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 		{
 			LocalizeUtility.UpdateRightToLeft(this);
 			InitializeComponent();
-			if (Environment.Is64BitProcess) this.cbPageFormat.Items.AddRange(new object[] { "HEIF", "AVIF" });
+			if (Environment.Is64BitProcess) this.cbPageFormat.Items.AddRange(new object[] { "HEIF", "AVIF", "JPEG2000" });
 			LocalizeUtility.Localize(this, null);
 			foreach (ComboBox control in this.GetControls<ComboBox>())
 			{
@@ -197,7 +197,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 			checkBox.Enabled = enabled;
 			txCustomStartIndex.Enabled = setting.Naming == ExportNaming.Custom;
 			txCustomName.Enabled = setting.Naming == ExportNaming.Custom || setting.Naming == ExportNaming.Caption;
-			tbQuality.Enabled = setting.PageType == StoragePageType.Jpeg || setting.PageType == StoragePageType.Webp || setting.PageType == StoragePageType.Heif || setting.PageType == StoragePageType.Avif;
+			tbQuality.Enabled = setting.PageType == StoragePageType.Jpeg || setting.PageType == StoragePageType.Webp || setting.PageType == StoragePageType.Heif || setting.PageType == StoragePageType.Avif || setting.PageType == StoragePageType.Jpeg2000;
 			txWidth.Enabled = setting.PageResize != StoragePageResize.Height && setting.PageResize != StoragePageResize.Original;
 			txHeight.Enabled = setting.PageResize != StoragePageResize.Width && setting.PageResize != StoragePageResize.Original;
 			chkDontEnlarge.Enabled = setting.PageResize != StoragePageResize.Original;

--- a/ComicRack/Output/ReadMe.txt
+++ b/ComicRack/Output/ReadMe.txt
@@ -67,6 +67,7 @@ Internally:
 	* WEBP
 	* HEIF & HEIC
 	* AVIF
+	* Jpeg2000
 
 4) NOTABLE UNSUPPORTED ITEMS
 ============================


### PR DESCRIPTION
Added support for reading Jpeg2000 files (.jp2 & .j2k). Write support is possible but the current library used seems bugged and returns the wrong gamma, so I've removed it.

A known issue to disabling write support like that, is when exporting a Jpeg2000 file that had pages merged and keeping the setting to Preserve Original, that merged page will be created as a normal Jpeg, but keep it's .jp2 extension. Seem a very very niche problem, not sure if it warrants checking into it more.