### PR TITLE
List Order devices sorting option

### DIFF
--- a/ComicRack.Engine/Metadata/ComicBook/ComicBookMetadata.cs
+++ b/ComicRack.Engine/Metadata/ComicBook/ComicBookMetadata.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using cYo.Common.ComponentModel;
+using cYo.Common.Windows.Forms;
+
+namespace cYo.Projects.ComicRack.Engine
+{
+	public class ComicBookMetadata
+	{
+		private readonly IComparer<IViewableItem> comparer;
+		private readonly IGrouper<IViewableItem> grouper;
+		public ComicBookMetadata(int id, string name, IComparer<IViewableItem> comparer = null, IGrouper<IViewableItem> grouper = null)
+		{
+			this.Id = id;
+			this.Name = name;
+			this.comparer = comparer;
+			this.grouper = grouper;
+		}
+
+		public int Id { get; }
+		public string Name { get; }
+
+		public IComparer<T> GetComparer<T>()
+		{
+			return typeof(T) switch
+			{
+				Type comicBookType when comicBookType == typeof(ComicBook) => (comparer as IComicBookComparer)?.Comparer as IComparer<T>,
+				Type viewableItem when viewableItem == typeof(IViewableItem) => comparer as IComparer<T>,
+				_ => null,
+			};
+		}
+
+		public IGrouper<T> GetGrouper<T>()
+		{
+			return typeof(T) switch
+			{
+				Type comicBookType when comicBookType == typeof(ComicBook) => (grouper as IBookGrouper)?.BookGrouper as IGrouper<T>,
+				Type viewableItem when viewableItem == typeof(IViewableItem) => grouper as IGrouper<T>,
+				_ => null,
+			};
+		}
+	}
+}

--- a/ComicRack.Engine/Metadata/ComicBook/ComicBookMetadataCollection.cs
+++ b/ComicRack.Engine/Metadata/ComicBook/ComicBookMetadataCollection.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using cYo.Common.Collections;
+using cYo.Common.ComponentModel;
+using cYo.Common.Windows.Forms;
+
+namespace cYo.Projects.ComicRack.Engine
+{
+	public class ComicBookMetadataCollection : SmartList<ComicBookMetadata>
+	{
+		public ComicBookMetadata FindById(int id)
+		{
+			return Find(h => h.Id == id);
+		}
+
+		public ComicBookMetadata FindBySorter(IComparer<ComicBook> comp)
+		{
+			if (comp != null)
+				return Find(h => h.GetComparer<ComicBook>() == comp);
+
+			return default;
+		}
+
+		public ComicBookMetadata FindByGrouper(IGrouper<ComicBook> comp)
+		{
+			if (comp != null)
+				return Find(h => h.GetGrouper<ComicBook>() == comp);
+
+			return default;
+		}
+	}
+}

--- a/ComicRack.Engine/Metadata/ComicBook/ComicBookMetadataManager.cs
+++ b/ComicRack.Engine/Metadata/ComicBook/ComicBookMetadataManager.cs
@@ -60,11 +60,11 @@ namespace cYo.Projects.ComicRack.Engine
 		// Gets the first generic comparer for the given comma separated sort key
 		private static IComparer<T> GetGenericFirstComparer<T>(string sortKey) => GetGenericComparers<T>(sortKey)?.FirstOrDefault();
 
-		// Gets a chained generic comparer for the given comma separated sort key
-		private static IComparer<T> GetGenericChainedComparer<T>(string sortKey)
+		// Gets an array of comparers for the given comma separated sort key
+		private static IComparer<T>[] GetGenericChainedComparer<T>(string sortKey)
 		{
 			var comparer = GetGenericComparers<T>(sortKey);
-			return comparer is null ? null : new ChainedComparer<T>(comparer);
+			return comparer is null ? null : comparer.TakeWhile(x => x != null).ToArray();
 		}
 		#endregion
 
