### PR TITLE
Deterministically select the issue that represents the stack

### DIFF
--- a/ComicRack.Engine/Metadata/ComicBook/Comparer/ComicBookIdComparer.cs
+++ b/ComicRack.Engine/Metadata/ComicBook/Comparer/ComicBookIdComparer.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace cYo.Projects.ComicRack.Engine
+{
+	public class ComicBookIdComparer : Comparer<ComicBook>
+	{
+		public override int Compare(ComicBook x, ComicBook y)
+		{
+			return x.Id.CompareTo(y.Id);
+		}
+	}
+}

--- a/ComicRack/Views/ComicBrowserControl.cs
+++ b/ComicRack/Views/ComicBrowserControl.cs
@@ -810,6 +810,7 @@ namespace cYo.Projects.ComicRack.Viewer.Views
 		}
 
 		private static readonly IComparer<IViewableItem> defaultSeriesComparer = new CoverViewItemBookComparer<ComicBookSeriesComparer>();
+		private static readonly IComparer<IViewableItem> IdComparer = new CoverViewItemBookComparer<ComicBookIdComparer>();
 		/// <summary>
 		/// Callback function that will sort the items in a stack based on the stack configuration.
 		/// </summary>
@@ -831,6 +832,7 @@ namespace cYo.Projects.ComicRack.Viewer.Views
 				stackColumnSorter = stackColumnSorter?.Reverse(); // Reverse the sorter if the sort order is Descending.
 
 			stackColumnSorter ??= defaultSeriesComparer; // Default comparer (series) if no stack configuration is found.
+			stackColumnSorter = stackColumnSorter.Chain(IdComparer); // Always chain the tie breaker comparer to ensure a stable sort.
 			return stackColumnSorter;
 		}
 

--- a/cYo.Common.Windows/Forms/ItemView.cs
+++ b/cYo.Common.Windows/Forms/ItemView.cs
@@ -2671,17 +2671,8 @@ namespace cYo.Common.Windows.Forms
 							{
 								// Chain the stack sorter with the default ItemStackSorter if it exists
 								var stackSortComparer = stackSorter is null ? ItemStackSorter : ItemStackSorter.Chain(stackSorter); // Default comparer if no specific sorter is found
-                                // Deterministically select the issue that represents the stack
-                                group.Items.Sort(System.Collections.Generic.Comparer<IViewableItem>.Create((book1, book2) =>
-                                {
-                                    int sortResult = stackSortComparer.Compare(book1, book2);
-                                    if (sortResult != 0) return sortResult;
-									// Else tie-breaker based on Comic GUID
-                                    var guid1 = ((dynamic)book1).Comic.Id;
-                                    var guid2 = ((dynamic)book2).Comic.Id;
-                                    return guid1.CompareTo(guid2);
-                                }));
-                            }
+								group.Items.Sort(stackSortComparer); // Sort the items in the group using the stack sorter
+							}
 							StackInfo stackInfo = new StackInfo(group);
 							OnProcessStack(stackInfo); // Settings like Top of Stack & Custom Thumbnail will be applied here
 							IViewableItem key = group.Items[0]; // Use the first item of the stack


### PR DESCRIPTION
Handles a few edge cases that result in the "top of the stack" issue changing when refreshing a smart list. Fixes #68.