### PR TITLE
Duplicate entries

### DIFF
--- a/ComicRack.Engine/IO/ComicExporter.cs
+++ b/ComicRack.Engine/IO/ComicExporter.cs
@@ -61,9 +61,9 @@ namespace cYo.Projects.ComicRack.Engine.IO
 				{
 					throw new InvalidOperationException(StringUtility.Format(TR.Messages["OutputFileExists", "Output file '{0}' already exists!"], targetPath));
 				}
-				// Check if the file already exists in the database. Overwrite should always be false, added just in case
+				// Check if the file already exists in the database.
 				bool existsInDatabase = FileIsInDatabase?.Invoke(targetPath, ComicBook.FilePath) ?? false;
-				if (File.Exists(targetPath) && existsInDatabase && !setting.Overwrite && setting.Target == ExportTarget.ReplaceSource)
+				if (File.Exists(targetPath) && existsInDatabase && setting.Target == ExportTarget.ReplaceSource)
 				{
 					// If the file exists in the database and we are replacing the source, we throw an exception
 					throw new InvalidOperationException(StringUtility.Format(TR.Messages["AlreadyExistsInDatabase", "Resulting operation would result in a duplicate entry in the database, Output file '{0}' already exists in the library"], targetPath));

--- a/ComicRack.Engine/Metadata/ComicBook/Comparer/ComicBookDublicateComparer.cs
+++ b/ComicRack.Engine/Metadata/ComicBook/Comparer/ComicBookDublicateComparer.cs
@@ -7,7 +7,12 @@ namespace cYo.Projects.ComicRack.Engine
 	{
 		public override int Compare(ComicBook x, ComicBook y)
 		{
-			int num = string.Compare(GroupInfo.CompressedName(x.ShadowSeries), GroupInfo.CompressedName(y.ShadowSeries), ignoreCase: true);
+			int num = string.Compare(x.FilePath, y.FilePath, ignoreCase: true);
+			if (num != 0)
+			{
+				return num;
+			}
+			num = string.Compare(GroupInfo.CompressedName(x.ShadowSeries), GroupInfo.CompressedName(y.ShadowSeries), ignoreCase: true);
 			if (num != 0)
 			{
 				return num;

--- a/ComicRack.Engine/QueueManager.cs
+++ b/ComicRack.Engine/QueueManager.cs
@@ -423,6 +423,18 @@ namespace cYo.Projects.ComicRack.Engine
 					IEnumerable<string> source = (from cb in cbs
 												  where cb.EditMode.IsLocalComic()
 												  select cb.FilePath).ToArray();
+
+
+					//Callback function to check if the file is already in the database, will be checked when calling Export
+					comicExporter.FileIsInDatabase = (string targetPath, string sourceFile) =>
+					{
+						if (string.IsNullOrEmpty(targetPath))
+							return false;
+
+						// If the target path is the same as the source file, we assume it's not a duplicate
+						return targetPath != sourceFile && DatabaseManager.Database.Books.FindItemByFile(targetPath) != null;
+					};
+
 					outPath = comicExporter.Export(CacheManager.ImagePool);
 					if (outPath != null)
 					{


### PR DESCRIPTION
- Show Duplicate will now show entries that point to the same file.
- When exporting would result in a duplicate entry in the database, throw an error instead of allowing it.

Ref #184 