@@ -73,14 +73,14 @@ namespace cYo.Projects.ComicRack.Engine
 		// Gets the first comparer for the given comma separated sort key
 		public static IComparer<ComicBook> GetComparer(string sortKey) => GetGenericFirstComparer<ComicBook>(sortKey);
 
-		// Gets a chained comparer for the given comma separated sort key
-		public static IComparer<ComicBook> GetComparers(string sortKey) => GetGenericChainedComparer<ComicBook>(sortKey);
+		// Gets an array of comparers for the given comma separated sort key
+		public static IComparer<ComicBook>[] GetComparers(string sortKey) => GetGenericChainedComparer<ComicBook>(sortKey);
 
 		// Gets the first comparer for the given comma separated sort key
 		public static IComparer<IViewableItem> GetIViewableItemComparer(string sortKey) => GetGenericFirstComparer<IViewableItem>(sortKey);
 
-		// Gets a chained comparer for the given comma separated sort key
-		public static IComparer<IViewableItem> GetIViewableItemComparers(string sortKey) => GetGenericChainedComparer<IViewableItem>(sortKey);
+		// Gets an array of comparers for the given comma separated sort key
+		public static IComparer<IViewableItem>[] GetIViewableItemComparers(string sortKey) => GetGenericChainedComparer<IViewableItem>(sortKey);
 		#endregion
 
 
@@ -103,7 +103,7 @@ namespace cYo.Projects.ComicRack.Engine
 		private static IGrouper<T> GetGenericCompoundGroupers<T>(string sortKey)
 		{
 			var groupers = GetGenericGrouper<T>(sortKey);
-			return groupers is null ? null : new CompoundSingleGrouper<T>(GetGenericGrouper<T>(sortKey).ToArray());
+			return groupers is null ? null : new CompoundSingleGrouper<T>(GetGenericGrouper<T>(sortKey).TakeWhile(x => x != null).ToArray());
 		}
 		#endregion
 

--- a/ComicRack.Engine/Metadata/ComicBook/ComicBookMetadataManager.cs
+++ b/ComicRack.Engine/Metadata/ComicBook/ComicBookMetadataManager.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using cYo.Common.Collections;
+using cYo.Common.ComponentModel;
+using cYo.Common.Windows.Forms;
+
+namespace cYo.Projects.ComicRack.Engine
+{
+	public class ComicBookMetadataManager
+	{
+		private static readonly Lazy<ComicBookMetadataManager> manager = new Lazy<ComicBookMetadataManager>(() => new ComicBookMetadataManager());
+
+		private readonly ComicBookMetadataCollection collection;
+		public static ComicBookMetadataCollection Collection => manager.Value?.collection;
+
+		private ComicBookMetadataManager()
+		{
+			collection = new ComicBookMetadataCollection();
+		}
+
+		// Take the list of IColumn and create the Collection
+		public static void Create(IEnumerable<IColumn> columns)
+		{
+			if (columns is null)
+				return;
+
+			Collection.Clear();
+			foreach (var column in columns)
+			{
+				if (column.ColumnSorter is null && column.ColumnGrouper is null)
+					continue;
+
+				if (Collection.Any(m => m.Id == column.Id))
+					return;
+
+				ComicBookMetadata metadata = new ComicBookMetadata(column.Id, column.Name, column.ColumnSorter, column.ColumnGrouper);
+				Collection.Add(metadata);
+			}
+		}
+
+
+		#region Generics Comparers
+		// Converts the sortKey to a list of ComicBookMetadata & returns the lists of comparers associated with it, returns null if the first one is null
+		private static IEnumerable<IComparer<T>> GetGenericComparers<T>(string sortKey)
+		{
+			var columns = ConvertKeyToMetadata(sortKey);
+			var comparers = columns.Where(m => m != null);
+			if (comparers?.FirstOrDefault()?.GetComparer<T>() == null)
+				return null;
+
+			return comparers.Where(m => m.GetComparer<T>() != null).Select(m => m.GetComparer<T>());
+		}
+
+		// Gets the first generic comparer for the given comma separated sort key
+		private static IComparer<T> GetGenericFirstComparer<T>(string sortKey) => GetGenericComparers<T>(sortKey)?.FirstOrDefault();
+
+		// Gets a chained generic comparer for the given comma separated sort key
+		private static IComparer<T> GetGenericChainedComparer<T>(string sortKey)
+		{
+			var comparer = GetGenericComparers<T>(sortKey);
+			return comparer is null ? null : new ChainedComparer<T>(comparer);
+		}
+		#endregion
+
+
+		#region Comparers
+		// Gets the first comparer for the given comma separated sort key
+		public static IComparer<ComicBook> GetComparer(string sortKey) => GetGenericFirstComparer<ComicBook>(sortKey);
+
+		// Gets a chained comparer for the given comma separated sort key
+		public static IComparer<ComicBook> GetComparers(string sortKey) => GetGenericChainedComparer<ComicBook>(sortKey);
+
+		// Gets the first comparer for the given comma separated sort key
+		public static IComparer<IViewableItem> GetIViewableItemComparer(string sortKey) => GetGenericFirstComparer<IViewableItem>(sortKey);
+
+		// Gets a chained comparer for the given comma separated sort key
+		public static IComparer<IViewableItem> GetIViewableItemComparers(string sortKey) => GetGenericChainedComparer<IViewableItem>(sortKey);
+		#endregion
+
+
+		#region Generic Groupers
+		// Converts the sortKey to a list of ComicBookMetadata & returns the lists of groupers associated with it, returns null if the first one is null
+		private static IEnumerable<IGrouper<T>> GetGenericGrouper<T>(string sortKey)
+		{
+			var columns = ConvertKeyToMetadata(sortKey);
+			var groupers = columns.Where(m => m != null);
+			if (groupers?.FirstOrDefault()?.GetGrouper<T>() == null)
+				return null;
+
+			return groupers?.Where(m => m.GetGrouper<T>() != null).Select(m => m.GetGrouper<T>());
+		}
+
+		// Gets the first generic grouper for the given comma separated sort key
+		private static IGrouper<T> GetGenericFirstGrouper<T>(string sortKey) => GetGenericGrouper<T>(sortKey)?.FirstOrDefault();
+
+		// Gets a chained generic grouper for the given comma separated sort key
+		private static IGrouper<T> GetGenericCompoundGroupers<T>(string sortKey)
+		{
+			var groupers = GetGenericGrouper<T>(sortKey);
+			return groupers is null ? null : new CompoundSingleGrouper<T>(GetGenericGrouper<T>(sortKey).ToArray());
+		}
+		#endregion
+
+
+		#region Groupers
+		// Gets the first grouper for the given comma separated sort key
+		public static IGrouper<ComicBook> GetGrouper(string sortKey) => GetGenericFirstGrouper<ComicBook>(sortKey);
+
+		// Gets a chained grouper for the given comma separated sort key
+		public static IGrouper<ComicBook> GetGroupers(string sortKey) => GetGenericCompoundGroupers<ComicBook>(sortKey);
+
+		// Gets the first grouper for the given comma separated sort key
+		public static IGrouper<IViewableItem> GetIViewableItemGrouper(string sortKey) => GetGenericFirstGrouper<IViewableItem>(sortKey);
+
+		// Gets a chained grouper for the given comma separated sort key
+		public static IGrouper<IViewableItem> GetIViewableItemGroupers(string sortKey) => GetGenericCompoundGroupers<IViewableItem>(sortKey); 
+		#endregion
+
+
+		//takes the key and outputs the corresponding ComicBookMetadata from the Manager Collection
+		private static IEnumerable<ComicBookMetadata> ConvertKeyToMetadata(string key)
+		{
+			if (string.IsNullOrEmpty(key))
+			{
+				yield break;
+			}
+			string[] array = key.Split(',');
+			foreach (string s in array)
+			{
+				if (int.TryParse(s, out var result))
+				{
+					ComicBookMetadata metadata = Collection.FindById(result);
+					if (metadata != null)
+						yield return metadata;
+				}
+			}
+		}
+	}
+}

--- a/ComicRack.Engine/Metadata/IBookGrouper.cs
+++ b/ComicRack.Engine/Metadata/IBookGrouper.cs
@@ -1,7 +1,6 @@
 using cYo.Common.ComponentModel;
-using cYo.Projects.ComicRack.Engine;
 
-namespace cYo.Projects.ComicRack.Viewer.Controls
+namespace cYo.Projects.ComicRack.Engine
 {
 	public interface IBookGrouper
 	{

--- a/ComicRack.Engine/Sync/DeviceSyncSettings.cs
+++ b/ComicRack.Engine/Sync/DeviceSyncSettings.cs
@@ -25,7 +25,8 @@ namespace cYo.Projects.ComicRack.Engine.Sync
 			AlternateSeries,
 			Published,
 			Added,
-			StoryArc
+			StoryArc,
+			ListOrder
 		}
 
 		[Serializable]

--- a/ComicRack.Engine/Sync/StorageSync.cs
+++ b/ComicRack.Engine/Sync/StorageSync.cs
@@ -277,27 +277,31 @@ namespace cYo.Projects.ComicRack.Engine.Sync
 			{
 				switch (setting.ListSortType)
 				{
-				default:
-					comparer = new ChainedComparer<ComicBook>(new ComicBookSeriesComparer(), new ComicBookPublishedComparer());
-					grouper = new ComicBookGroupSeries();
-					break;
-				case DeviceSyncSettings.ListSort.Random:
-					list2.Randomize();
-					break;
-				case DeviceSyncSettings.ListSort.AlternateSeries:
-					comparer = new ChainedComparer<ComicBook>(new ComicBookAlternateSeriesComparer(), new ComicBookSeriesComparer(), new ComicBookPublishedComparer());
-					grouper = new ComicBookGroupAlternateSeries();
-					break;
-				case DeviceSyncSettings.ListSort.Published:
-					comparer = new ChainedComparer<ComicBook>(new ComicBookPublishedComparer(), new ComicBookSeriesComparer());
-					break;
-				case DeviceSyncSettings.ListSort.Added:
-					comparer = new ComicBookAddedComparer();
-					break;
-				case DeviceSyncSettings.ListSort.StoryArc:
-					comparer = new ChainedComparer<ComicBook>(new ComicBookStoryArcComparer(), new ComicBookAlternateNumberComparer(), new ComicBookSeriesComparer(), new ComicBookPublishedComparer());
-					grouper = new ComicBookGroupStoryArc();
-					break;
+					default:
+						comparer = new ChainedComparer<ComicBook>(new ComicBookSeriesComparer(), new ComicBookPublishedComparer());
+						grouper = new ComicBookGroupSeries();
+						break;
+					case DeviceSyncSettings.ListSort.Random:
+						list2.Randomize();
+						break;
+					case DeviceSyncSettings.ListSort.AlternateSeries:
+						comparer = new ChainedComparer<ComicBook>(new ComicBookAlternateSeriesComparer(), new ComicBookSeriesComparer(), new ComicBookPublishedComparer());
+						grouper = new ComicBookGroupAlternateSeries();
+						break;
+					case DeviceSyncSettings.ListSort.Published:
+						comparer = new ChainedComparer<ComicBook>(new ComicBookPublishedComparer(), new ComicBookSeriesComparer());
+						break;
+					case DeviceSyncSettings.ListSort.Added:
+						comparer = new ComicBookAddedComparer();
+						break;
+					case DeviceSyncSettings.ListSort.ListOrder:
+						comparer = ComicBookMetadataManager.GetComparers(list.Display.View.SortKey);
+						grouper = ComicBookMetadataManager.GetGroupers(list.Display.View.GrouperId);
+						break;
+					case DeviceSyncSettings.ListSort.StoryArc:
+						comparer = new ChainedComparer<ComicBook>(new ComicBookStoryArcComparer(), new ComicBookAlternateNumberComparer(), new ComicBookSeriesComparer(), new ComicBookPublishedComparer());
+						grouper = new ComicBookGroupStoryArc();
+						break;
 				}
 			}
 			List<ComicBook>[] array = ((grouper != null) ? (from gc in new GroupManager<ComicBook>(grouper, list2).GetGroups()

--- a/ComicRack.Engine/Sync/StorageSync.cs
+++ b/ComicRack.Engine/Sync/StorageSync.cs
@@ -295,7 +295,7 @@ namespace cYo.Projects.ComicRack.Engine.Sync
 						comparer = new ComicBookAddedComparer();
 						break;
 					case DeviceSyncSettings.ListSort.ListOrder:
-						comparer = ComicBookMetadataManager.GetComparers(list.Display.View.SortKey);
+						comparer = ComicBookMetadataManager.GetComparers(list.Display.View.SortKey)?.Chain();
 						grouper = ComicBookMetadataManager.GetGroupers(list.Display.View.GrouperId);
 						break;
 					case DeviceSyncSettings.ListSort.StoryArc:

--- a/ComicRack/Controls/CoverViewItemVirtualTagComparer.cs
+++ b/ComicRack/Controls/CoverViewItemVirtualTagComparer.cs
@@ -4,9 +4,10 @@ using cYo.Projects.ComicRack.Engine.Metadata.VirtualTags;
 
 namespace cYo.Projects.ComicRack.Viewer.Controls
 {
-	public class CoverViewItemVirtualTagComparer : CoverViewItemComparer
+	public class CoverViewItemVirtualTagComparer : CoverViewItemComparer, IComicBookComparer
 	{
 		private readonly IComparer<ComicBook> _comparer;
+		public IComparer<ComicBook> Comparer => _comparer;
 
 		public CoverViewItemVirtualTagComparer(string property)
 		{

--- a/ComicRack/Dialogs/DeviceEditControl.Designer.cs
+++ b/ComicRack/Dialogs/DeviceEditControl.Designer.cs
@@ -157,7 +157,8 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             "Alternate Series",
             "Published",
             "Added",
-            "Story Arc"});
+            "Story Arc",
+            "List Order"});
             this.cbLimitSort.Location = new System.Drawing.Point(126, 18);
             this.cbLimitSort.Name = "cbLimitSort";
             this.cbLimitSort.Size = new System.Drawing.Size(144, 21);

--- a/ComicRack/MainForm.cs
+++ b/ComicRack/MainForm.cs
@@ -2192,6 +2192,7 @@ namespace cYo.Projects.ComicRack.Viewer
 
 		public void MenuSynchronizeDevices()
 		{
+			StoreWorkspace(); // save workspace before sync, so sorted lists key are up to date
 			if (!Program.QueueManager.SynchronizeDevices())
 			{
 				ShowPortableDevices();
@@ -4107,6 +4108,7 @@ namespace cYo.Projects.ComicRack.Viewer
 
 		void IApplication.SynchronizeDevices()
 		{
+			StoreWorkspace(); // save workspace before sync, so sorted lists key are up to date
 			Program.QueueManager.SynchronizeDevices();
 		}
 

--- a/ComicRack/Program.cs
+++ b/ComicRack/Program.cs
@@ -752,7 +752,8 @@ namespace cYo.Projects.ComicRack.Viewer
                     {
                         MainForm.BeginInvoke(delegate
                         {
-                            QueueManager.SynchronizeDevice(e.Key, address);
+							MainForm.StoreWorkspace(); // save workspace before sync, so sorted lists key are up to date
+							QueueManager.SynchronizeDevice(e.Key, address);
                         });
                     }
                 }

--- a/ComicRack/Views/ComicBrowserControl.cs
+++ b/ComicRack/Views/ComicBrowserControl.cs
@@ -569,6 +569,7 @@ namespace cYo.Projects.ComicRack.Viewer.Views
 						SetCustomColumns();
 					};
 					SetCustomColumns();
+					SetVirtualTagColumns();
 				}
 			}
 		}
@@ -787,7 +788,6 @@ namespace cYo.Projects.ComicRack.Viewer.Views
 			itemView.Columns.Add(new ItemViewColumn(212, "Series: Opened", 50, new ComicListField("SeriesStatLastOpenedTime", "Last time a book was opened from the Series", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemStatsComparer<ComicBookSeriesStatsLastOpenedTimeComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupLastOpenedTime>(), visible: false, StringAlignment.Far, strings));
 			itemView.Columns.Add(new ItemViewColumn(213, "Series: Book released", 50, new ComicListField("SeriesStatLastReleasedTime", "Last time a book of this Series was released", null, StringTrimming.Word, typeof(DateTime)), new CoverViewItemStatsComparer<ComicBookSeriesStatsLastReleasedTimeComparer>(), new CoverViewItemStatsGrouper<ComicBookStatsGroupLastReleasedTime>(), visible: false, StringAlignment.Far, strings));
 			itemView.Columns.Add(new ItemViewColumn(214, "Actual File Format (slow)", 40, new ComicListField("ActualFileFormat", "Actual File format of the Book (based on the header)"), new CoverViewItemBookComparer<ComicBookActualFileFormatComparer>(), new CoverViewItemBookGrouper<ComicBookGroupActualFileFormat>(), visible: false));
-			SetVirtualTagColumns();
 			SubView.TranslateColumns(itemView.Columns);
 			foreach (ItemViewColumn column in itemView.Columns)
 			{

--- a/ComicRack/Views/ComicBrowserControl.cs
+++ b/ComicRack/Views/ComicBrowserControl.cs
@@ -567,9 +567,11 @@ namespace cYo.Projects.ComicRack.Viewer.Views
 					library.CustomValuesChanged += delegate
 					{
 						SetCustomColumns();
+						ComicBookMetadataManager.Create(itemView.Columns);
 					};
 					SetCustomColumns();
 					SetVirtualTagColumns();
+					ComicBookMetadataManager.Create(itemView.Columns);
 				}
 			}
 		}
@@ -828,7 +830,7 @@ namespace cYo.Projects.ComicRack.Viewer.Views
 			IComparer<IViewableItem> stackColumnSorter = colInfo?.ColumnSorter; // Get the column sorter for the column.
 
 			SortOrder sortOrder = config?.ItemSortOrder ?? SortOrder.None; // Default to None if there is no config
-			if (sortOrder == SortOrder.Descending) 
+			if (sortOrder == SortOrder.Descending)
 				stackColumnSorter = stackColumnSorter?.Reverse(); // Reverse the sorter if the sort order is Descending.
 
 			stackColumnSorter ??= defaultSeriesComparer; // Default comparer (series) if no stack configuration is found.
@@ -2532,7 +2534,7 @@ namespace cYo.Projects.ComicRack.Viewer.Views
 		public void RefreshInformation()
 		{
 			IEnumerable<CoverViewItem> selectedItems = from CoverViewItem cvi in new List<IViewableItem>(itemView.SelectedItems)
-														select cvi;
+													   select cvi;
 
 			foreach (CoverViewItem item in selectedItems)
 			{
@@ -3248,6 +3250,7 @@ namespace cYo.Projects.ComicRack.Viewer.Views
 		{
 			SetCustomColumns();
 			SetVirtualTagColumns();
+			ComicBookMetadataManager.Create(itemView.Columns);
 			FillBookList();
 		}
 

--- a/ComicRack/Views/ComicBrowserControl.cs
+++ b/ComicRack/Views/ComicBrowserControl.cs
@@ -864,8 +864,7 @@ namespace cYo.Projects.ComicRack.Viewer.Views
 
 			// Determine the stack configuration depending on program settings.
 			ItemViewConfig config = stacksConfig?.GetStackViewConfig(Program.Settings.CommonListStackLayout ? BookList.Name : stackCaption);
-			IColumn colInfo = itemView.ConvertKeyToColumns(config?.SortKey)?.FirstOrDefault(); // Get the IColumn that refers to the sort key
-			IComparer<IViewableItem> stackColumnSorter = colInfo?.ColumnSorter; // Get the column sorter for the column.
+			var stackColumnSorter = ComicBookMetadataManager.GetIViewableItemComparers(config?.SortKey); // Get the IComparer for the sort key
 
 			SortOrder sortOrder = config?.ItemSortOrder ?? SortOrder.None; // Default to None if there is no config
 			if (sortOrder == SortOrder.Descending)

--- a/ComicRack/Views/ComicListLibraryBrowser.cs
+++ b/ComicRack/Views/ComicListLibraryBrowser.cs
@@ -1413,7 +1413,10 @@ namespace cYo.Projects.ComicRack.Viewer.Views
 		private IComparer<ComicBook> GetCurrentListSorter(string sortKey)
 		{
 			var comicBrowser = Program.MainForm.FindActiveService<IComicBrowser>() as ComicBrowserControl;
-			var comparer = (comicBrowser?.ItemView.ConvertKeyToColumns(sortKey).FirstOrDefault()?.ColumnSorter as IComicBookComparer)?.Comparer;
+			var comparer = ComicBookMetadataManager.GetComparers(sortKey);
+
+			if (comparer is null)
+				return null;
 
 			var sortOrder = comicBrowser?.ItemView.ItemSortOrder ?? SortOrder.None;
 			if (sortOrder == SortOrder.Descending && comparer != null)

--- a/ComicRack/Views/ComicListLibraryBrowser.cs
+++ b/ComicRack/Views/ComicListLibraryBrowser.cs
@@ -1413,16 +1413,17 @@ namespace cYo.Projects.ComicRack.Viewer.Views
 		private IComparer<ComicBook> GetCurrentListSorter(string sortKey)
 		{
 			var comicBrowser = Program.MainForm.FindActiveService<IComicBrowser>() as ComicBrowserControl;
-			var comparer = ComicBookMetadataManager.GetComparers(sortKey);
-
-			if (comparer is null)
-				return null;
+			var comparers = ComicBookMetadataManager.GetComparers(sortKey);
+			var firstComparer = comparers?.FirstOrDefault(); // Get the first comparer to reverse the sort order
 
 			var sortOrder = comicBrowser?.ItemView.ItemSortOrder ?? SortOrder.None;
-			if (sortOrder == SortOrder.Descending && comparer != null)
-				comparer = comparer.Reverse();
+			if (sortOrder == SortOrder.Descending && firstComparer != null)
+				firstComparer = firstComparer.Reverse();
 
-			return comparer;
+			if (comparers?.Length > 0 && firstComparer != null)
+				comparers[0] = firstComparer; // Replace the first comparer with the reversed one.
+
+			return comparers?.Chain();
 		}
 
 		private bool isPasteListEnabled()

--- a/cYo.Common.Windows/Forms/ItemView.cs
+++ b/cYo.Common.Windows/Forms/ItemView.cs
@@ -1665,7 +1665,7 @@ namespace cYo.Common.Windows.Forms
 
 		public event PaintEventHandler PostPaint;
 
-		public Func<string, IComparer<IViewableItem>> StackColumnSorter { get; set; }
+		public Func<string, IComparer<IViewableItem>[]> StackColumnSorter { get; set; }
 
 
 		public ItemView()


### PR DESCRIPTION
This pull request introduces a new metadata management system for comic books, allowing for easier sorting and grouping capabilities.

- Added a new `List Order` sorting option for devices syncing that uses the sorting from that list.

- Updated sorting and grouping logic when to utilize the new metadata management system when exporting lists, sorting stacks & device sync using list order.

All changes now uses the complete sorting keys and not just the 1st one anymore.

closes #203 