### PR TITLE
FEATURE: Embed Library metadata into Book Files (Comicbook.xml)

### DIFF
--- a/ComicRack.Engine/BookChangedEventArgs.cs
+++ b/ComicRack.Engine/BookChangedEventArgs.cs
@@ -2,58 +2,63 @@ using System.ComponentModel;
 
 namespace cYo.Projects.ComicRack.Engine
 {
-	public class BookChangedEventArgs : PropertyChangedEventArgs
-	{
-		public object OldValue
-		{
-			get;
-			private set;
-		}
+    public enum ComicInfoType
+    {
+        None,
+        ComicInfo,
+        ComicBook
+    }
 
-		public object NewValue
-		{
-			get;
-			private set;
-		}
+    public class BookChangedEventArgs : PropertyChangedEventArgs
+    {
+        public object OldValue
+        {
+            get;
+            private set;
+        }
 
-		public bool IsComicInfo
-		{
-			get;
-			private set;
-		}
+        public object NewValue
+        {
+            get;
+            private set;
+        }
 
-		public int Page
-		{
-			get;
-			private set;
-		}
+        private ComicInfoType ComicInfoType { get; set; }
+        public bool IsComicInfo => ComicInfoType == ComicInfoType.ComicInfo;
+        public bool IsComicBook => ComicInfoType == ComicInfoType.ComicBook;
 
-		public BookChangedEventArgs(string propertyName, int page, bool isComicInfo)
-			: base(propertyName)
-		{
-			IsComicInfo = isComicInfo;
-			Page = page;
-		}
+        public int Page
+        {
+            get;
+            private set;
+        }
 
-		public BookChangedEventArgs(string propertyName, bool isComicInfo)
-			: this(propertyName, -1, isComicInfo)
-		{
-		}
+        public BookChangedEventArgs(string propertyName, int page, ComicInfoType comicInfoType)
+            : base(propertyName)
+        {
+            ComicInfoType = comicInfoType;
+            Page = page;
+        }
 
-		public BookChangedEventArgs(string propertyName, bool isComicInfo, object oldValue, object newValue)
-			: this(propertyName, -1, isComicInfo)
-		{
-			OldValue = oldValue;
-			NewValue = newValue;
-		}
+        public BookChangedEventArgs(string propertyName, ComicInfoType comicInfoType)
+            : this(propertyName, -1, comicInfoType)
+        {
+        }
 
-		public BookChangedEventArgs(BookChangedEventArgs e)
-			: base(e.PropertyName)
-		{
-			OldValue = e.OldValue;
-			NewValue = e.NewValue;
-			IsComicInfo = e.IsComicInfo;
-			Page = e.Page;
-		}
-	}
+        public BookChangedEventArgs(string propertyName, ComicInfoType comicInfoType, object oldValue, object newValue)
+            : this(propertyName, -1, comicInfoType)
+        {
+            OldValue = oldValue;
+            NewValue = newValue;
+        }
+
+        public BookChangedEventArgs(BookChangedEventArgs e)
+            : base(e.PropertyName)
+        {
+            OldValue = e.OldValue;
+            NewValue = e.NewValue;
+            ComicInfoType = e.ComicInfoType;
+            Page = e.Page;
+        }
+    }
 }

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -302,7 +302,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
             set
             {
-                SetProperty("ReleasedTime", ref releasedTime, value, lockItem: true);
+                SetProperty("ReleasedTime", ref releasedTime, value, lockItem: true, includeInComicBook: true);
             }
         }
 
@@ -400,7 +400,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
             set
             {
-                SetProperty("Rating", ref rating, value.Clamp(0f, 5f));
+                SetProperty("Rating", ref rating, value.Clamp(0f, 5f), includeInComicBook: true);
             }
         }
 
@@ -426,7 +426,7 @@ namespace cYo.Projects.ComicRack.Engine
                     bitmapAdjustment = colorAdjustment;
                     colorAdjustment = value;
                 }
-                FireBookChanged("ColorAdjustment", bitmapAdjustment, colorAdjustment);
+                FireBookChanged("ColorAdjustment", bitmapAdjustment, colorAdjustment, includeInComicBook: true);
             }
         }
 
@@ -458,7 +458,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
             set
             {
-                SetProperty("SeriesComplete", ref seriesComplete, value);
+                SetProperty("SeriesComplete", ref seriesComplete, value, includeInComicBook: true);
             }
         }
 
@@ -679,7 +679,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
             set
             {
-                SetProperty("BookPrice", ref bookPrice, value);
+                SetProperty("BookPrice", ref bookPrice, value, includeInComicBook: true);
             }
         }
 
@@ -694,7 +694,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
             set
             {
-                SetProperty("BookAge", ref bookAge, value);
+                SetProperty("BookAge", ref bookAge, value, includeInComicBook: true);
             }
         }
 
@@ -709,7 +709,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
             set
             {
-                SetProperty("BookCondition", ref bookCondition, value);
+                SetProperty("BookCondition", ref bookCondition, value, includeInComicBook: true);
             }
         }
 
@@ -724,7 +724,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
             set
             {
-                SetProperty("BookStore", ref bookStore, value);
+                SetProperty("BookStore", ref bookStore, value, includeInComicBook: true);
             }
         }
 
@@ -739,7 +739,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
             set
             {
-                SetProperty("BookOwner", ref bookOwner, value);
+                SetProperty("BookOwner", ref bookOwner, value, includeInComicBook: true);
             }
         }
 
@@ -754,7 +754,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
             set
             {
-                SetProperty("BookCollectionStatus", ref bookCollectionStatus, value);
+                SetProperty("BookCollectionStatus", ref bookCollectionStatus, value, includeInComicBook: true);
             }
         }
 
@@ -769,7 +769,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
             set
             {
-                SetProperty("BookNotes", ref bookNotes, value);
+                SetProperty("BookNotes", ref bookNotes, value, includeInComicBook: true);
             }
         }
 
@@ -784,7 +784,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
             set
             {
-                SetProperty("BookLocation", ref bookLocation, value);
+                SetProperty("BookLocation", ref bookLocation, value, includeInComicBook: true);
             }
         }
 
@@ -799,7 +799,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
             set
             {
-                SetProperty("ISBN", ref isbn, value);
+                SetProperty("ISBN", ref isbn, value, includeInComicBook: true);
             }
         }
 
@@ -1367,7 +1367,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
             set
             {
-                SetProperty("NewPages", ref newPages, value);
+                SetProperty("NewPages", ref newPages, value, includeInComicBook: true);
             }
         }
 
@@ -1606,7 +1606,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
             set
             {
-                SetProperty("CustomValuesStore", ref customValuesStore, value);
+                SetProperty("CustomValuesStore", ref customValuesStore, value, includeInComicBook: true);
             }
         }
 
@@ -2550,7 +2550,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
         }
 
-        private bool SetProperty<T>(string name, ref T property, T value, bool lockItem = false, bool addUndo = true)
+        private bool SetProperty<T>(string name, ref T property, T value, bool lockItem = false, bool addUndo = true, bool includeInComicBook = false)
         {
             if (object.Equals(property, value))
                 return false;
@@ -2565,21 +2565,23 @@ namespace cYo.Projects.ComicRack.Engine
             }
 
             if (addUndo)
-                FireBookChanged(name, val, value);
+                FireBookChanged(name, val, value, includeInComicBook);
             else
-                FireBookChanged(name);
+                FireBookChanged(name, includeInComicBook);
 
             return true;
         }
 
-        private void FireBookChanged(string name)
+        private void FireBookChanged(string name, bool includeInComicBook = false)
         {
-            OnBookChanged(new BookChangedEventArgs(name, isComicInfo: false));
+            ComicInfoType infoType = includeInComicBook ? ComicInfoType.ComicBook : ComicInfoType.None;
+            OnBookChanged(new BookChangedEventArgs(name, comicInfoType: infoType));
         }
 
-        private void FireBookChanged(string name, object oldValue, object newValue)
+        private void FireBookChanged(string name, object oldValue, object newValue, bool includeInComicBook = false)
         {
-            OnBookChanged(new BookChangedEventArgs(name, isComicInfo: false, oldValue, newValue));
+            ComicInfoType infoType = includeInComicBook ? ComicInfoType.ComicBook : ComicInfoType.None;
+            OnBookChanged(new BookChangedEventArgs(name, comicInfoType: infoType, oldValue, newValue));
         }
 
         private void UpdateProposed()

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -141,6 +141,8 @@ namespace cYo.Projects.ComicRack.Engine
 
         private volatile bool comicInfoIsDirty;
 
+        private volatile bool comicBookIsDirty;
+
         private volatile string filePath = string.Empty;
 
         private long fileSize = -1L;
@@ -529,6 +531,24 @@ namespace cYo.Projects.ComicRack.Engine
                 {
                     comicInfoIsDirty = value;
                     FireBookChanged("ComicInfoIsDirty");
+                }
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue(false)]
+        public bool ComicBookIsDirty
+        {
+            get
+            {
+                return comicBookIsDirty;
+            }
+            set
+            {
+                if (comicBookIsDirty != value)
+                {
+                    comicBookIsDirty = value;
+                    FireBookChanged("ComicBookIsDirty");
                 }
             }
         }
@@ -1288,13 +1308,11 @@ namespace cYo.Projects.ComicRack.Engine
             {
                 int num = 0;
                 if (FileIsMissing && IsLinked)
-                {
                     num |= 1;
-                }
-                if (ComicInfoIsDirty)
-                {
+
+                if (ComicInfoIsDirty || ComicBookIsDirty)
                     num |= 2;
-                }
+
                 return num;
             }
         }
@@ -2454,7 +2472,7 @@ namespace cYo.Projects.ComicRack.Engine
                     return;
                 }
                 bool forceRefreshInfo = options.HasFlag(RefreshInfoOptions.ForceRefresh);
-                if (forceRefreshInfo || !ComicInfoIsDirty)
+                if (forceRefreshInfo || !(ComicInfoIsDirty || ComicBookIsDirty))
                 {
                     InfoLoadingMethod method = (dateIsModified || !FileInfoRetrieved) ? InfoLoadingMethod.Complete : InfoLoadingMethod.Fast;
                     ComicInfo ci = infoStorage.LoadInfo(method); // Read ComicInfo.xml
@@ -2471,7 +2489,10 @@ namespace cYo.Projects.ComicRack.Engine
                     }
 
                     if (forceRefreshInfo)
+                    {
                         ComicInfoIsDirty = false;
+                        ComicBookIsDirty = false;
+                    }
                 }
 
                 // Refresh page count info if:
@@ -2725,11 +2746,12 @@ namespace cYo.Projects.ComicRack.Engine
                 cb.LastOpenedFromListId = Guid.Empty; // related to Library
                 cb.CustomThumbnailKey = null; // related to Library
                 cb.ComicInfoIsDirty = false;
+                cb.ComicBookIsDirty = false;
                 cb.FileInfoRetrieved = false;
                 cb.FileIsMissing = false; // file dependant
                 cb.ExtraSyncInformation = null; // related to sync, probably always null anyway
                 cb.NewPages = 0; // related to dynamic page count, probably should not be included
-                                 // cb.EnableProposed = true // Also Ignore EnableProposed?
+                // cb.EnableProposed = true // Also Ignore EnableProposed?
 
                 XmlUtility.Store(outStream, cb, compressed: false);
             }

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -2696,7 +2696,8 @@ namespace cYo.Projects.ComicRack.Engine
                 && LastPageRead == cb.LastPageRead
                 && Rating == cb.Rating
                 && ColorAdjustment == cb.ColorAdjustment
-                && EnableDynamicUpdate == cb.EnableDynamicUpdate
+                //&& EnableDynamicUpdate == cb.EnableDynamicUpdate
+                //&& IsDynamicSource == cb.IsDynamicSource
                 && EnableProposed == cb.EnableProposed
                 && SeriesComplete == cb.SeriesComplete
                 && Checked == cb.Checked
@@ -2751,6 +2752,8 @@ namespace cYo.Projects.ComicRack.Engine
                 cb.FileIsMissing = false; // file dependant
                 cb.ExtraSyncInformation = null; // related to sync, probably always null anyway
                 cb.NewPages = 0; // related to dynamic page count, probably should not be included
+                cb.IsDynamicSource = false; // related to dynamic source, probably should not be included
+                cb.EnableDynamicUpdate = true; // related to dynamic source, probably should not be included
                 // cb.EnableProposed = true // Also Ignore EnableProposed?
 
                 XmlUtility.Store(outStream, cb, compressed: false);

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -2358,7 +2358,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
         }
 
-        public bool WriteInfoToFile(bool withRefreshFileProperties = true)
+        public bool WriteInfoToFile(IComicUpdateSettings settings, bool withRefreshFileProperties = true)
         {
             bool success = false;
             if (!EditMode.IsLocalComic())
@@ -2379,7 +2379,7 @@ namespace cYo.Projects.ComicRack.Engine
 
                 try
                 {
-					bool updateComicBook = true; // TODO: connect setting
+					bool updateComicBook = settings.UpdateComicBookFiles; // Only update if enabled in the Settings
                     ComicInfo info = updateComicBook ? this.Clone<ComicBook>() : GetInfo();
                     success = infoStorage.StoreInfo(info); 
                     FileInfoRetrieved = true;

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -30,7 +30,7 @@ using SharpCompress.Common;
 
 namespace cYo.Projects.ComicRack.Engine
 {
-	[Serializable]
+    [Serializable]
 	[ComVisible(true)]
 	public class ComicBook : ComicInfo, IImageKeyProvider, ICloneable
 	{
@@ -1726,7 +1726,7 @@ namespace cYo.Projects.ComicRack.Engine
 			VirtualTagsCollection.TagsRefresh += VirtualTagsCollection_TagsRefresh;
 		}
 
-		public ComicBook(ComicBook cb)
+		public ComicBook(ComicBook cb) : this()
 		{
 			CopyFrom(cb);
 			if (cb.CreateComicProvider != null)
@@ -1739,7 +1739,7 @@ namespace cYo.Projects.ComicRack.Engine
 			}
 		}
 
-		public static ComicBook Create(string file, RefreshInfoOptions options)
+        public static ComicBook Create(string file, RefreshInfoOptions options)
 		{
 			ComicBook comicBook = new ComicBook
 			{
@@ -2635,7 +2635,16 @@ namespace cYo.Projects.ComicRack.Engine
 			XmlUtility.Store(file, this, compressed: false);
 		}
 
-		public static string FormatPages(int pages)
+        public byte[] ToArrayFull()
+        {
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                SerializeFull(memoryStream);
+                return memoryStream.ToArray();
+            }
+        }
+
+        public static string FormatPages(int pages)
 		{
 			if (pages <= 0)
 			{

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -242,7 +242,9 @@ namespace cYo.Projects.ComicRack.Engine
 			}
 		}
 
-		[XmlAttribute]
+        public bool ShouldSerializeId() => Id != Guid.Empty; // Don't serialize the Id if it's empty
+
+        [XmlAttribute]
 		public Guid Id
 		{
 			get
@@ -481,7 +483,9 @@ namespace cYo.Projects.ComicRack.Engine
 			set;
 		}
 
-		public bool LastOpenedFromListIdSpecified => LastOpenedFromListId != Guid.Empty;
+		public bool LastOpenedFromListIdSpecified => LastOpenedFromListId != Guid.Empty; // Know when the Id has been set to a non-empty value
+
+        public bool ShouldSerializeLastOpenedFromListId() => LastOpenedFromListId != Guid.Empty; // Don't serialize the Id if it's empty
 
 		[XmlAttribute]
 		[DefaultValue(true)]
@@ -2635,8 +2639,23 @@ namespace cYo.Projects.ComicRack.Engine
 			XmlUtility.Store(file, this, compressed: false);
 		}
 
-        public byte[] ToArrayFull()
+        public byte[] ToArrayFull(bool onlyPortable = false)
         {
+			if (onlyPortable)
+			{
+				// Don't include these properties in the exported ComicBook.xml
+				Id = Guid.Empty;
+				FilePath = string.Empty;
+				FileModifiedTime = DateTime.MinValue;
+				FileCreationTime = DateTime.MinValue;
+				AddedTime = DateTime.MinValue; // Keep or not?
+				FileSize = -1;
+				LastOpenedFromListId = Guid.Empty;
+				CustomThumbnailKey = null;
+				ComicInfoIsDirty = false;
+				// TODO: Also Ignore EnableProposed? 
+			}
+
             using (MemoryStream memoryStream = new MemoryStream())
             {
                 SerializeFull(memoryStream);

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -1385,7 +1385,7 @@ namespace cYo.Projects.ComicRack.Engine
             }
             set
             {
-                SetProperty("NewPages", ref newPages, value, includeInComicBook: true);
+                SetProperty("NewPages", ref newPages, value);
             }
         }
 

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -2690,16 +2690,16 @@ namespace cYo.Projects.ComicRack.Engine
             try
             {
                 // Don't include these properties in the exported ComicBook.xml
-                Id = Guid.Empty;
-                FilePath = string.Empty;
-                FileModifiedTime = DateTime.MinValue;
-                FileCreationTime = DateTime.MinValue;
-                AddedTime = DateTime.MinValue; // Keep or not?
-                FileSize = -1;
-                LastOpenedFromListId = Guid.Empty;
-                CustomThumbnailKey = null;
+                Id = Guid.Empty; // related to Library
+                FilePath = string.Empty; // file dependant
+                FileModifiedTime = DateTime.MinValue; // file dependant
+                FileCreationTime = DateTime.MinValue;  // file dependant
+                //AddedTime = DateTime.MinValue; // Keep or not? 
+                FileSize = -1;  // file dependant 
+                LastOpenedFromListId = Guid.Empty; // related to Library
+                CustomThumbnailKey = null; // related to Library
                 ComicInfoIsDirty = false;
-                // TODO: Also Ignore EnableProposed?
+                // Also Ignore EnableProposed?
 
                 XmlUtility.Store(outStream, this, compressed: false);
             }

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -2661,10 +2661,10 @@ namespace cYo.Projects.ComicRack.Engine
 			return XmlUtility.Load<ComicBook>(file, compressed: false);
 		}
 
-		public void SerializeFull(Stream stream, bool onlyPortable = false)
-		{
-            if (onlyPortable)
-            {
+        public override void Serialize(Stream outStream)
+        {
+			try
+			{
                 // Don't include these properties in the exported ComicBook.xml
                 Id = Guid.Empty;
                 FilePath = string.Empty;
@@ -2675,25 +2675,26 @@ namespace cYo.Projects.ComicRack.Engine
                 LastOpenedFromListId = Guid.Empty;
                 CustomThumbnailKey = null;
                 ComicInfoIsDirty = false;
-                // TODO: Also Ignore EnableProposed? 
-            }
+                // TODO: Also Ignore EnableProposed?
 
+                XmlUtility.Store(outStream, this, compressed: false);
+			}
+			catch (Exception)
+			{
+
+				throw;
+			}
+        }
+
+        public void SerializeFull(Stream stream)
+        {
             XmlUtility.Store(stream, this, compressed: false);
-		}
+        }
 
-		public void SerializeFull(string file)
+        public void SerializeFull(string file)
 		{
 			XmlUtility.Store(file, this, compressed: false);
 		}
-
-        public byte[] ToArrayFull(bool onlyPortable = false)
-        {
-            using (MemoryStream memoryStream = new MemoryStream())
-            {
-                SerializeFull(memoryStream, onlyPortable);
-                return memoryStream.ToArray();
-            }
-        }
 
         public static string FormatPages(int pages)
 		{

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -2381,12 +2381,12 @@ namespace cYo.Projects.ComicRack.Engine
                 {
                     // TODO: find a way that both are updated a the same time
 					bool updateComicBook = true; // TODO: connect setting
-                    success = infoStorage.StoreInfo(GetInfo());
+                    bool successBook = true; // Always true so that the final check passes even when updateComicBook is false, otherwise it will be set to the result of StoreBook
 
-                    // if option to save ComicBook is enabled update the ComicBook.xml
                     if (updateComicBook)
-                        success &= infoStorage.StoreBook(this.Clone<ComicBook>());
+                        successBook = infoStorage.StoreBook(this.Clone<ComicBook>());
 
+                    success = successBook & infoStorage.StoreInfo(GetInfo()); // Do last so that the NTFS Stream of ComicInfo is the one kept. 7-Zip replaces the whole file when updating ComicInfo, so if ComicBook is updated after it, its NTFS Stream will be lost.
                     FileInfoRetrieved = true;
                 }
                 finally

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -1725,7 +1725,7 @@ namespace cYo.Projects.ComicRack.Engine
             NewBooksChecked = true;
         }
 
-        public ComicBook()
+		public ComicBook()
         {
             VirtualTagsCollection.TagsRefresh += VirtualTagsCollection_TagsRefresh;
         }
@@ -2620,13 +2620,10 @@ namespace cYo.Projects.ComicRack.Engine
         {
             base.OnBookChanged(e);
             if (e.PropertyName == "FilePath" || e.PropertyName == "Number" || e.PropertyName == "EnableProposed")
-            {
                 compareNumber = null;
-            }
             else if (e.PropertyName == "AlternateNumber")
-            {
                 compareAlternateNumber = null;
-            }
+
             ClearVirtualTagsCache();
         }
 
@@ -2933,7 +2930,18 @@ namespace cYo.Projects.ComicRack.Engine
             return GetWritableStringProperties().ToDictionary((string s) => tr[s].PascalToSpaced());
         }
 
-        public static bool MapPropertyName(string propName, out string newName, ComicValueType cvt)
+		public static IEnumerable<PropertyInfo> GetXmlWritableProperties(Type type)
+		{
+			return type
+				.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+				.Where(p =>
+					p.CanWrite &&
+					p.GetSetMethod() != null &&
+					!p.IsDefined(typeof(XmlIgnoreAttribute), inherit: false)
+				);
+		}
+
+		public static bool MapPropertyName(string propName, out string newName, ComicValueType cvt)
         {
             string text = propName.ToLower();
             if (text == "cover" || text == "rating")

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -1725,7 +1725,7 @@ namespace cYo.Projects.ComicRack.Engine
             NewBooksChecked = true;
         }
 
-		public ComicBook()
+        public ComicBook()
         {
             VirtualTagsCollection.TagsRefresh += VirtualTagsCollection_TagsRefresh;
         }
@@ -2391,9 +2391,9 @@ namespace cYo.Projects.ComicRack.Engine
 
                 try
                 {
-					bool updateComicBook = settings.UpdateComicBookFiles; // Only update if enabled in the Settings
+                    bool updateComicBook = settings.UpdateComicBookFiles; // Only update if enabled in the Settings
                     ComicInfo info = updateComicBook ? this : GetInfo();
-                    success = infoStorage.StoreInfo(info); 
+                    success = infoStorage.StoreInfo(info);
                     FileInfoRetrieved = true;
                 }
                 finally
@@ -2654,10 +2654,14 @@ namespace cYo.Projects.ComicRack.Engine
             return info;
         }
 
-        public override bool IsSameContent(ComicInfo ci, bool withPages = true)
+        public override bool IsSameContent(ComicInfo ci, bool withPages = true, bool onlyComicInfo = true)
         {
+            // Used for SyncProvider, we don't want to match all properties for this
+            if (onlyComicInfo)
+                return base.IsSameContent(ci, withPages);
+
             ComicBook cb = ci as ComicBook;
-            // The commented poperties are not included in the comparison as they are determined by the file and should not be embeded in the ComicBook.xml, so they should not be compared when comparing the content of two ComicBook objects, as they can differ even if the content is the same
+            // The commented properties are not included in the comparison as they are determined by the file and should not be embeded in the ComicBook.xml, so they should not be compared when comparing the content of two ComicBook objects, as they can differ even if the content is the same
             return cb != null
                 && base.IsSameContent(cb, withPages)
                 //&& Id == cb.Id
@@ -2680,7 +2684,17 @@ namespace cYo.Projects.ComicRack.Engine
                 //&& fileLocation == cb.FileLocation
                 //&& customThumbnailKey == cb.CustomThumbnailKey
                 //&& LastOpenedFromListId == cb.LastOpenedFromListId
-                && CustomValuesStore == cb.CustomValuesStore;
+                && CustomValuesStore == cb.CustomValuesStore
+                && BookStore == cb.BookStore
+                && BookPrice == cb.BookPrice
+                && ISBN == cb.ISBN
+                && BookAge == cb.BookAge
+                && BookCondition == cb.BookCondition
+                && BookOwner == cb.BookOwner
+                && BookLocation == cb.BookLocation
+                && BookCondition == cb.BookCondition
+                && BookCollectionStatus == cb.BookCollectionStatus
+                && BookNotes == cb.BookNotes;
         }
 
         public static ComicBook DeserializeFull(Stream stream)
@@ -2704,7 +2718,7 @@ namespace cYo.Projects.ComicRack.Engine
                 cb.FilePath = string.Empty; // file dependant
                 cb.FileModifiedTime = DateTime.MinValue; // file dependant
                 cb.FileCreationTime = DateTime.MinValue;  // file dependant
-                // cb.AddedTime = DateTime.MinValue; // Keep or not? 
+                                                          // cb.AddedTime = DateTime.MinValue; // Keep or not? 
                 cb.FileSize = -1;  // file dependant 
                 cb.LastOpenedFromListId = Guid.Empty; // related to Library
                 cb.CustomThumbnailKey = null; // related to Library
@@ -2713,7 +2727,7 @@ namespace cYo.Projects.ComicRack.Engine
                 cb.FileIsMissing = false; // file dependant
                 cb.ExtraSyncInformation = null; // related to sync, probably always null anyway
                 cb.NewPages = 0; // related to dynamic page count, probably should not be included
-                // cb.EnableProposed = true // Also Ignore EnableProposed?
+                                 // cb.EnableProposed = true // Also Ignore EnableProposed?
 
                 XmlUtility.Store(outStream, cb, compressed: false);
             }
@@ -2930,18 +2944,18 @@ namespace cYo.Projects.ComicRack.Engine
             return GetWritableStringProperties().ToDictionary((string s) => tr[s].PascalToSpaced());
         }
 
-		public static IEnumerable<PropertyInfo> GetXmlWritableProperties(Type type)
-		{
-			return type
-				.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-				.Where(p =>
-					p.CanWrite &&
-					p.GetSetMethod() != null &&
-					!p.IsDefined(typeof(XmlIgnoreAttribute), inherit: false)
-				);
-		}
+        public static IEnumerable<PropertyInfo> GetXmlWritableProperties(Type type)
+        {
+            return type
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(p =>
+                    p.CanWrite &&
+                    p.GetSetMethod() != null &&
+                    !p.IsDefined(typeof(XmlIgnoreAttribute), inherit: false)
+                );
+        }
 
-		public static bool MapPropertyName(string propName, out string newName, ComicValueType cvt)
+        public static bool MapPropertyName(string propName, out string newName, ComicValueType cvt)
         {
             string text = propName.ToLower();
             if (text == "cover" || text == "rating")

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -2406,7 +2406,7 @@ namespace cYo.Projects.ComicRack.Engine
 			}
 			DateTime d = FileModifiedTime;
 			long num = FileSize;
-			RefreshFileProperties();
+			RefreshFileProperties(); // Sets FileSize / Timestamps
 			if (FileIsMissing)
 			{
 				return;
@@ -2442,7 +2442,21 @@ namespace cYo.Projects.ComicRack.Engine
 				bool forceRefreshInfo = options.HasFlag(RefreshInfoOptions.ForceRefresh);
 				if (forceRefreshInfo || !ComicInfoIsDirty)
 				{
-					SetInfo(infoStorage.LoadInfo((dateIsModified || !FileInfoRetrieved) ? InfoLoadingMethod.Complete : InfoLoadingMethod.Fast), !forceRefreshInfo);
+                    InfoLoadingMethod method = (dateIsModified || !FileInfoRetrieved) ? InfoLoadingMethod.Complete : InfoLoadingMethod.Fast;
+                    ComicInfo ci = infoStorage.LoadInfo(method); // Read ComicInfo.xml
+                    SetInfo(ci, !forceRefreshInfo);
+
+                    bool preferComicBook = true; // TODO: connect to a setting
+                    if (preferComicBook)
+                    {
+						ComicBook cb = infoStorage.LoadBook(method); // Read ComicBook.xml
+						if (cb != null)
+						{
+							cb.SetInfo(ci, onlyUpdateEmpty: false); // Replace ComicBook properties with the ComicInfo ones. In case they differ, info should always have the most up to date information
+							SetBook(cb);  // Copy all properties from the file, not only the ComicInfo ones
+                        }
+                    }
+
 					if (forceRefreshInfo)
 						ComicInfoIsDirty = false;
 				}
@@ -2609,6 +2623,17 @@ namespace cYo.Projects.ComicRack.Engine
 			LastPageRead = Math.Min(base.PageCount - 1, LastPageRead);
 			CurrentPage = Math.Min(base.PageCount - 1, CurrentPage);
 		}
+
+		public void SetBook(ComicBook cb)
+		{
+            // Sets these so they are kept and not overwritten by CopyFrom, they are determined by the file and should not be embeded in the ComicBook.xml
+            if (!cb.LastOpenedFromListIdSpecified) cb.LastOpenedFromListId = LastOpenedFromListId; // Keep the same ID, unless specified
+            cb.FilePath = FilePath; // Keep the same file path
+            cb.FileSize = FileSize; // Keep the same file size
+            cb.FileModifiedTime = FileModifiedTime; // Keep the same modified time
+            cb.FileCreationTime = FileCreationTime; // Keep the same creation time
+            CopyFrom(cb);
+        }
 
 		protected override ComicPageInfo OnNewComicPageAdded(ComicPageInfo info)
 		{

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -31,2424 +31,2424 @@ using SharpCompress.Common;
 namespace cYo.Projects.ComicRack.Engine
 {
     [Serializable]
-	[ComVisible(true)]
-	public class ComicBook : ComicInfo, IImageKeyProvider, ICloneable
-	{
-		private class ComicTextNumberFloat : TextNumberFloat
-		{
-			public ComicTextNumberFloat(string text)
-				: base(text)
-			{
-			}
+    [ComVisible(true)]
+    public class ComicBook : ComicInfo, IImageKeyProvider, ICloneable
+    {
+        private class ComicTextNumberFloat : TextNumberFloat
+        {
+            public ComicTextNumberFloat(string text)
+                : base(text)
+            {
+            }
 
-			protected override void OnParseText(string s)
-			{
-				if (s == "1/2")
-				{
-					base.Number = 0.5f;
-				}
-				else
-				{
-					base.OnParseText(s);
-				}
-			}
-		}
+            protected override void OnParseText(string s)
+            {
+                if (s == "1/2")
+                {
+                    base.Number = 0.5f;
+                }
+                else
+                {
+                    base.OnParseText(s);
+                }
+            }
+        }
 
-		public class ParseFilePathEventArgs : EventArgs
-		{
-			private readonly string path;
+        public class ParseFilePathEventArgs : EventArgs
+        {
+            private readonly string path;
 
-			private readonly ComicNameInfo nameInfo;
+            private readonly ComicNameInfo nameInfo;
 
-			public string Path => path;
+            public string Path => path;
 
-			public ComicNameInfo NameInfo => nameInfo;
+            public ComicNameInfo NameInfo => nameInfo;
 
-			public ParseFilePathEventArgs(string path)
-			{
-				this.path = path;
-				nameInfo = ComicNameInfo.FromFilePath(path);
-			}
-		}
+            public ParseFilePathEventArgs(string path)
+            {
+                this.path = path;
+                nameInfo = ComicNameInfo.FromFilePath(path);
+            }
+        }
 
-		public const int ReadPercentageAsRead = 95;
+        public const int ReadPercentageAsRead = 95;
 
-		public const string ClipboardFormat = "ComicBook";
+        public const string ClipboardFormat = "ComicBook";
 
-		public const string DefaultCaptionFormat = "[{format} ][{series}][ {volume}][ #{number}][ - {title}][ ({year}[/{month}[/{day}]])]";
+        public const string DefaultCaptionFormat = "[{format} ][{series}][ {volume}][ #{number}][ - {title}][ ({year}[/{month}[/{day}]])]";
 
-		public const string DefaultAlternateCaptionFormat = "[{alternateseries}][ #{alternatenumber}]";
+        public const string DefaultAlternateCaptionFormat = "[{alternateseries}][ #{alternatenumber}]";
 
-		public const string DefaultComicExportFileNameFormat = "[{format} ][{series}][ {volume}][ #{number}][ ({year}[/{month}])]";
+        public const string DefaultComicExportFileNameFormat = "[{format} ][{series}][ {volume}][ #{number}][ ({year}[/{month}])]";
 
-		public static readonly Equality<ComicBook> GuidEquality;
+        public static readonly Equality<ComicBook> GuidEquality;
 
-		public static bool EnableGroupNameCompression;
+        public static bool EnableGroupNameCompression;
 
-		private static TR tr;
+        private static TR tr;
 
-		private static readonly Lazy<string> unkownText;
+        private static readonly Lazy<string> unkownText;
 
-		private static readonly Lazy<string> pagesText;
+        private static readonly Lazy<string> pagesText;
 
-		private static readonly Lazy<string> lastTimeOpenedAtText;
+        private static readonly Lazy<string> lastTimeOpenedAtText;
 
-		private static readonly Lazy<string> readingAtPageText;
+        private static readonly Lazy<string> readingAtPageText;
 
-		private static readonly Lazy<string> lastPageReadIsText;
+        private static readonly Lazy<string> lastPageReadIsText;
 
-		private static readonly Lazy<string> noneText;
+        private static readonly Lazy<string> noneText;
 
-		private static readonly Lazy<string> notFoundText;
+        private static readonly Lazy<string> notFoundText;
 
-		private static readonly Lazy<string> neverText;
+        private static readonly Lazy<string> neverText;
 
-		private static readonly Lazy<string> volumeFormat;
+        private static readonly Lazy<string> volumeFormat;
 
-		private static readonly Lazy<string> ofText;
+        private static readonly Lazy<string> ofText;
 
-		[NonSerialized]
-		private volatile ComicBookContainer container;
+        [NonSerialized]
+        private volatile ComicBookContainer container;
 
-		private Guid id = Guid.NewGuid();
+        private Guid id = Guid.NewGuid();
 
-		private DateTime addedTime = DateTime.MinValue;
+        private DateTime addedTime = DateTime.MinValue;
 
-		private DateTime releasedTime = DateTime.MinValue;
+        private DateTime releasedTime = DateTime.MinValue;
 
-		private DateTime openedTime = DateTime.MinValue;
+        private DateTime openedTime = DateTime.MinValue;
 
-		private volatile int openCount;
+        private volatile int openCount;
 
-		private volatile int currentPage;
+        private volatile int currentPage;
 
-		private volatile int lastPage;
+        private volatile int lastPage;
 
-		private float rating;
+        private float rating;
 
-		private BitmapAdjustment colorAdjustment = BitmapAdjustment.Empty;
+        private BitmapAdjustment colorAdjustment = BitmapAdjustment.Empty;
 
-		private bool enableProposed = true;
+        private bool enableProposed = true;
 
-		private YesNo seriesComplete = YesNo.Unknown;
+        private YesNo seriesComplete = YesNo.Unknown;
 
-		private bool enableDynamicUpdate = true;
+        private bool enableDynamicUpdate = true;
 
-		private bool check = NewBooksChecked;
+        private bool check = NewBooksChecked;
 
-		[NonSerialized]
-		private volatile bool fileInfoRetrieved;
+        [NonSerialized]
+        private volatile bool fileInfoRetrieved;
 
-		private volatile bool comicInfoIsDirty;
+        private volatile bool comicInfoIsDirty;
 
-		private volatile string filePath = string.Empty;
+        private volatile string filePath = string.Empty;
 
-		private long fileSize = -1L;
+        private long fileSize = -1L;
 
-		private volatile bool fileIsMissing;
+        private volatile bool fileIsMissing;
 
-		private DateTime fileModifiedTime = DateTime.MinValue;
+        private DateTime fileModifiedTime = DateTime.MinValue;
 
-		private DateTime fileCreationTime = DateTime.MinValue;
+        private DateTime fileCreationTime = DateTime.MinValue;
 
-		private string customThumbnailKey;
+        private string customThumbnailKey;
 
-		private float bookPrice = -1f;
+        private float bookPrice = -1f;
 
-		private string bookAge = string.Empty;
+        private string bookAge = string.Empty;
 
-		private string bookCondition = string.Empty;
+        private string bookCondition = string.Empty;
 
-		private string bookStore = string.Empty;
+        private string bookStore = string.Empty;
 
-		private string bookOwner = string.Empty;
+        private string bookOwner = string.Empty;
 
-		private string bookCollectionStatus = string.Empty;
+        private string bookCollectionStatus = string.Empty;
 
-		private string bookNotes = string.Empty;
+        private string bookNotes = string.Empty;
 
-		private string bookLocation = string.Empty;
+        private string bookLocation = string.Empty;
 
-		private string isbn = string.Empty;
+        private string isbn = string.Empty;
 
-		private volatile string fileName;
+        private volatile string fileName;
 
-		private volatile string fileNameWithExtension;
+        private volatile string fileNameWithExtension;
 
-		private volatile string fileFormat;
+        private volatile string fileFormat;
 
-		private volatile string actualFileFormat;
+        private volatile string actualFileFormat;
 
-		private volatile string fileDirectory;
+        private volatile string fileDirectory;
 
-		private static readonly Calendar weekCalendar;
+        private static readonly Calendar weekCalendar;
 
-		private string fileLocation;
+        private string fileLocation;
 
-		private int newPages;
+        private int newPages;
 
-		private ComicNameInfo proposed;
+        private ComicNameInfo proposed;
 
-		[NonSerialized]
-		private TextNumberFloat compareNumber;
+        [NonSerialized]
+        private TextNumberFloat compareNumber;
 
-		[NonSerialized]
-		private TextNumberFloat compareAlternateNumber;
+        [NonSerialized]
+        private TextNumberFloat compareAlternateNumber;
 
-		private static readonly Dictionary<ComicBook, ExtraSyncInformation> syncInfo;
+        private static readonly Dictionary<ComicBook, ExtraSyncInformation> syncInfo;
 
-		private string customValuesStore = string.Empty;
+        private string customValuesStore = string.Empty;
 
-		private static HashSet<string> searchableProperties;
+        private static HashSet<string> searchableProperties;
 
-		private static readonly Regex rxField;
+        private static readonly Regex rxField;
 
-		private static Dictionary<string, CultureInfo> languages;
+        private static Dictionary<string, CultureInfo> languages;
 
-		public static readonly ComicBook Default;
+        public static readonly ComicBook Default;
 
-		private static readonly Dictionary<string, string> hasAsText;
+        private static readonly Dictionary<string, string> hasAsText;
 
-		private static readonly ImagePackage publisherIcons;
+        private static readonly ImagePackage publisherIcons;
 
-		private static readonly ImagePackage ageRatingIcons;
+        private static readonly ImagePackage ageRatingIcons;
 
-		private static readonly ImagePackage formatIcons;
+        private static readonly ImagePackage formatIcons;
 
-		private static readonly ImagePackage specialIcons;
+        private static readonly ImagePackage specialIcons;
 
-		public static TR TR
-		{
-			get
-			{
-				if (tr == null)
-				{
-					tr = TR.Load("ComicBook");
-				}
-				return tr;
-			}
-		}
+        public static TR TR
+        {
+            get
+            {
+                if (tr == null)
+                {
+                    tr = TR.Load("ComicBook");
+                }
+                return tr;
+            }
+        }
 
-		[XmlIgnore]
-		public ComicBookContainer Container
-		{
-			get
-			{
-				return container;
-			}
-			internal set
-			{
-				container = value;
-			}
-		}
+        [XmlIgnore]
+        public ComicBookContainer Container
+        {
+            get
+            {
+                return container;
+            }
+            internal set
+            {
+                container = value;
+            }
+        }
 
         public bool ShouldSerializeId() => Id != Guid.Empty; // Don't serialize the Id if it's empty
 
         [XmlAttribute]
-		public Guid Id
-		{
-			get
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					return id;
-				}
-			}
-			set
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					if (id == value)
-					{
-						return;
-					}
-					id = value;
-				}
-				FireBookChanged("Id");
-			}
-		}
+        public Guid Id
+        {
+            get
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    return id;
+                }
+            }
+            set
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    if (id == value)
+                    {
+                        return;
+                    }
+                    id = value;
+                }
+                FireBookChanged("Id");
+            }
+        }
 
-		[Browsable(true)]
-		[XmlElement("Added")]
-		[DefaultValue(typeof(DateTime), "01.01.0001")]
-		[ResetValue(1)]
-		public DateTime AddedTime
-		{
-			get
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					return addedTime;
-				}
-			}
-			set
-			{
-				SetProperty("AddedTime", ref addedTime, value, lockItem: true, !IsLinked);
-			}
-		}
+        [Browsable(true)]
+        [XmlElement("Added")]
+        [DefaultValue(typeof(DateTime), "01.01.0001")]
+        [ResetValue(1)]
+        public DateTime AddedTime
+        {
+            get
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    return addedTime;
+                }
+            }
+            set
+            {
+                SetProperty("AddedTime", ref addedTime, value, lockItem: true, !IsLinked);
+            }
+        }
 
-		[Browsable(true)]
-		[XmlElement("Released")]
-		[DefaultValue(typeof(DateTime), "01.01.0001")]
-		[ResetValue(1)]
-		public DateTime ReleasedTime
-		{
-			get
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					return releasedTime.DateOnly();
-				}
-			}
-			set
-			{
-				SetProperty("ReleasedTime", ref releasedTime, value, lockItem: true);
-			}
-		}
+        [Browsable(true)]
+        [XmlElement("Released")]
+        [DefaultValue(typeof(DateTime), "01.01.0001")]
+        [ResetValue(1)]
+        public DateTime ReleasedTime
+        {
+            get
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    return releasedTime.DateOnly();
+                }
+            }
+            set
+            {
+                SetProperty("ReleasedTime", ref releasedTime, value, lockItem: true);
+            }
+        }
 
-		[Browsable(true)]
-		[XmlElement("Opened")]
-		[DefaultValue(typeof(DateTime), "01.01.0001")]
-		[ResetValue(1)]
-		public DateTime OpenedTime
-		{
-			get
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					return openedTime;
-				}
-			}
-			set
-			{
-				SetProperty("OpenedTime", ref openedTime, value, lockItem: true, !IsLinked);
-			}
-		}
+        [Browsable(true)]
+        [XmlElement("Opened")]
+        [DefaultValue(typeof(DateTime), "01.01.0001")]
+        [ResetValue(1)]
+        public DateTime OpenedTime
+        {
+            get
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    return openedTime;
+                }
+            }
+            set
+            {
+                SetProperty("OpenedTime", ref openedTime, value, lockItem: true, !IsLinked);
+            }
+        }
 
-		[Browsable(true)]
-		[XmlElement("OpenCount")]
-		[DefaultValue(0)]
-		[ResetValue(1)]
-		public int OpenedCount
-		{
-			get
-			{
-				return openCount;
-			}
-			set
-			{
-				if (openCount != value)
-				{
-					openCount = value;
-					FireBookChanged("OpenedCount");
-				}
-			}
-		}
+        [Browsable(true)]
+        [XmlElement("OpenCount")]
+        [DefaultValue(0)]
+        [ResetValue(1)]
+        public int OpenedCount
+        {
+            get
+            {
+                return openCount;
+            }
+            set
+            {
+                if (openCount != value)
+                {
+                    openCount = value;
+                    FireBookChanged("OpenedCount");
+                }
+            }
+        }
 
-		[Browsable(true)]
-		[DefaultValue(0)]
-		[ResetValue(1)]
-		public int CurrentPage
-		{
-			get
-			{
-				return currentPage;
-			}
-			set
-			{
-				value = Math.Max(0, value);
-				if (currentPage != value)
-				{
-					currentPage = value;
-					FireBookChanged("CurrentPage");
-					if (currentPage > LastPageRead)
-					{
-						LastPageRead = value;
-					}
-				}
-			}
-		}
+        [Browsable(true)]
+        [DefaultValue(0)]
+        [ResetValue(1)]
+        public int CurrentPage
+        {
+            get
+            {
+                return currentPage;
+            }
+            set
+            {
+                value = Math.Max(0, value);
+                if (currentPage != value)
+                {
+                    currentPage = value;
+                    FireBookChanged("CurrentPage");
+                    if (currentPage > LastPageRead)
+                    {
+                        LastPageRead = value;
+                    }
+                }
+            }
+        }
 
-		[Browsable(true)]
-		[DefaultValue(0)]
-		[ResetValue(1)]
-		public int LastPageRead
-		{
-			get
-			{
-				return lastPage;
-			}
-			set
-			{
-				value = Math.Max(0, value);
-				if (lastPage != value)
-				{
-					lastPage = value;
-					FireBookChanged("LastPageRead");
-				}
-			}
-		}
+        [Browsable(true)]
+        [DefaultValue(0)]
+        [ResetValue(1)]
+        public int LastPageRead
+        {
+            get
+            {
+                return lastPage;
+            }
+            set
+            {
+                value = Math.Max(0, value);
+                if (lastPage != value)
+                {
+                    lastPage = value;
+                    FireBookChanged("LastPageRead");
+                }
+            }
+        }
 
-		[Browsable(true)]
-		[DefaultValue(0)]
-		[ResetValue(0)]
-		public float Rating
-		{
-			get
-			{
-				return rating;
-			}
-			set
-			{
-				SetProperty("Rating", ref rating, value.Clamp(0f, 5f));
-			}
-		}
+        [Browsable(true)]
+        [DefaultValue(0)]
+        [ResetValue(0)]
+        public float Rating
+        {
+            get
+            {
+                return rating;
+            }
+            set
+            {
+                SetProperty("Rating", ref rating, value.Clamp(0f, 5f));
+            }
+        }
 
-		[DefaultValue(typeof(BitmapAdjustment), "Empty")]
-		public BitmapAdjustment ColorAdjustment
-		{
-			get
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					return colorAdjustment;
-				}
-			}
-			set
-			{
-				BitmapAdjustment bitmapAdjustment;
-				using (ItemMonitor.Lock(this))
-				{
-					if (colorAdjustment == value)
-					{
-						return;
-					}
-					bitmapAdjustment = colorAdjustment;
-					colorAdjustment = value;
-				}
-				FireBookChanged("ColorAdjustment", bitmapAdjustment, colorAdjustment);
-			}
-		}
+        [DefaultValue(typeof(BitmapAdjustment), "Empty")]
+        public BitmapAdjustment ColorAdjustment
+        {
+            get
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    return colorAdjustment;
+                }
+            }
+            set
+            {
+                BitmapAdjustment bitmapAdjustment;
+                using (ItemMonitor.Lock(this))
+                {
+                    if (colorAdjustment == value)
+                    {
+                        return;
+                    }
+                    bitmapAdjustment = colorAdjustment;
+                    colorAdjustment = value;
+                }
+                FireBookChanged("ColorAdjustment", bitmapAdjustment, colorAdjustment);
+            }
+        }
 
-		public bool ColorAdjustmentSpecified => ColorAdjustment != BitmapAdjustment.Empty;
+        public bool ColorAdjustmentSpecified => ColorAdjustment != BitmapAdjustment.Empty;
 
-		[Browsable(true)]
-		[DefaultValue(true)]
-		[ResetValue(0)]
-		public bool EnableProposed
-		{
-			get
-			{
-				return enableProposed;
-			}
-			set
-			{
-				SetProperty("EnableProposed", ref enableProposed, value);
-			}
-		}
+        [Browsable(true)]
+        [DefaultValue(true)]
+        [ResetValue(0)]
+        public bool EnableProposed
+        {
+            get
+            {
+                return enableProposed;
+            }
+            set
+            {
+                SetProperty("EnableProposed", ref enableProposed, value);
+            }
+        }
 
-		[Browsable(true)]
-		[DefaultValue(YesNo.Unknown)]
-		[ResetValue(0)]
-		public YesNo SeriesComplete
-		{
-			get
-			{
-				return seriesComplete;
-			}
-			set
-			{
-				SetProperty("SeriesComplete", ref seriesComplete, value);
-			}
-		}
+        [Browsable(true)]
+        [DefaultValue(YesNo.Unknown)]
+        [ResetValue(0)]
+        public YesNo SeriesComplete
+        {
+            get
+            {
+                return seriesComplete;
+            }
+            set
+            {
+                SetProperty("SeriesComplete", ref seriesComplete, value);
+            }
+        }
 
-		[Browsable(true)]
-		[DefaultValue(true)]
-		[ResetValue(1)]
-		public bool EnableDynamicUpdate
-		{
-			get
-			{
-				return enableDynamicUpdate;
-			}
-			set
-			{
-				SetProperty("EnableDynamicUpdate", ref enableDynamicUpdate, value);
-			}
-		}
+        [Browsable(true)]
+        [DefaultValue(true)]
+        [ResetValue(1)]
+        public bool EnableDynamicUpdate
+        {
+            get
+            {
+                return enableDynamicUpdate;
+            }
+            set
+            {
+                SetProperty("EnableDynamicUpdate", ref enableDynamicUpdate, value);
+            }
+        }
 
-		public Guid LastOpenedFromListId
-		{
-			get;
-			set;
-		}
+        public Guid LastOpenedFromListId
+        {
+            get;
+            set;
+        }
 
-		public bool LastOpenedFromListIdSpecified => LastOpenedFromListId != Guid.Empty; // Know when the Id has been set to a non-empty value
+        public bool LastOpenedFromListIdSpecified => LastOpenedFromListId != Guid.Empty; // Know when the Id has been set to a non-empty value
 
         public bool ShouldSerializeLastOpenedFromListId() => LastOpenedFromListId != Guid.Empty; // Don't serialize the Id if it's empty
 
         [XmlAttribute]
-		[DefaultValue(true)]
-		public bool Checked
-		{
-			get
-			{
-				return check;
-			}
-			set
-			{
-				SetProperty("Checked", ref check, value);
-			}
-		}
+        [DefaultValue(true)]
+        public bool Checked
+        {
+            get
+            {
+                return check;
+            }
+            set
+            {
+                SetProperty("Checked", ref check, value);
+            }
+        }
 
-		[Browsable(true)]
-		[XmlIgnore]
-		public bool FileInfoRetrieved
-		{
-			get
-			{
-				return fileInfoRetrieved;
-			}
-			set
-			{
-				fileInfoRetrieved = value;
-			}
-		}
+        [Browsable(true)]
+        [XmlIgnore]
+        public bool FileInfoRetrieved
+        {
+            get
+            {
+                return fileInfoRetrieved;
+            }
+            set
+            {
+                fileInfoRetrieved = value;
+            }
+        }
 
-		[Browsable(true)]
-		[DefaultValue(false)]
-		public bool ComicInfoIsDirty
-		{
-			get
-			{
-				return comicInfoIsDirty;
-			}
-			set
-			{
-				if (comicInfoIsDirty != value)
-				{
-					comicInfoIsDirty = value;
-					FireBookChanged("ComicInfoIsDirty");
-				}
-			}
-		}
+        [Browsable(true)]
+        [DefaultValue(false)]
+        public bool ComicInfoIsDirty
+        {
+            get
+            {
+                return comicInfoIsDirty;
+            }
+            set
+            {
+                if (comicInfoIsDirty != value)
+                {
+                    comicInfoIsDirty = value;
+                    FireBookChanged("ComicInfoIsDirty");
+                }
+            }
+        }
 
-		[Browsable(true)]
-		[XmlAttribute("File")]
-		[DefaultValue("")]
-		public string FilePath
-		{
-			get
-			{
-				return filePath;
-			}
-			set
-			{
-				if (value == null)
-				{
-					throw new ArgumentNullException();
-				}
-				if (!(filePath == value))
-				{
-					string text = FilePath;
-					filePath = value;
-					fileName = fileNameWithExtension = actualFileFormat = fileFormat = fileDirectory = null;
-					proposed = null;
-					FireBookChanged("FilePath", text, filePath);
-					if (!string.IsNullOrEmpty(text))
-					{
-						OnFileRenamed(new ComicBookFileRenameEventArgs(text, filePath));
-					}
-				}
-			}
-		}
+        [Browsable(true)]
+        [XmlAttribute("File")]
+        [DefaultValue("")]
+        public string FilePath
+        {
+            get
+            {
+                return filePath;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException();
+                }
+                if (!(filePath == value))
+                {
+                    string text = FilePath;
+                    filePath = value;
+                    fileName = fileNameWithExtension = actualFileFormat = fileFormat = fileDirectory = null;
+                    proposed = null;
+                    FireBookChanged("FilePath", text, filePath);
+                    if (!string.IsNullOrEmpty(text))
+                    {
+                        OnFileRenamed(new ComicBookFileRenameEventArgs(text, filePath));
+                    }
+                }
+            }
+        }
 
-		[Browsable(true)]
-		[DefaultValue(-1)]
-		public long FileSize
-		{
-			get
-			{
-				return Interlocked.Read(ref fileSize);
-			}
-			set
-			{
-				if (Interlocked.Read(ref fileSize) != value)
-				{
-					Interlocked.Exchange(ref fileSize, value);
-					FireBookChanged("FileSize");
-				}
-			}
-		}
+        [Browsable(true)]
+        [DefaultValue(-1)]
+        public long FileSize
+        {
+            get
+            {
+                return Interlocked.Read(ref fileSize);
+            }
+            set
+            {
+                if (Interlocked.Read(ref fileSize) != value)
+                {
+                    Interlocked.Exchange(ref fileSize, value);
+                    FireBookChanged("FileSize");
+                }
+            }
+        }
 
-		[Browsable(true)]
-		[XmlElement("Missing")]
-		[DefaultValue(false)]
-		public bool FileIsMissing
-		{
-			get
-			{
-				return fileIsMissing;
-			}
-			set
-			{
-				if (fileIsMissing != value)
-				{
-					fileIsMissing = value;
-					FireBookChanged("FileIsMissing");
-				}
-			}
-		}
+        [Browsable(true)]
+        [XmlElement("Missing")]
+        [DefaultValue(false)]
+        public bool FileIsMissing
+        {
+            get
+            {
+                return fileIsMissing;
+            }
+            set
+            {
+                if (fileIsMissing != value)
+                {
+                    fileIsMissing = value;
+                    FireBookChanged("FileIsMissing");
+                }
+            }
+        }
 
-		[Browsable(true)]
-		[DefaultValue(typeof(DateTime), "01.01.0001")]
-		public DateTime FileModifiedTime
-		{
-			get
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					return fileModifiedTime;
-				}
-			}
-			set
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					if (fileModifiedTime == value)
-					{
-						return;
-					}
-					fileModifiedTime = value;
-				}
-				FireBookChanged("FileModifiedTime");
-			}
-		}
+        [Browsable(true)]
+        [DefaultValue(typeof(DateTime), "01.01.0001")]
+        public DateTime FileModifiedTime
+        {
+            get
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    return fileModifiedTime;
+                }
+            }
+            set
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    if (fileModifiedTime == value)
+                    {
+                        return;
+                    }
+                    fileModifiedTime = value;
+                }
+                FireBookChanged("FileModifiedTime");
+            }
+        }
 
-		[Browsable(true)]
-		[DefaultValue(typeof(DateTime), "01.01.0001")]
-		public DateTime FileCreationTime
-		{
-			get
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					return fileCreationTime;
-				}
-			}
-			set
-			{
-				using (ItemMonitor.Lock(this))
-				{
-					if (fileCreationTime == value)
-					{
-						return;
-					}
-					fileCreationTime = value;
-				}
-				FireBookChanged("FileCreationTime");
-			}
-		}
+        [Browsable(true)]
+        [DefaultValue(typeof(DateTime), "01.01.0001")]
+        public DateTime FileCreationTime
+        {
+            get
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    return fileCreationTime;
+                }
+            }
+            set
+            {
+                using (ItemMonitor.Lock(this))
+                {
+                    if (fileCreationTime == value)
+                    {
+                        return;
+                    }
+                    fileCreationTime = value;
+                }
+                FireBookChanged("FileCreationTime");
+            }
+        }
 
         [DefaultValue(null)]
-		[ResetValue(0)]
-		public string CustomThumbnailKey
-		{
-			get
-			{
-				return customThumbnailKey;
-			}
-			set
-			{
-				if (!(customThumbnailKey == value))
-				{
-					customThumbnailKey = value;
-					FireBookChanged("CustomThumbnailKey");
-				}
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue(-1f)]
-		[ResetValue(0)]
-		public float BookPrice
-		{
-			get
-			{
-				return bookPrice;
-			}
-			set
-			{
-				SetProperty("BookPrice", ref bookPrice, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string BookAge
-		{
-			get
-			{
-				return bookAge;
-			}
-			set
-			{
-				SetProperty("BookAge", ref bookAge, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string BookCondition
-		{
-			get
-			{
-				return bookCondition;
-			}
-			set
-			{
-				SetProperty("BookCondition", ref bookCondition, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string BookStore
-		{
-			get
-			{
-				return bookStore;
-			}
-			set
-			{
-				SetProperty("BookStore", ref bookStore, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string BookOwner
-		{
-			get
-			{
-				return bookOwner;
-			}
-			set
-			{
-				SetProperty("BookOwner", ref bookOwner, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string BookCollectionStatus
-		{
-			get
-			{
-				return bookCollectionStatus;
-			}
-			set
-			{
-				SetProperty("BookCollectionStatus", ref bookCollectionStatus, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string BookNotes
-		{
-			get
-			{
-				return bookNotes;
-			}
-			set
-			{
-				SetProperty("BookNotes", ref bookNotes, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string BookLocation
-		{
-			get
-			{
-				return bookLocation;
-			}
-			set
-			{
-				SetProperty("BookLocation", ref bookLocation, value);
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string ISBN
-		{
-			get
-			{
-				return isbn;
-			}
-			set
-			{
-				SetProperty("ISBN", ref isbn, value);
-			}
-		}
-
-		[XmlIgnore]
-		public string PagesAsTextSimple
-		{
-			get
-			{
-				if (base.PageCount > 0)
-				{
-					return base.PageCount.ToString();
-				}
-				return "-";
-			}
-			set
-			{
-				if (int.TryParse(value, out var result) && result >= 0)
-				{
-					base.PageCount = result;
-				}
-			}
-		}
-
-		[Browsable(true)]
-		public string FileName
-		{
-			get
-			{
-				if (fileName != null)
-				{
-					return fileName;
-				}
-				try
-				{
-					fileName = Path.GetFileNameWithoutExtension(filePath);
-				}
-				catch (Exception)
-				{
-					fileName = string.Empty;
-				}
-				return fileName;
-			}
-		}
-
-		[Browsable(true)]
-		public string FileNameWithExtension
-		{
-			get
-			{
-				if (fileNameWithExtension != null)
-				{
-					return fileNameWithExtension;
-				}
-				try
-				{
-					fileNameWithExtension = Path.GetFileName(filePath);
-				}
-				catch (Exception)
-				{
-					fileNameWithExtension = string.Empty;
-				}
-				return fileNameWithExtension;
-			}
-		}
-
-		[Browsable(true)]
-		public string FileFormat
-		{
-			get
-			{
-				if (fileFormat != null)
-				{
-					return fileFormat;
-				}
-				try
-				{
-					fileFormat = Providers.Readers.GetSourceFormatName(filePath);
-				}
-				catch (Exception)
-				{
-					fileFormat = string.Empty;
-				}
-				return fileFormat;
-			}
-		}
-
-		[Browsable(true)]
-		public string ActualFileFormat
-		{
-			get
-			{
-				if (actualFileFormat != null)
-				{
-					return actualFileFormat;
-				}
-				try
-				{
-					actualFileFormat = Providers.Readers.GetSourceFormatName(filePath, true);
-				}
-				catch (Exception)
-				{
-					actualFileFormat = string.Empty;
-				}
-				return actualFileFormat;
-			}
-		}
-
-		[Browsable(true)]
-		public string FileDirectory
-		{
-			get
-			{
-				if (fileDirectory != null)
-				{
-					return fileDirectory;
-				}
-				try
-				{
-					fileDirectory = Path.GetDirectoryName(filePath);
-				}
-				catch (Exception)
-				{
-					fileDirectory = string.Empty;
-				}
-				return fileDirectory;
-			}
-		}
-
-		[Browsable(true)]
-		public bool IsValidComicBook
-		{
-			get
-			{
-				if (!string.IsNullOrEmpty(FilePath))
-				{
-					return Providers.Readers.GetSourceProviderType(FilePath) != null;
-				}
-				return false;
-			}
-		}
-
-		//TODO: check to update Caption to a Virtual Tag
-		[Browsable(true)]
-		public string Caption => GetFullTitle(EngineConfiguration.Default.ComicCaptionFormat);
-
-		[Browsable(true)]
-		public string CaptionWithoutTitle => GetFullTitle(EngineConfiguration.Default.ComicCaptionFormat, "title");
-
-		[Browsable(true)]
-		public string CaptionWithoutFormat => GetFullTitle(EngineConfiguration.Default.ComicCaptionFormat, "format");
-
-		[Browsable(true)]
-		public string AlternateCaption => GetFullTitle(DefaultAlternateCaptionFormat);
-
-		public string TargetFilename => GetFullTitle(EngineConfiguration.Default.ComicExportFileNameFormat);
-
-		[Browsable(true)]
-		public int ReadPercentage
-		{
-			get
-			{
-				if (base.PageCount <= 0 || LastPageRead <= 0)
-				{
-					return 0;
-				}
-				return ((LastPageRead + 1) * 100 / base.PageCount).Clamp(1, 100);
-			}
-		}
-
-		public string ReadPercentageAsText => $"{ReadPercentage}%";
-
-		[Browsable(true)]
-		public bool HasBeenOpened => OpenedTime != DateTime.MinValue;
-
-		[Browsable(true)]
-		[XmlIgnore]
-		public bool HasBeenRead
-		{
-			get
-			{
-				return ReadPercentage >= ReadPercentageAsRead;
-			}
-			set
-			{
-				if (value)
-				{
-					MarkAsRead();
-				}
-				else
-				{
-					MarkAsNotRead();
-				}
-			}
-		}
-
-		public string PagesAsText => FormatPages(base.PageCount);
-
-		public string OpenedCountAsText => OpenedCount.ToString();
-
-		public string InfoText
-		{
-			get
-			{
-				StringBuilder stringBuilder = new StringBuilder();
-				stringBuilder.AppendFormat("{0}\n", FileName);
-				stringBuilder.AppendFormat("{0} ({1})\n\n", FileSizeAsText, PagesAsText);
-				stringBuilder.AppendFormat("{0}\n", ActualFileFormat);
-				stringBuilder.AppendFormat("{0}\n\n", FileDirectory);
-				stringBuilder.Append(StringUtility.Format(lastTimeOpenedAtText.Value, OpenedTimeAsText));
-				stringBuilder.AppendLine();
-				stringBuilder.Append(StringUtility.Format(readingAtPageText.Value, CurrentPage + 1));
-				stringBuilder.AppendLine();
-				stringBuilder.Append(StringUtility.Format(lastPageReadIsText.Value, LastPageRead + 1));
-				return stringBuilder.ToString();
-			}
-		}
-
-		public string NumberAsText => FormatNumber(base.Number, ShadowCount);
-
-		[Browsable(true)]
-		public string NumberOnly => ShadowNumber;
-
-		public string AlternateNumberAsText => FormatNumber(base.AlternateNumber, base.AlternateCount);
-
-		public string VolumeAsText => FormatVolume(base.Volume);
-
-		[Browsable(true)]
-		public string VolumeOnly
-		{
-			get
-			{
-				if (base.Volume >= 0)
-				{
-					return base.Volume.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public string LastPageReadAsText
-		{
-			get
-			{
-				if (LastPageRead > 0)
-				{
-					return (LastPageRead + 1).ToString();
-				}
-				return noneText.Value;
-			}
-		}
-
-		public string LanguageAsText
-		{
-			get
-			{
-				if (!string.IsNullOrEmpty(base.LanguageISO))
-				{
-					return GetLanguageName(base.LanguageISO);
-				}
-				return string.Empty;
-			}
-		}
-
-		public string ArtistInfo
-		{
-			get
-			{
-				HashSet<string> uniqueNames = new HashSet<string>();
-				StringBuilder stringBuilder = new StringBuilder();
-				AppendUniqueName(stringBuilder, "/", base.Writer, uniqueNames);
-				AppendUniqueName(stringBuilder, "/", base.Penciller, uniqueNames);
-				AppendUniqueName(stringBuilder, "/", base.Inker, uniqueNames);
-				AppendUniqueName(stringBuilder, "/", base.Colorist, uniqueNames);
-				AppendUniqueName(stringBuilder, "/", base.Letterer, uniqueNames);
-				AppendUniqueName(stringBuilder, "/", base.CoverArtist, uniqueNames);
-				AppendUniqueName(stringBuilder, "/", base.Translator, uniqueNames);
-
-				return stringBuilder.ToString();
-			}
-		}
-
-		public string YearAsText => FormatYear(base.Year);
-
-		public string MonthAsText
-		{
-			get
-			{
-				if (base.Month != -1)
-				{
-					return base.Month.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public string DayAsText
-		{
-			get
-			{
-				if (base.Day != -1)
-				{
-					return base.Day.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public int Week
-		{
-			get
-			{
-				DateTime published = Published;
-				if (published == DateTime.MinValue)
-				{
-					return -1;
-				}
-				return weekCalendar.GetWeekOfYear(published, CalendarWeekRule.FirstDay, DayOfWeek.Monday);
-			}
-		}
-
-		public string WeekAsText
-		{
-			get
-			{
-				int week = Week;
-				if (week != -1)
-				{
-					return week.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public string PublishedRegional => FormatDate(Published, ComicDateFormat.Short, toLocal: false, unkownText.Value);
-
-		public string PublishedAsText
-		{
-			get
-			{
-				string shadowYearAsText = ShadowYearAsText;
-				string text = string.Empty;
-				if (!string.IsNullOrEmpty(shadowYearAsText))
-				{
-					string monthAsText = MonthAsText;
-					if (!string.IsNullOrEmpty(monthAsText))
-					{
-						string dayAsText = DayAsText;
-						if (!string.IsNullOrEmpty(dayAsText))
-						{
-							text = text + dayAsText + "/";
-						}
-						text = text + monthAsText + "/";
-					}
-					text += shadowYearAsText;
-				}
-				return text;
-			}
-		}
-
-		public DateTime Published
-		{
-			get
-			{
-				if (ShadowYear <= 0)
-				{
-					return DateTime.MinValue;
-				}
-				int year = ShadowYear.Clamp(1, 10000);
-				int month = base.Month.Clamp(1, 12);
-				int day = base.Day.Clamp(1, DateTime.DaysInMonth(year, month));
-				return new DateTime(year, month, day);
-			}
-		}
-
-		public string CountAsText
-		{
-			get
-			{
-				if (base.Count != -1)
-				{
-					return base.Count.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public string NewPagesAsText
-		{
-			get
-			{
-				if (!IsDynamicSource || NewPages <= 0)
-				{
-					return string.Empty;
-				}
-				return NewPages.ToString();
-			}
-		}
-
-		public string AlternateCountAsText
-		{
-			get
-			{
-				if (base.AlternateCount != -1)
-				{
-					return base.AlternateCount.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public string RatingAsText => FormatRating(Rating);
-
-		public string CommunityRatingAsText => FormatRating(base.CommunityRating);
-
-		public string CoverAsText => ComicInfo.GetYesNoAsText((base.FrontCoverCount != 0) ? YesNo.Yes : YesNo.No);
-
-		public string FileSizeAsText
-		{
-			get
-			{
-				long num = FileSize;
-				if (num == -1)
-				{
-					return notFoundText.Value;
-				}
-				return string.Format(new FileLengthFormat(), "{0}", new object[1]
-				{
-					num
-				});
-			}
-		}
-
-		public string MangaAsText => ComicInfo.GetYesNoAsText(base.Manga);
-
-		public string SeriesCompleteAsText => ComicInfo.GetYesNoAsText(SeriesComplete);
-
-		public string EnableProposedAsText => ComicInfo.GetYesNoAsText(EnableProposed ? YesNo.Yes : YesNo.No);
-
-		public string HasBeenReadAsText => ComicInfo.GetYesNoAsText(HasBeenRead ? YesNo.Yes : YesNo.No);
-
-		public string IsLinkedAsText => ComicInfo.GetYesNoAsText(IsLinked);
-
-		public string BlackAndWhiteAsText => ComicInfo.GetYesNoAsText(base.BlackAndWhite);
-
-		public string BookmarkCountAsText
-		{
-			get
-			{
-				if (base.BookmarkCount > 0)
-				{
-					return base.BookmarkCount.ToString();
-				}
-				return noneText.Value;
-			}
-		}
-
-		public ComicPageInfo CurrentPageInfo => GetPage(CurrentPage);
-
-		public string FileLocation
-		{
-			get
-			{
-				if (!string.IsNullOrEmpty(fileLocation))
-				{
-					return fileLocation;
-				}
-				return FilePath;
-			}
-		}
-
-		public string DisplayFileLocation
-		{
-			get
-			{
-				if (!IsInContainer)
-				{
-					return FilePath;
-				}
-				return Caption;
-			}
-		}
-
-		public int Status
-		{
-			get
-			{
-				int num = 0;
-				if (FileIsMissing && IsLinked)
-				{
-					num |= 1;
-				}
-				if (ComicInfoIsDirty)
-				{
-					num |= 2;
-				}
-				return num;
-			}
-		}
-
-		[Browsable(true)]
-		public bool IsLinked => !string.IsNullOrEmpty(filePath);
-
-		[XmlIgnore]
-		public string BookPriceAsText
-		{
-			get
-			{
-				if (!(bookPrice < 0f))
-				{
-					return $"{bookPrice:0.00}";
-				}
-				return unkownText.Value;
-			}
-			set
-			{
-				if (float.TryParse(value, out var result))
-				{
-					BookPrice = result;
-				}
-				else
-				{
-					BookPrice = -1f;
-				}
-			}
-		}
-
-		public string OpenedTimeAsText => FormatDate(OpenedTime);
-
-		public string AddedTimeAsText => FormatDate(AddedTime, ComicDateFormat.Long, toLocal: false, unkownText.Value);
-
-		public string ReleasedTimeAsText => FormatDate(ReleasedTime, ComicDateFormat.Short, toLocal: false, unkownText.Value);
-
-		public string FileCreationTimeAsText => FormatFileDate(FileCreationTime);
-
-		public string FileModifiedTimeAsText => FormatFileDate(FileModifiedTime);
-
-		public bool IsInContainer => container != null;
-
-		public ComicsEditModes EditMode
-		{
-			get
-			{
-				if (!IsInContainer)
-				{
-					return ComicsEditModes.Default;
-				}
-				return Container.EditMode;
-			}
-		}
-
-		[DefaultValue(false)]
-		[XmlAttribute]
-		public bool IsDynamicSource
-		{
-			get;
-			set;
-		}
-
-		[DefaultValue(0)]
-		public int NewPages
-		{
-			get
-			{
-				return newPages;
-			}
-			set
-			{
-				SetProperty("NewPages", ref newPages, value);
-			}
-		}
-
-		public string ProposedSeries
-		{
-			get
-			{
-				UpdateProposed();
-				return proposed.Series;
-			}
-		}
-
-		public string ProposedTitle
-		{
-			get
-			{
-				UpdateProposed();
-				return proposed.Title;
-			}
-		}
-
-		public string ProposedFormat
-		{
-			get
-			{
-				UpdateProposed();
-				return proposed.Format;
-			}
-		}
-
-		public int ProposedVolume
-		{
-			get
-			{
-				UpdateProposed();
-				return proposed.Volume;
-			}
-		}
-
-		public string ProposedNumber
-		{
-			get
-			{
-				UpdateProposed();
-				if (!(base.Number == "-"))
-				{
-					return proposed.Number;
-				}
-				return string.Empty;
-			}
-		}
-
-		public int ProposedCount
-		{
-			get
-			{
-				UpdateProposed();
-				return proposed.Count;
-			}
-		}
-
-		public int ProposedYear
-		{
-			get
-			{
-				UpdateProposed();
-				return proposed.Year;
-			}
-		}
-
-		public string ProposedYearAsText => FormatYear(ProposedYear);
-
-		public string ProposedNumberAsText => FormatNumber(ProposedNumber, ProposedCount);
-
-		public string ProposedVolumeAsText => FormatVolume(ProposedVolume);
-
-		public string ProposedNakedVolumeAsText
-		{
-			get
-			{
-				if (ProposedVolume != -1)
-				{
-					return ProposedVolume.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public string ProposedCountAsText
-		{
-			get
-			{
-				if (ProposedCount != -1)
-				{
-					return ProposedCount.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public string ShadowSeries
-		{
-			get
-			{
-				if (!EnableProposed || !string.IsNullOrEmpty(base.Series))
-				{
-					return base.Series;
-				}
-				return ProposedSeries;
-			}
-		}
-
-		public string ShadowTitle
-		{
-			get
-			{
-				if (!EnableProposed || !string.IsNullOrEmpty(base.Title))
-				{
-					return base.Title;
-				}
-				return ProposedTitle;
-			}
-		}
-
-		public string ShadowFormat
-		{
-			get
-			{
-				if (!EnableProposed || !string.IsNullOrEmpty(base.Format))
-				{
-					return base.Format;
-				}
-				return ProposedFormat;
-			}
-		}
-
-		public int ShadowVolume
-		{
-			get
-			{
-				if (!EnableProposed || base.Volume != -1)
-				{
-					return base.Volume;
-				}
-				return ProposedVolume;
-			}
-		}
-
-		public string ShadowNumber
-		{
-			get
-			{
-				if (!EnableProposed || !string.IsNullOrEmpty(base.Number))
-				{
-					return base.Number;
-				}
-				return ProposedNumber;
-			}
-		}
-
-		public int ShadowCount
-		{
-			get
-			{
-				if (!EnableProposed || base.Count != -1)
-				{
-					return base.Count;
-				}
-				return ProposedCount;
-			}
-		}
-
-		public int ShadowYear
-		{
-			get
-			{
-				if (!EnableProposed || base.Year != -1)
-				{
-					return base.Year;
-				}
-				return ProposedYear;
-			}
-		}
-
-		[Browsable(true)]
-		public string ShadowYearAsText => FormatYear(ShadowYear);
-
-		public string ShadowNumberAsText => FormatNumber(ShadowNumber, ShadowCount);
-
-		public string ShadowVolumeAsText => FormatVolume(ShadowVolume);
-
-		public string ShadowCountAsText
-		{
-			get
-			{
-				if (ShadowCount != -1)
-				{
-					return ShadowCount.ToString();
-				}
-				return string.Empty;
-			}
-		}
-
-		public TextNumberFloat CompareNumber => compareNumber ?? (compareNumber = new ComicTextNumberFloat(ShadowNumber));
-
-		public TextNumberFloat CompareAlternateNumber => compareAlternateNumber ?? (compareAlternateNumber = new ComicTextNumberFloat(base.AlternateNumber));
-
-		[DefaultValue(null)]
-		public ExtraSyncInformation ExtraSyncInformation
-		{
-			get
-			{
-				using (ItemMonitor.Lock(syncInfo))
-				{
-					ExtraSyncInformation value;
-					return syncInfo.TryGetValue(this, out value) ? value : null;
-				}
-			}
-			set
-			{
-				using (ItemMonitor.Lock(syncInfo))
-				{
-					syncInfo[this] = value;
-				}
-			}
-		}
-
-		[Browsable(true)]
-		[DefaultValue("")]
-		[ResetValue(0)]
-		public string CustomValuesStore
-		{
-			get
-			{
-				return customValuesStore;
-			}
-			set
-			{
-				SetProperty("CustomValuesStore", ref customValuesStore, value);
-			}
-		}
-
-		public static ImagePackage PublisherIcons => publisherIcons;
-
-		public static ImagePackage AgeRatingIcons => ageRatingIcons;
-
-		public static ImagePackage FormatIcons => formatIcons;
-
-		public static ImagePackage SpecialIcons => specialIcons;
-
-		public static Dictionary<string, ImagePackage> GenericIcons { get; set; } = new Dictionary<string, ImagePackage>(StringComparer.OrdinalIgnoreCase);
-
-		public static bool NewBooksChecked
-		{
-			get;
-			set;
-		}
-
-		[field: NonSerialized]
-		public event EventHandler<ComicBookFileRenameEventArgs> FileRenamed;
-
-		[field: NonSerialized]
-		public event EventHandler<CreateComicProviderEventArgs> CreateComicProvider;
-
-		[field: NonSerialized]
-		public event EventHandler<CreateComicProviderEventArgs> ComicProviderCreated;
+        [ResetValue(0)]
+        public string CustomThumbnailKey
+        {
+            get
+            {
+                return customThumbnailKey;
+            }
+            set
+            {
+                if (!(customThumbnailKey == value))
+                {
+                    customThumbnailKey = value;
+                    FireBookChanged("CustomThumbnailKey");
+                }
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue(-1f)]
+        [ResetValue(0)]
+        public float BookPrice
+        {
+            get
+            {
+                return bookPrice;
+            }
+            set
+            {
+                SetProperty("BookPrice", ref bookPrice, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string BookAge
+        {
+            get
+            {
+                return bookAge;
+            }
+            set
+            {
+                SetProperty("BookAge", ref bookAge, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string BookCondition
+        {
+            get
+            {
+                return bookCondition;
+            }
+            set
+            {
+                SetProperty("BookCondition", ref bookCondition, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string BookStore
+        {
+            get
+            {
+                return bookStore;
+            }
+            set
+            {
+                SetProperty("BookStore", ref bookStore, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string BookOwner
+        {
+            get
+            {
+                return bookOwner;
+            }
+            set
+            {
+                SetProperty("BookOwner", ref bookOwner, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string BookCollectionStatus
+        {
+            get
+            {
+                return bookCollectionStatus;
+            }
+            set
+            {
+                SetProperty("BookCollectionStatus", ref bookCollectionStatus, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string BookNotes
+        {
+            get
+            {
+                return bookNotes;
+            }
+            set
+            {
+                SetProperty("BookNotes", ref bookNotes, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string BookLocation
+        {
+            get
+            {
+                return bookLocation;
+            }
+            set
+            {
+                SetProperty("BookLocation", ref bookLocation, value);
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string ISBN
+        {
+            get
+            {
+                return isbn;
+            }
+            set
+            {
+                SetProperty("ISBN", ref isbn, value);
+            }
+        }
+
+        [XmlIgnore]
+        public string PagesAsTextSimple
+        {
+            get
+            {
+                if (base.PageCount > 0)
+                {
+                    return base.PageCount.ToString();
+                }
+                return "-";
+            }
+            set
+            {
+                if (int.TryParse(value, out var result) && result >= 0)
+                {
+                    base.PageCount = result;
+                }
+            }
+        }
+
+        [Browsable(true)]
+        public string FileName
+        {
+            get
+            {
+                if (fileName != null)
+                {
+                    return fileName;
+                }
+                try
+                {
+                    fileName = Path.GetFileNameWithoutExtension(filePath);
+                }
+                catch (Exception)
+                {
+                    fileName = string.Empty;
+                }
+                return fileName;
+            }
+        }
+
+        [Browsable(true)]
+        public string FileNameWithExtension
+        {
+            get
+            {
+                if (fileNameWithExtension != null)
+                {
+                    return fileNameWithExtension;
+                }
+                try
+                {
+                    fileNameWithExtension = Path.GetFileName(filePath);
+                }
+                catch (Exception)
+                {
+                    fileNameWithExtension = string.Empty;
+                }
+                return fileNameWithExtension;
+            }
+        }
+
+        [Browsable(true)]
+        public string FileFormat
+        {
+            get
+            {
+                if (fileFormat != null)
+                {
+                    return fileFormat;
+                }
+                try
+                {
+                    fileFormat = Providers.Readers.GetSourceFormatName(filePath);
+                }
+                catch (Exception)
+                {
+                    fileFormat = string.Empty;
+                }
+                return fileFormat;
+            }
+        }
+
+        [Browsable(true)]
+        public string ActualFileFormat
+        {
+            get
+            {
+                if (actualFileFormat != null)
+                {
+                    return actualFileFormat;
+                }
+                try
+                {
+                    actualFileFormat = Providers.Readers.GetSourceFormatName(filePath, true);
+                }
+                catch (Exception)
+                {
+                    actualFileFormat = string.Empty;
+                }
+                return actualFileFormat;
+            }
+        }
+
+        [Browsable(true)]
+        public string FileDirectory
+        {
+            get
+            {
+                if (fileDirectory != null)
+                {
+                    return fileDirectory;
+                }
+                try
+                {
+                    fileDirectory = Path.GetDirectoryName(filePath);
+                }
+                catch (Exception)
+                {
+                    fileDirectory = string.Empty;
+                }
+                return fileDirectory;
+            }
+        }
+
+        [Browsable(true)]
+        public bool IsValidComicBook
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(FilePath))
+                {
+                    return Providers.Readers.GetSourceProviderType(FilePath) != null;
+                }
+                return false;
+            }
+        }
+
+        //TODO: check to update Caption to a Virtual Tag
+        [Browsable(true)]
+        public string Caption => GetFullTitle(EngineConfiguration.Default.ComicCaptionFormat);
+
+        [Browsable(true)]
+        public string CaptionWithoutTitle => GetFullTitle(EngineConfiguration.Default.ComicCaptionFormat, "title");
+
+        [Browsable(true)]
+        public string CaptionWithoutFormat => GetFullTitle(EngineConfiguration.Default.ComicCaptionFormat, "format");
+
+        [Browsable(true)]
+        public string AlternateCaption => GetFullTitle(DefaultAlternateCaptionFormat);
+
+        public string TargetFilename => GetFullTitle(EngineConfiguration.Default.ComicExportFileNameFormat);
+
+        [Browsable(true)]
+        public int ReadPercentage
+        {
+            get
+            {
+                if (base.PageCount <= 0 || LastPageRead <= 0)
+                {
+                    return 0;
+                }
+                return ((LastPageRead + 1) * 100 / base.PageCount).Clamp(1, 100);
+            }
+        }
+
+        public string ReadPercentageAsText => $"{ReadPercentage}%";
+
+        [Browsable(true)]
+        public bool HasBeenOpened => OpenedTime != DateTime.MinValue;
+
+        [Browsable(true)]
+        [XmlIgnore]
+        public bool HasBeenRead
+        {
+            get
+            {
+                return ReadPercentage >= ReadPercentageAsRead;
+            }
+            set
+            {
+                if (value)
+                {
+                    MarkAsRead();
+                }
+                else
+                {
+                    MarkAsNotRead();
+                }
+            }
+        }
+
+        public string PagesAsText => FormatPages(base.PageCount);
+
+        public string OpenedCountAsText => OpenedCount.ToString();
+
+        public string InfoText
+        {
+            get
+            {
+                StringBuilder stringBuilder = new StringBuilder();
+                stringBuilder.AppendFormat("{0}\n", FileName);
+                stringBuilder.AppendFormat("{0} ({1})\n\n", FileSizeAsText, PagesAsText);
+                stringBuilder.AppendFormat("{0}\n", ActualFileFormat);
+                stringBuilder.AppendFormat("{0}\n\n", FileDirectory);
+                stringBuilder.Append(StringUtility.Format(lastTimeOpenedAtText.Value, OpenedTimeAsText));
+                stringBuilder.AppendLine();
+                stringBuilder.Append(StringUtility.Format(readingAtPageText.Value, CurrentPage + 1));
+                stringBuilder.AppendLine();
+                stringBuilder.Append(StringUtility.Format(lastPageReadIsText.Value, LastPageRead + 1));
+                return stringBuilder.ToString();
+            }
+        }
+
+        public string NumberAsText => FormatNumber(base.Number, ShadowCount);
+
+        [Browsable(true)]
+        public string NumberOnly => ShadowNumber;
+
+        public string AlternateNumberAsText => FormatNumber(base.AlternateNumber, base.AlternateCount);
+
+        public string VolumeAsText => FormatVolume(base.Volume);
+
+        [Browsable(true)]
+        public string VolumeOnly
+        {
+            get
+            {
+                if (base.Volume >= 0)
+                {
+                    return base.Volume.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public string LastPageReadAsText
+        {
+            get
+            {
+                if (LastPageRead > 0)
+                {
+                    return (LastPageRead + 1).ToString();
+                }
+                return noneText.Value;
+            }
+        }
+
+        public string LanguageAsText
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(base.LanguageISO))
+                {
+                    return GetLanguageName(base.LanguageISO);
+                }
+                return string.Empty;
+            }
+        }
+
+        public string ArtistInfo
+        {
+            get
+            {
+                HashSet<string> uniqueNames = new HashSet<string>();
+                StringBuilder stringBuilder = new StringBuilder();
+                AppendUniqueName(stringBuilder, "/", base.Writer, uniqueNames);
+                AppendUniqueName(stringBuilder, "/", base.Penciller, uniqueNames);
+                AppendUniqueName(stringBuilder, "/", base.Inker, uniqueNames);
+                AppendUniqueName(stringBuilder, "/", base.Colorist, uniqueNames);
+                AppendUniqueName(stringBuilder, "/", base.Letterer, uniqueNames);
+                AppendUniqueName(stringBuilder, "/", base.CoverArtist, uniqueNames);
+                AppendUniqueName(stringBuilder, "/", base.Translator, uniqueNames);
+
+                return stringBuilder.ToString();
+            }
+        }
+
+        public string YearAsText => FormatYear(base.Year);
+
+        public string MonthAsText
+        {
+            get
+            {
+                if (base.Month != -1)
+                {
+                    return base.Month.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public string DayAsText
+        {
+            get
+            {
+                if (base.Day != -1)
+                {
+                    return base.Day.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public int Week
+        {
+            get
+            {
+                DateTime published = Published;
+                if (published == DateTime.MinValue)
+                {
+                    return -1;
+                }
+                return weekCalendar.GetWeekOfYear(published, CalendarWeekRule.FirstDay, DayOfWeek.Monday);
+            }
+        }
+
+        public string WeekAsText
+        {
+            get
+            {
+                int week = Week;
+                if (week != -1)
+                {
+                    return week.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public string PublishedRegional => FormatDate(Published, ComicDateFormat.Short, toLocal: false, unkownText.Value);
+
+        public string PublishedAsText
+        {
+            get
+            {
+                string shadowYearAsText = ShadowYearAsText;
+                string text = string.Empty;
+                if (!string.IsNullOrEmpty(shadowYearAsText))
+                {
+                    string monthAsText = MonthAsText;
+                    if (!string.IsNullOrEmpty(monthAsText))
+                    {
+                        string dayAsText = DayAsText;
+                        if (!string.IsNullOrEmpty(dayAsText))
+                        {
+                            text = text + dayAsText + "/";
+                        }
+                        text = text + monthAsText + "/";
+                    }
+                    text += shadowYearAsText;
+                }
+                return text;
+            }
+        }
+
+        public DateTime Published
+        {
+            get
+            {
+                if (ShadowYear <= 0)
+                {
+                    return DateTime.MinValue;
+                }
+                int year = ShadowYear.Clamp(1, 10000);
+                int month = base.Month.Clamp(1, 12);
+                int day = base.Day.Clamp(1, DateTime.DaysInMonth(year, month));
+                return new DateTime(year, month, day);
+            }
+        }
+
+        public string CountAsText
+        {
+            get
+            {
+                if (base.Count != -1)
+                {
+                    return base.Count.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public string NewPagesAsText
+        {
+            get
+            {
+                if (!IsDynamicSource || NewPages <= 0)
+                {
+                    return string.Empty;
+                }
+                return NewPages.ToString();
+            }
+        }
+
+        public string AlternateCountAsText
+        {
+            get
+            {
+                if (base.AlternateCount != -1)
+                {
+                    return base.AlternateCount.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public string RatingAsText => FormatRating(Rating);
+
+        public string CommunityRatingAsText => FormatRating(base.CommunityRating);
+
+        public string CoverAsText => ComicInfo.GetYesNoAsText((base.FrontCoverCount != 0) ? YesNo.Yes : YesNo.No);
+
+        public string FileSizeAsText
+        {
+            get
+            {
+                long num = FileSize;
+                if (num == -1)
+                {
+                    return notFoundText.Value;
+                }
+                return string.Format(new FileLengthFormat(), "{0}", new object[1]
+                {
+                    num
+                });
+            }
+        }
+
+        public string MangaAsText => ComicInfo.GetYesNoAsText(base.Manga);
+
+        public string SeriesCompleteAsText => ComicInfo.GetYesNoAsText(SeriesComplete);
+
+        public string EnableProposedAsText => ComicInfo.GetYesNoAsText(EnableProposed ? YesNo.Yes : YesNo.No);
+
+        public string HasBeenReadAsText => ComicInfo.GetYesNoAsText(HasBeenRead ? YesNo.Yes : YesNo.No);
+
+        public string IsLinkedAsText => ComicInfo.GetYesNoAsText(IsLinked);
+
+        public string BlackAndWhiteAsText => ComicInfo.GetYesNoAsText(base.BlackAndWhite);
+
+        public string BookmarkCountAsText
+        {
+            get
+            {
+                if (base.BookmarkCount > 0)
+                {
+                    return base.BookmarkCount.ToString();
+                }
+                return noneText.Value;
+            }
+        }
+
+        public ComicPageInfo CurrentPageInfo => GetPage(CurrentPage);
+
+        public string FileLocation
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(fileLocation))
+                {
+                    return fileLocation;
+                }
+                return FilePath;
+            }
+        }
+
+        public string DisplayFileLocation
+        {
+            get
+            {
+                if (!IsInContainer)
+                {
+                    return FilePath;
+                }
+                return Caption;
+            }
+        }
+
+        public int Status
+        {
+            get
+            {
+                int num = 0;
+                if (FileIsMissing && IsLinked)
+                {
+                    num |= 1;
+                }
+                if (ComicInfoIsDirty)
+                {
+                    num |= 2;
+                }
+                return num;
+            }
+        }
+
+        [Browsable(true)]
+        public bool IsLinked => !string.IsNullOrEmpty(filePath);
+
+        [XmlIgnore]
+        public string BookPriceAsText
+        {
+            get
+            {
+                if (!(bookPrice < 0f))
+                {
+                    return $"{bookPrice:0.00}";
+                }
+                return unkownText.Value;
+            }
+            set
+            {
+                if (float.TryParse(value, out var result))
+                {
+                    BookPrice = result;
+                }
+                else
+                {
+                    BookPrice = -1f;
+                }
+            }
+        }
+
+        public string OpenedTimeAsText => FormatDate(OpenedTime);
+
+        public string AddedTimeAsText => FormatDate(AddedTime, ComicDateFormat.Long, toLocal: false, unkownText.Value);
+
+        public string ReleasedTimeAsText => FormatDate(ReleasedTime, ComicDateFormat.Short, toLocal: false, unkownText.Value);
+
+        public string FileCreationTimeAsText => FormatFileDate(FileCreationTime);
+
+        public string FileModifiedTimeAsText => FormatFileDate(FileModifiedTime);
+
+        public bool IsInContainer => container != null;
+
+        public ComicsEditModes EditMode
+        {
+            get
+            {
+                if (!IsInContainer)
+                {
+                    return ComicsEditModes.Default;
+                }
+                return Container.EditMode;
+            }
+        }
+
+        [DefaultValue(false)]
+        [XmlAttribute]
+        public bool IsDynamicSource
+        {
+            get;
+            set;
+        }
+
+        [DefaultValue(0)]
+        public int NewPages
+        {
+            get
+            {
+                return newPages;
+            }
+            set
+            {
+                SetProperty("NewPages", ref newPages, value);
+            }
+        }
+
+        public string ProposedSeries
+        {
+            get
+            {
+                UpdateProposed();
+                return proposed.Series;
+            }
+        }
+
+        public string ProposedTitle
+        {
+            get
+            {
+                UpdateProposed();
+                return proposed.Title;
+            }
+        }
+
+        public string ProposedFormat
+        {
+            get
+            {
+                UpdateProposed();
+                return proposed.Format;
+            }
+        }
+
+        public int ProposedVolume
+        {
+            get
+            {
+                UpdateProposed();
+                return proposed.Volume;
+            }
+        }
+
+        public string ProposedNumber
+        {
+            get
+            {
+                UpdateProposed();
+                if (!(base.Number == "-"))
+                {
+                    return proposed.Number;
+                }
+                return string.Empty;
+            }
+        }
+
+        public int ProposedCount
+        {
+            get
+            {
+                UpdateProposed();
+                return proposed.Count;
+            }
+        }
+
+        public int ProposedYear
+        {
+            get
+            {
+                UpdateProposed();
+                return proposed.Year;
+            }
+        }
+
+        public string ProposedYearAsText => FormatYear(ProposedYear);
+
+        public string ProposedNumberAsText => FormatNumber(ProposedNumber, ProposedCount);
+
+        public string ProposedVolumeAsText => FormatVolume(ProposedVolume);
+
+        public string ProposedNakedVolumeAsText
+        {
+            get
+            {
+                if (ProposedVolume != -1)
+                {
+                    return ProposedVolume.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public string ProposedCountAsText
+        {
+            get
+            {
+                if (ProposedCount != -1)
+                {
+                    return ProposedCount.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public string ShadowSeries
+        {
+            get
+            {
+                if (!EnableProposed || !string.IsNullOrEmpty(base.Series))
+                {
+                    return base.Series;
+                }
+                return ProposedSeries;
+            }
+        }
+
+        public string ShadowTitle
+        {
+            get
+            {
+                if (!EnableProposed || !string.IsNullOrEmpty(base.Title))
+                {
+                    return base.Title;
+                }
+                return ProposedTitle;
+            }
+        }
+
+        public string ShadowFormat
+        {
+            get
+            {
+                if (!EnableProposed || !string.IsNullOrEmpty(base.Format))
+                {
+                    return base.Format;
+                }
+                return ProposedFormat;
+            }
+        }
+
+        public int ShadowVolume
+        {
+            get
+            {
+                if (!EnableProposed || base.Volume != -1)
+                {
+                    return base.Volume;
+                }
+                return ProposedVolume;
+            }
+        }
+
+        public string ShadowNumber
+        {
+            get
+            {
+                if (!EnableProposed || !string.IsNullOrEmpty(base.Number))
+                {
+                    return base.Number;
+                }
+                return ProposedNumber;
+            }
+        }
+
+        public int ShadowCount
+        {
+            get
+            {
+                if (!EnableProposed || base.Count != -1)
+                {
+                    return base.Count;
+                }
+                return ProposedCount;
+            }
+        }
+
+        public int ShadowYear
+        {
+            get
+            {
+                if (!EnableProposed || base.Year != -1)
+                {
+                    return base.Year;
+                }
+                return ProposedYear;
+            }
+        }
+
+        [Browsable(true)]
+        public string ShadowYearAsText => FormatYear(ShadowYear);
+
+        public string ShadowNumberAsText => FormatNumber(ShadowNumber, ShadowCount);
+
+        public string ShadowVolumeAsText => FormatVolume(ShadowVolume);
+
+        public string ShadowCountAsText
+        {
+            get
+            {
+                if (ShadowCount != -1)
+                {
+                    return ShadowCount.ToString();
+                }
+                return string.Empty;
+            }
+        }
+
+        public TextNumberFloat CompareNumber => compareNumber ?? (compareNumber = new ComicTextNumberFloat(ShadowNumber));
+
+        public TextNumberFloat CompareAlternateNumber => compareAlternateNumber ?? (compareAlternateNumber = new ComicTextNumberFloat(base.AlternateNumber));
+
+        [DefaultValue(null)]
+        public ExtraSyncInformation ExtraSyncInformation
+        {
+            get
+            {
+                using (ItemMonitor.Lock(syncInfo))
+                {
+                    ExtraSyncInformation value;
+                    return syncInfo.TryGetValue(this, out value) ? value : null;
+                }
+            }
+            set
+            {
+                using (ItemMonitor.Lock(syncInfo))
+                {
+                    syncInfo[this] = value;
+                }
+            }
+        }
+
+        [Browsable(true)]
+        [DefaultValue("")]
+        [ResetValue(0)]
+        public string CustomValuesStore
+        {
+            get
+            {
+                return customValuesStore;
+            }
+            set
+            {
+                SetProperty("CustomValuesStore", ref customValuesStore, value);
+            }
+        }
+
+        public static ImagePackage PublisherIcons => publisherIcons;
+
+        public static ImagePackage AgeRatingIcons => ageRatingIcons;
+
+        public static ImagePackage FormatIcons => formatIcons;
+
+        public static ImagePackage SpecialIcons => specialIcons;
+
+        public static Dictionary<string, ImagePackage> GenericIcons { get; set; } = new Dictionary<string, ImagePackage>(StringComparer.OrdinalIgnoreCase);
+
+        public static bool NewBooksChecked
+        {
+            get;
+            set;
+        }
+
+        [field: NonSerialized]
+        public event EventHandler<ComicBookFileRenameEventArgs> FileRenamed;
+
+        [field: NonSerialized]
+        public event EventHandler<CreateComicProviderEventArgs> CreateComicProvider;
+
+        [field: NonSerialized]
+        public event EventHandler<CreateComicProviderEventArgs> ComicProviderCreated;
 
         [field: NonSerialized]
         public event EventHandler<IO.Provider.ErrorEventArgs> WriteError;
 
-		public static event EventHandler<ParseFilePathEventArgs> ParseFilePath;
+        public static event EventHandler<ParseFilePathEventArgs> ParseFilePath;
 
-		Dictionary<int, string> CachedVirtualTags = new Dictionary<int, string>();
-		public string GetVirtualTagValue(int id)
-		{
-			using (ItemMonitor.Lock(CachedVirtualTags))
+        Dictionary<int, string> CachedVirtualTags = new Dictionary<int, string>();
+        public string GetVirtualTagValue(int id)
+        {
+            using (ItemMonitor.Lock(CachedVirtualTags))
             {
-				if (CachedVirtualTags.TryGetValue(id, out var value))
-					return value;
+                if (CachedVirtualTags.TryGetValue(id, out var value))
+                    return value;
 
-				string captionFormat = VirtualTagsCollection.Tags.GetValue(id).CaptionFormat;
-				string saved = (!string.IsNullOrEmpty(captionFormat)) ? GetFullTitle(captionFormat) : string.Empty;
+                string captionFormat = VirtualTagsCollection.Tags.GetValue(id).CaptionFormat;
+                string saved = (!string.IsNullOrEmpty(captionFormat)) ? GetFullTitle(captionFormat) : string.Empty;
 
-				CachedVirtualTags[id] = saved;
-				return saved;
-			}
-		}
+                CachedVirtualTags[id] = saved;
+                return saved;
+            }
+        }
 
-		private void VirtualTagsCollection_TagsRefresh(object sender, EventArgs e)
-		{
-			ClearVirtualTagsCache();
-		}
+        private void VirtualTagsCollection_TagsRefresh(object sender, EventArgs e)
+        {
+            ClearVirtualTagsCache();
+        }
 
-		private void ClearVirtualTagsCache()
-		{
-			CachedVirtualTags.Clear();
-		}
+        private void ClearVirtualTagsCache()
+        {
+            CachedVirtualTags.Clear();
+        }
 
-		public string VirtualTag01 => GetVirtualTagValue(1);
-		public string VirtualTag02 => GetVirtualTagValue(2);
-		public string VirtualTag03 => GetVirtualTagValue(3);
-		public string VirtualTag04 => GetVirtualTagValue(4);
-		public string VirtualTag05 => GetVirtualTagValue(5);
-		public string VirtualTag06 => GetVirtualTagValue(6);
-		public string VirtualTag07 => GetVirtualTagValue(7);
-		public string VirtualTag08 => GetVirtualTagValue(8);
-		public string VirtualTag09 => GetVirtualTagValue(9);
-		public string VirtualTag10 => GetVirtualTagValue(10);
-		public string VirtualTag11 => GetVirtualTagValue(11);
-		public string VirtualTag12 => GetVirtualTagValue(12);
-		public string VirtualTag13 => GetVirtualTagValue(13);
-		public string VirtualTag14 => GetVirtualTagValue(14);
-		public string VirtualTag15 => GetVirtualTagValue(15);
-		public string VirtualTag16 => GetVirtualTagValue(16);
-		public string VirtualTag17 => GetVirtualTagValue(17);
-		public string VirtualTag18 => GetVirtualTagValue(18);
-		public string VirtualTag19 => GetVirtualTagValue(19);
-		public string VirtualTag20 => GetVirtualTagValue(20);
+        public string VirtualTag01 => GetVirtualTagValue(1);
+        public string VirtualTag02 => GetVirtualTagValue(2);
+        public string VirtualTag03 => GetVirtualTagValue(3);
+        public string VirtualTag04 => GetVirtualTagValue(4);
+        public string VirtualTag05 => GetVirtualTagValue(5);
+        public string VirtualTag06 => GetVirtualTagValue(6);
+        public string VirtualTag07 => GetVirtualTagValue(7);
+        public string VirtualTag08 => GetVirtualTagValue(8);
+        public string VirtualTag09 => GetVirtualTagValue(9);
+        public string VirtualTag10 => GetVirtualTagValue(10);
+        public string VirtualTag11 => GetVirtualTagValue(11);
+        public string VirtualTag12 => GetVirtualTagValue(12);
+        public string VirtualTag13 => GetVirtualTagValue(13);
+        public string VirtualTag14 => GetVirtualTagValue(14);
+        public string VirtualTag15 => GetVirtualTagValue(15);
+        public string VirtualTag16 => GetVirtualTagValue(16);
+        public string VirtualTag17 => GetVirtualTagValue(17);
+        public string VirtualTag18 => GetVirtualTagValue(18);
+        public string VirtualTag19 => GetVirtualTagValue(19);
+        public string VirtualTag20 => GetVirtualTagValue(20);
 
-		static ComicBook()
-		{
-			GuidEquality = new Equality<ComicBook>((ComicBook a, ComicBook b) => a.Id == b.Id, (ComicBook a) => a.Id.GetHashCode());
-			EnableGroupNameCompression = false;
-			unkownText = new Lazy<string>(() => TR["Unknown"]);
-			pagesText = new Lazy<string>(() => TR["Pages", "{0} Page(s)"]);
-			lastTimeOpenedAtText = new Lazy<string>(() => TR["LastTimeOpenedAt", "Last time opened at {0}"]);
-			readingAtPageText = new Lazy<string>(() => TR["ReadingAtPage", "Reading at page {0}"]);
-			lastPageReadIsText = new Lazy<string>(() => TR["LastPageReadIs", "Last page read is {0}"]);
-			noneText = new Lazy<string>(() => TR["None", "None"]);
-			notFoundText = new Lazy<string>(() => TR["NotFound", "not found"]);
-			neverText = new Lazy<string>(() => TR["Never", "never"]);
-			volumeFormat = new Lazy<string>(() => TR["Volume", "V{0}"]);
-			ofText = new Lazy<string>(() => TR["Of", "of"]);
-			weekCalendar = new GregorianCalendar();
-			syncInfo = new Dictionary<ComicBook, ExtraSyncInformation>();
-			rxField = new Regex("{(?<name>[a-z]+)}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-			Default = new ComicBook();
-			hasAsText = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-			publisherIcons = new ImagePackage
-			{
-				EnableWidthCropping = true
-			};
-			ageRatingIcons = new ImagePackage
-			{
-				EnableWidthCropping = true
-			};
-			formatIcons = new ImagePackage
-			{
-				EnableWidthCropping = true
-			};
-			specialIcons = new ImagePackage
-			{
-				EnableWidthCropping = true
-			};
-			NewBooksChecked = true;
-		}
+        static ComicBook()
+        {
+            GuidEquality = new Equality<ComicBook>((ComicBook a, ComicBook b) => a.Id == b.Id, (ComicBook a) => a.Id.GetHashCode());
+            EnableGroupNameCompression = false;
+            unkownText = new Lazy<string>(() => TR["Unknown"]);
+            pagesText = new Lazy<string>(() => TR["Pages", "{0} Page(s)"]);
+            lastTimeOpenedAtText = new Lazy<string>(() => TR["LastTimeOpenedAt", "Last time opened at {0}"]);
+            readingAtPageText = new Lazy<string>(() => TR["ReadingAtPage", "Reading at page {0}"]);
+            lastPageReadIsText = new Lazy<string>(() => TR["LastPageReadIs", "Last page read is {0}"]);
+            noneText = new Lazy<string>(() => TR["None", "None"]);
+            notFoundText = new Lazy<string>(() => TR["NotFound", "not found"]);
+            neverText = new Lazy<string>(() => TR["Never", "never"]);
+            volumeFormat = new Lazy<string>(() => TR["Volume", "V{0}"]);
+            ofText = new Lazy<string>(() => TR["Of", "of"]);
+            weekCalendar = new GregorianCalendar();
+            syncInfo = new Dictionary<ComicBook, ExtraSyncInformation>();
+            rxField = new Regex("{(?<name>[a-z]+)}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            Default = new ComicBook();
+            hasAsText = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            publisherIcons = new ImagePackage
+            {
+                EnableWidthCropping = true
+            };
+            ageRatingIcons = new ImagePackage
+            {
+                EnableWidthCropping = true
+            };
+            formatIcons = new ImagePackage
+            {
+                EnableWidthCropping = true
+            };
+            specialIcons = new ImagePackage
+            {
+                EnableWidthCropping = true
+            };
+            NewBooksChecked = true;
+        }
 
-		public ComicBook()
-		{
-			VirtualTagsCollection.TagsRefresh += VirtualTagsCollection_TagsRefresh;
-		}
+        public ComicBook()
+        {
+            VirtualTagsCollection.TagsRefresh += VirtualTagsCollection_TagsRefresh;
+        }
 
-		public ComicBook(ComicBook cb) : this()
-		{
-			CopyFrom(cb);
-			if (cb.CreateComicProvider != null)
-			{
-				CreateComicProvider += cb.CreateComicProvider;
-			}
-			if (cb.ComicProviderCreated != null)
-			{
-				ComicProviderCreated += cb.ComicProviderCreated;
-			}
-		}
+        public ComicBook(ComicBook cb) : this()
+        {
+            CopyFrom(cb);
+            if (cb.CreateComicProvider != null)
+            {
+                CreateComicProvider += cb.CreateComicProvider;
+            }
+            if (cb.ComicProviderCreated != null)
+            {
+                ComicProviderCreated += cb.ComicProviderCreated;
+            }
+        }
 
         public static ComicBook Create(string file, RefreshInfoOptions options)
-		{
-			ComicBook comicBook = new ComicBook
-			{
-				FilePath = file
-			};
-			comicBook.RefreshInfoFromFile(options);
-			return comicBook;
-		}
+        {
+            ComicBook comicBook = new ComicBook
+            {
+                FilePath = file
+            };
+            comicBook.RefreshInfoFromFile(options);
+            return comicBook;
+        }
 
-		private void ResetOptimizedNumbers()
-		{
-			compareNumber = (compareAlternateNumber = null);
-		}
+        private void ResetOptimizedNumbers()
+        {
+            compareNumber = (compareAlternateNumber = null);
+        }
 
-		public static void ClearExtraSyncInformation()
-		{
-			using (ItemMonitor.Lock(syncInfo))
-			{
-				syncInfo.Clear();
-			}
-		}
+        public static void ClearExtraSyncInformation()
+        {
+            using (ItemMonitor.Lock(syncInfo))
+            {
+                syncInfo.Clear();
+            }
+        }
 
-		public IEnumerable<StringPair> GetCustomValues()
-		{
-			return ValuesStore.GetValues(CustomValuesStore);
-		}
+        public IEnumerable<StringPair> GetCustomValues()
+        {
+            return ValuesStore.GetValues(CustomValuesStore);
+        }
 
-		public void SetCustomValue(string key, string value)
-		{
-			if (!string.IsNullOrEmpty(key))
-			{
-				if (string.IsNullOrEmpty(value))
-				{
-					DeleteCustomValue(key);
-				}
-				else
-				{
-					CustomValuesStore = new ValuesStore(CustomValuesStore).Add(key, value).ToString();
-				}
-			}
-		}
+        public void SetCustomValue(string key, string value)
+        {
+            if (!string.IsNullOrEmpty(key))
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    DeleteCustomValue(key);
+                }
+                else
+                {
+                    CustomValuesStore = new ValuesStore(CustomValuesStore).Add(key, value).ToString();
+                }
+            }
+        }
 
-		public string GetCustomValue(string key)
-		{
-			return ValuesStore.GetValue(CustomValuesStore, key);
-		}
+        public string GetCustomValue(string key)
+        {
+            return ValuesStore.GetValue(CustomValuesStore, key);
+        }
 
-		public void DeleteCustomValue(string key)
-		{
-			CustomValuesStore = new ValuesStore(CustomValuesStore).Remove(key).ToString();
-		}
+        public void DeleteCustomValue(string key)
+        {
+            CustomValuesStore = new ValuesStore(CustomValuesStore).Remove(key).ToString();
+        }
 
-		public ThumbnailKey GetThumbnailKey(int page)
-		{
-			string locationKey = ((!IsLinked) ? (string.IsNullOrEmpty(CustomThumbnailKey) ? ThumbnailKey.GetResource(ThumbnailKey.ResourceKey, "Unknown") : ThumbnailKey.GetResource(ThumbnailKey.CustomKey, CustomThumbnailKey)) : FileLocation);
-			return GetThumbnailKey(page, locationKey);
-		}
+        public ThumbnailKey GetThumbnailKey(int page)
+        {
+            string locationKey = ((!IsLinked) ? (string.IsNullOrEmpty(CustomThumbnailKey) ? ThumbnailKey.GetResource(ThumbnailKey.ResourceKey, "Unknown") : ThumbnailKey.GetResource(ThumbnailKey.CustomKey, CustomThumbnailKey)) : FileLocation);
+            return GetThumbnailKey(page, locationKey);
+        }
 
-		public ThumbnailKey GetThumbnailKey(int page, string locationKey)
-		{
-			return new ThumbnailKey(this, locationKey, FileSize, FileModifiedTime, TranslatePageToImageIndex(page), GetPage(page).Rotation);
-		}
+        public ThumbnailKey GetThumbnailKey(int page, string locationKey)
+        {
+            return new ThumbnailKey(this, locationKey, FileSize, FileModifiedTime, TranslatePageToImageIndex(page), GetPage(page).Rotation);
+        }
 
-		public ThumbnailKey GetFrontCoverThumbnailKey()
-		{
-			return GetThumbnailKey(base.FrontCoverPageIndex);
-		}
+        public ThumbnailKey GetFrontCoverThumbnailKey()
+        {
+            return GetThumbnailKey(base.FrontCoverPageIndex);
+        }
 
-		public PageKey GetFrontCoverKey(BitmapAdjustment bitmapAdjustment)
-		{
-			return GetPageKey(base.FrontCoverPageIndex, bitmapAdjustment);
-		}
+        public PageKey GetFrontCoverKey(BitmapAdjustment bitmapAdjustment)
+        {
+            return GetPageKey(base.FrontCoverPageIndex, bitmapAdjustment);
+        }
 
-		public PageKey GetPageKey(int page, BitmapAdjustment bitmapAdjustment)
-		{
-			return new PageKey(this, FileLocation, FileSize, FileModifiedTime, TranslatePageToImageIndex(page), GetPage(page).Rotation, bitmapAdjustment);
-		}
+        public PageKey GetPageKey(int page, BitmapAdjustment bitmapAdjustment)
+        {
+            return new PageKey(this, FileLocation, FileSize, FileModifiedTime, TranslatePageToImageIndex(page), GetPage(page).Rotation, bitmapAdjustment);
+        }
 
-		public ImageKey GetImageKey(int image)
-		{
-			return new PageKey(this, FileLocation, FileSize, FileModifiedTime, image, ImageRotation.None, BitmapAdjustment.Empty);
-		}
+        public ImageKey GetImageKey(int image)
+        {
+            return new PageKey(this, FileLocation, FileSize, FileModifiedTime, image, ImageRotation.None, BitmapAdjustment.Empty);
+        }
 
-		public ImageProvider CreateImageProvider()
-		{
-			CreateComicProviderEventArgs createComicProviderEventArgs = new CreateComicProviderEventArgs();
-			OnCreateComicProvider(createComicProviderEventArgs);
-			createComicProviderEventArgs.Provider = createComicProviderEventArgs.Provider ?? Providers.Readers.CreateSourceProvider(FilePath);
-			OnComicProviderCreated(createComicProviderEventArgs);
-			return createComicProviderEventArgs.Provider;
-		}
+        public ImageProvider CreateImageProvider()
+        {
+            CreateComicProviderEventArgs createComicProviderEventArgs = new CreateComicProviderEventArgs();
+            OnCreateComicProvider(createComicProviderEventArgs);
+            createComicProviderEventArgs.Provider = createComicProviderEventArgs.Provider ?? Providers.Readers.CreateSourceProvider(FilePath);
+            OnComicProviderCreated(createComicProviderEventArgs);
+            return createComicProviderEventArgs.Provider;
+        }
 
-		public ImageProvider OpenProvider(int lastPageIndexToRead = -1)
-		{
-			ImageProvider imageProvider = CreateImageProvider();
-			try
-			{
-				if (lastPageIndexToRead != -1)
-				{
-					int imageIndex = TranslatePageToImageIndex(lastPageIndexToRead);
+        public ImageProvider OpenProvider(int lastPageIndexToRead = -1)
+        {
+            ImageProvider imageProvider = CreateImageProvider();
+            try
+            {
+                if (lastPageIndexToRead != -1)
+                {
+                    int imageIndex = TranslatePageToImageIndex(lastPageIndexToRead);
                     imageProvider.ImageReady += delegate(object s, ImageIndexReadyEventArgs e)
-					{
-						e.Cancel = e.ImageNumber == imageIndex;
-					};
-				}
-				imageProvider.Open(async: false);
-				return imageProvider;
-			}
-			catch
-			{
-				imageProvider?.Dispose();
-				return null;
-			}
-		}
+                    {
+                        e.Cancel = e.ImageNumber == imageIndex;
+                    };
+                }
+                imageProvider.Open(async: false);
+                return imageProvider;
+            }
+            catch
+            {
+                imageProvider?.Dispose();
+                return null;
+            }
+        }
 
-		public string GetPublisherIconKey(bool yearOnly = true)
-		{
-			string text = base.Publisher;
-			if (base.Year >= 0 && base.Month >= 0 && !yearOnly)
-				return $"{text}({YearAsText}_{Month:00})";
+        public string GetPublisherIconKey(bool yearOnly = true)
+        {
+            string text = base.Publisher;
+            if (base.Year >= 0 && base.Month >= 0 && !yearOnly)
+                return $"{text}({YearAsText}_{Month:00})";
 
-			if (base.Year >= 0)
-				return $"{text}({YearAsText})";
+            if (base.Year >= 0)
+                return $"{text}({YearAsText})";
 
-			return text;
-		}
+            return text;
+        }
 
-		public string GetImprintIconKey(bool yearOnly = true)
-		{
-			string text = base.Imprint;
-			if (base.Year >= 0 && base.Month >= 0 && !yearOnly)
-				return $"{text}({YearAsText}_{Month:00})";
+        public string GetImprintIconKey(bool yearOnly = true)
+        {
+            string text = base.Imprint;
+            if (base.Year >= 0 && base.Month >= 0 && !yearOnly)
+                return $"{text}({YearAsText}_{Month:00})";
 
-			if (base.Year >= 0)
-				return $"{text}({YearAsText})";
+            if (base.Year >= 0)
+                return $"{text}({YearAsText})";
 
-			return text;
-		}
+            return text;
+        }
 
-		private IEnumerable<Image> GetIconsInternal()
-		{
-			Image image = PublisherIcons.GetImage(GetPublisherIconKey(false));//Year_Month
-			if (image != null)
-			{
-				yield return image;
-			}
-			else if ((image = PublisherIcons.GetImage(GetPublisherIconKey(true))) != null)//Year Only
-			{
-				yield return image;
-			}
-			else
-			{
-				image = PublisherIcons.GetImage(Publisher);
-				if (image != null)
-					yield return image;
-			}
+        private IEnumerable<Image> GetIconsInternal()
+        {
+            Image image = PublisherIcons.GetImage(GetPublisherIconKey(false));//Year_Month
+            if (image != null)
+            {
+                yield return image;
+            }
+            else if ((image = PublisherIcons.GetImage(GetPublisherIconKey(true))) != null)//Year Only
+            {
+                yield return image;
+            }
+            else
+            {
+                image = PublisherIcons.GetImage(Publisher);
+                if (image != null)
+                    yield return image;
+            }
 
-			image = PublisherIcons.GetImage(GetImprintIconKey(false));//Year_Month
-			if (image != null)
-			{
-				yield return image;
-			}
-			else if ((image = PublisherIcons.GetImage(GetImprintIconKey(true))) != null)//Year Only
-			{
-				yield return image;
-			}
-			else
-			{
-				image = PublisherIcons.GetImage(Imprint);
-				if (image != null)
-					yield return image;
-			}
+            image = PublisherIcons.GetImage(GetImprintIconKey(false));//Year_Month
+            if (image != null)
+            {
+                yield return image;
+            }
+            else if ((image = PublisherIcons.GetImage(GetImprintIconKey(true))) != null)//Year Only
+            {
+                yield return image;
+            }
+            else
+            {
+                image = PublisherIcons.GetImage(Imprint);
+                if (image != null)
+                    yield return image;
+            }
 
-			image = AgeRatingIcons.GetImage(AgeRating);
-			if (image != null)
-			{
-				yield return image;
-			}
+            image = AgeRatingIcons.GetImage(AgeRating);
+            if (image != null)
+            {
+                yield return image;
+            }
 
-			image = FormatIcons.GetImage(ShadowFormat);
-			if (image != null)
-			{
-				yield return image;
-			}
+            image = FormatIcons.GetImage(ShadowFormat);
+            if (image != null)
+            {
+                yield return image;
+            }
 
-			if (!string.IsNullOrEmpty(Tags))
-			{
-				foreach (string item in Tags.ListStringToSet(','))
-				{
-					image = (image = SpecialIcons.GetImage(item));
-					if (image != null)
-						yield return image;
-				}
-			}
-			if (SeriesComplete == YesNo.Yes)
-			{
-				image = SpecialIcons.GetImage("SeriesComplete");
-				if (image != null)
-					yield return image;
-			}
-			if (BlackAndWhite == YesNo.Yes)
-			{
-				image = SpecialIcons.GetImage("BlackAndWhite");
-				if (image != null)
-					yield return image;
-			}
-			if (Manga == MangaYesNo.Yes)
-			{
-				image = SpecialIcons.GetImage("Manga");
-				if (image != null)
-					yield return image;
-			}
-			if (Manga == MangaYesNo.YesAndRightToLeft)
-			{
-				image = SpecialIcons.GetImage("MangaRightToLeft");
-				if (image != null)
-					yield return image;
-			}
-			foreach (var image2 in GetGenericImages())
-			{
-				if (image2 != null)
-					yield return image2;
-			}
-		}
+            if (!string.IsNullOrEmpty(Tags))
+            {
+                foreach (string item in Tags.ListStringToSet(','))
+                {
+                    image = (image = SpecialIcons.GetImage(item));
+                    if (image != null)
+                        yield return image;
+                }
+            }
+            if (SeriesComplete == YesNo.Yes)
+            {
+                image = SpecialIcons.GetImage("SeriesComplete");
+                if (image != null)
+                    yield return image;
+            }
+            if (BlackAndWhite == YesNo.Yes)
+            {
+                image = SpecialIcons.GetImage("BlackAndWhite");
+                if (image != null)
+                    yield return image;
+            }
+            if (Manga == MangaYesNo.Yes)
+            {
+                image = SpecialIcons.GetImage("Manga");
+                if (image != null)
+                    yield return image;
+            }
+            if (Manga == MangaYesNo.YesAndRightToLeft)
+            {
+                image = SpecialIcons.GetImage("MangaRightToLeft");
+                if (image != null)
+                    yield return image;
+            }
+            foreach (var image2 in GetGenericImages())
+            {
+                if (image2 != null)
+                    yield return image2;
+            }
+        }
 
-		public IEnumerable<Image> GetIcons()
-		{
-			return GetIconsInternal();
-		}
+        public IEnumerable<Image> GetIcons()
+        {
+            return GetIconsInternal();
+        }
 
-		private IEnumerable<Image> GetGenericImages()
-		{
-			var properties = GetWritableStringProperties();
-			foreach (var imagePackage in GenericIcons)
-			{
-				string keyValue = properties.Contains(imagePackage.Key) ? GetStringPropertyValue(imagePackage.Key)?.Trim() : GetCustomValue(imagePackage.Key)?.Trim();
-				if (!string.IsNullOrEmpty(keyValue))
-				{
-					var propertiesValues = keyValue.FromListString(',');
-					foreach (var propertiesValue in propertiesValues)
-					{
-						Image image = imagePackage.Value.GetImage(propertiesValue);
-						if (image != null)
-							yield return image;
-					} 
-				}
-			}
-		}
+        private IEnumerable<Image> GetGenericImages()
+        {
+            var properties = GetWritableStringProperties();
+            foreach (var imagePackage in GenericIcons)
+            {
+                string keyValue = properties.Contains(imagePackage.Key) ? GetStringPropertyValue(imagePackage.Key)?.Trim() : GetCustomValue(imagePackage.Key)?.Trim();
+                if (!string.IsNullOrEmpty(keyValue))
+                {
+                    var propertiesValues = keyValue.FromListString(',');
+                    foreach (var propertiesValue in propertiesValues)
+                    {
+                        Image image = imagePackage.Value.GetImage(propertiesValue);
+                        if (image != null)
+                            yield return image;
+                    }
+                }
+            }
+        }
 
-		public void CopyFrom(ComicBook cb)
-		{
-			SetInfo(cb, onlyUpdateEmpty: false);
-			Id = cb.Id;
-			AddedTime = cb.AddedTime;
-			ReleasedTime = cb.ReleasedTime;
-			OpenedTime = cb.OpenedTime;
-			OpenedCount = cb.OpenedCount;
-			CurrentPage = cb.CurrentPage;
-			LastPageRead = cb.LastPageRead;
-			Rating = cb.Rating;
-			ColorAdjustment = cb.ColorAdjustment;
-			EnableDynamicUpdate = cb.EnableDynamicUpdate;
-			EnableProposed = cb.EnableProposed;
-			SeriesComplete = cb.SeriesComplete;
-			Checked = cb.Checked;
-			FilePath = cb.FilePath;
-			FileSize = cb.FileSize;
-			FileModifiedTime = cb.FileModifiedTime;
-			FileCreationTime = cb.FileCreationTime;
-			fileLocation = cb.FileLocation;
-			customThumbnailKey = cb.CustomThumbnailKey;
-			LastOpenedFromListId = cb.LastOpenedFromListId;
-			CustomValuesStore = cb.CustomValuesStore;
-		}
+        public void CopyFrom(ComicBook cb)
+        {
+            SetInfo(cb, onlyUpdateEmpty: false);
+            Id = cb.Id;
+            AddedTime = cb.AddedTime;
+            ReleasedTime = cb.ReleasedTime;
+            OpenedTime = cb.OpenedTime;
+            OpenedCount = cb.OpenedCount;
+            CurrentPage = cb.CurrentPage;
+            LastPageRead = cb.LastPageRead;
+            Rating = cb.Rating;
+            ColorAdjustment = cb.ColorAdjustment;
+            EnableDynamicUpdate = cb.EnableDynamicUpdate;
+            EnableProposed = cb.EnableProposed;
+            SeriesComplete = cb.SeriesComplete;
+            Checked = cb.Checked;
+            FilePath = cb.FilePath;
+            FileSize = cb.FileSize;
+            FileModifiedTime = cb.FileModifiedTime;
+            FileCreationTime = cb.FileCreationTime;
+            fileLocation = cb.FileLocation;
+            customThumbnailKey = cb.CustomThumbnailKey;
+            LastOpenedFromListId = cb.LastOpenedFromListId;
+            CustomValuesStore = cb.CustomValuesStore;
+        }
 
         public void CopyTo(ComicBook cb)
-		{
-			cb.CopyFrom(this);
-		}
+        {
+            cb.CopyFrom(this);
+        }
 
-		public string GetFullTitle(string textFormat, params string[] ignore)
-		{
-			try
-			{
+        public string GetFullTitle(string textFormat, params string[] ignore)
+        {
+            try
+            {
                 return ExtendedStringFormater.Format(textFormat, delegate(string s)
-				{
-					try
-					{
-						if (ignore != null && ignore.Length != 0 && ignore.Contains(s, StringComparer.OrdinalIgnoreCase))
-						{
-							return null;
-						}
-						MapPropertyNameToAsText(s, out var newName);
-						return GetPropertyValue<string>(newName, ComicValueType.Shadow);
-					}
-					catch
-					{
-						return null;
-					}
-				});
-			}
-			catch
-			{
-				return string.Empty;
-			}
-		}
+                {
+                    try
+                    {
+                        if (ignore != null && ignore.Length != 0 && ignore.Contains(s, StringComparer.OrdinalIgnoreCase))
+                        {
+                            return null;
+                        }
+                        MapPropertyNameToAsText(s, out var newName);
+                        return GetPropertyValue<string>(newName, ComicValueType.Shadow);
+                    }
+                    catch
+                    {
+                        return null;
+                    }
+                });
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
 
-		public void SetShadowValues(ComicInfo ci)
-		{
-			ci.Series = ShadowSeries;
-			ci.Count = ShadowCount;
-			ci.Title = ShadowTitle;
-			ci.Year = ShadowYear;
-			ci.Number = ShadowNumber;
-			ci.Format = ShadowFormat;
-			ci.Volume = ShadowVolume;
-		}
+        public void SetShadowValues(ComicInfo ci)
+        {
+            ci.Series = ShadowSeries;
+            ci.Count = ShadowCount;
+            ci.Title = ShadowTitle;
+            ci.Year = ShadowYear;
+            ci.Number = ShadowNumber;
+            ci.Format = ShadowFormat;
+            ci.Volume = ShadowVolume;
+        }
 
-		public void SetFileLocation(string fileLocation)
-		{
-			this.fileLocation = fileLocation;
-		}
+        public void SetFileLocation(string fileLocation)
+        {
+            this.fileLocation = fileLocation;
+        }
 
-		public void MarkAsNotRead()
-		{
-			OpenedTime = DateTime.MinValue;
-			int num2 = (CurrentPage = 0);
-			int num5 = (OpenedCount = (LastPageRead = num2));
-		}
+        public void MarkAsNotRead()
+        {
+            OpenedTime = DateTime.MinValue;
+            int num2 = (CurrentPage = 0);
+            int num5 = (OpenedCount = (LastPageRead = num2));
+        }
 
-		public void MarkAsRead()
-		{
-			if (OpenedCount == 0)
-			{
-				OpenedCount = 1;
-			}
-			OpenedTime = DateTime.Now;
-			if (base.PageCount > 0)
-			{
-				//HACK: When marking as read a book with only 1 page, set it to 1 (Page 2)
-				int currentPage = base.PageCount == 1 ? 1 : base.PageCount - 1;
-				CurrentPage = LastPageRead = currentPage;
-			}
-		}
+        public void MarkAsRead()
+        {
+            if (OpenedCount == 0)
+            {
+                OpenedCount = 1;
+            }
+            OpenedTime = DateTime.Now;
+            if (base.PageCount > 0)
+            {
+                //HACK: When marking as read a book with only 1 page, set it to 1 (Page 2)
+                int currentPage = base.PageCount == 1 ? 1 : base.PageCount - 1;
+                CurrentPage = LastPageRead = currentPage;
+            }
+        }
 
-		public void ResetProperties(int level = 0)
-		{
-			ResetValueAttribute.ResetProperties(this, level);
-		}
+        public void ResetProperties(int level = 0)
+        {
+            ResetValueAttribute.ResetProperties(this, level);
+        }
 
-		public bool RemoveFromContainer()
-		{
-			return Container?.Books.Remove(this) ?? false;
-		}
+        public bool RemoveFromContainer()
+        {
+            return Container?.Books.Remove(this) ?? false;
+        }
 
-		public bool IsSearchable(string propName)
-		{
-			if (searchableProperties == null)
-			{
-				searchableProperties = new HashSet<string>(from pi in GetType().GetProperties().Where(SearchableAttribute.IsSearchable)
-														   select pi.Name);
-			}
-			return searchableProperties.Contains(propName);
-		}
+        public bool IsSearchable(string propName)
+        {
+            if (searchableProperties == null)
+            {
+                searchableProperties = new HashSet<string>(from pi in GetType().GetProperties().Where(SearchableAttribute.IsSearchable)
+                                                           select pi.Name);
+            }
+            return searchableProperties.Contains(propName);
+        }
 
-		public object GetUntypedPropertyValue(string propName)
-		{
-			return GetType().GetProperty(propName).GetValue(this, null);
-		}
+        public object GetUntypedPropertyValue(string propName)
+        {
+            return GetType().GetProperty(propName).GetValue(this, null);
+        }
 
-		public T GetPropertyValue<T>(string propName, ComicValueType cvt = ComicValueType.Standard)
-		{
-			MapPropertyName(propName, out propName, cvt);
-			try
-			{
-				if (!propName.StartsWith("{"))
-				{
-					return PropertyCaller.CreateGetMethod<ComicBook, T>(propName)(this);
-				}
-				propName = propName.Substring(1, propName.Length - 2);
-				return (T)(object)GetCustomValue(propName);
-			}
-			catch (Exception)
-			{
-				return default(T);
-			}
-		}
+        public T GetPropertyValue<T>(string propName, ComicValueType cvt = ComicValueType.Standard)
+        {
+            MapPropertyName(propName, out propName, cvt);
+            try
+            {
+                if (!propName.StartsWith("{"))
+                {
+                    return PropertyCaller.CreateGetMethod<ComicBook, T>(propName)(this);
+                }
+                propName = propName.Substring(1, propName.Length - 2);
+                return (T)(object)GetCustomValue(propName);
+            }
+            catch (Exception)
+            {
+                return default(T);
+            }
+        }
 
-		public string GetStringPropertyValue(string propName, ComicValueType cvt = ComicValueType.Standard)
-		{
-			return GetPropertyValue<string>(propName, cvt) ?? string.Empty;
-		}
+        public string GetStringPropertyValue(string propName, ComicValueType cvt = ComicValueType.Standard)
+        {
+            return GetPropertyValue<string>(propName, cvt) ?? string.Empty;
+        }
 
-		public T GetPropertyValue<T>(string propName, bool proposed)
-		{
-			T propertyValue = GetPropertyValue<T>(propName);
-			if (!proposed || !EnableProposed || !IsDefaultPropertyValue(propertyValue) || !MapPropertyName(propName, out propName, ComicValueType.Proposed))
-			{
-				return propertyValue;
-			}
-			return GetPropertyValue<T>(propName);
-		}
+        public T GetPropertyValue<T>(string propName, bool proposed)
+        {
+            T propertyValue = GetPropertyValue<T>(propName);
+            if (!proposed || !EnableProposed || !IsDefaultPropertyValue(propertyValue) || !MapPropertyName(propName, out propName, ComicValueType.Proposed))
+            {
+                return propertyValue;
+            }
+            return GetPropertyValue<T>(propName);
+        }
 
-		public string FormatString(string format)
-		{
-			return rxField.Replace(format, delegate (Match m)
-			{
-				try
-				{
-					return PropertyCaller.CreateGetMethod<ComicBook, string>(m.Groups[1].Value)(this) ?? string.Empty;
-				}
-				catch (Exception)
-				{
-					return m.Value;
-				}
-			});
-		}
+        public string FormatString(string format)
+        {
+            return rxField.Replace(format, delegate (Match m)
+            {
+                try
+                {
+                    return PropertyCaller.CreateGetMethod<ComicBook, string>(m.Groups[1].Value)(this) ?? string.Empty;
+                }
+                catch (Exception)
+                {
+                    return m.Value;
+                }
+            });
+        }
 
-		public void WriteProposedValues(bool overwriteAll)
-		{
-			if (overwriteAll || string.IsNullOrEmpty(base.Series))
-			{
-				base.Series = ProposedSeries;
-			}
-			if (overwriteAll || string.IsNullOrEmpty(base.Title))
-			{
-				base.Title = ProposedTitle;
-			}
-			if (overwriteAll || base.Year == -1)
-			{
-				base.Year = ProposedYear;
-			}
-			if (overwriteAll || string.IsNullOrEmpty(base.Number))
-			{
-				base.Number = ProposedNumber;
-			}
-			if (overwriteAll || base.Volume == -1)
-			{
-				base.Volume = ProposedVolume;
-			}
-			if (overwriteAll || base.Count == -1)
-			{
-				base.Count = ProposedCount;
-			}
-			if (overwriteAll || string.IsNullOrEmpty(base.Format))
-			{
-				base.Format = ProposedFormat;
-			}
-			EnableProposed = false;
-		}
+        public void WriteProposedValues(bool overwriteAll)
+        {
+            if (overwriteAll || string.IsNullOrEmpty(base.Series))
+            {
+                base.Series = ProposedSeries;
+            }
+            if (overwriteAll || string.IsNullOrEmpty(base.Title))
+            {
+                base.Title = ProposedTitle;
+            }
+            if (overwriteAll || base.Year == -1)
+            {
+                base.Year = ProposedYear;
+            }
+            if (overwriteAll || string.IsNullOrEmpty(base.Number))
+            {
+                base.Number = ProposedNumber;
+            }
+            if (overwriteAll || base.Volume == -1)
+            {
+                base.Volume = ProposedVolume;
+            }
+            if (overwriteAll || base.Count == -1)
+            {
+                base.Count = ProposedCount;
+            }
+            if (overwriteAll || string.IsNullOrEmpty(base.Format))
+            {
+                base.Format = ProposedFormat;
+            }
+            EnableProposed = false;
+        }
 
-		public bool RenameFile(string newName)
-		{
-			if (!IsLinked || !EditMode.IsLocalComic())
-			{
-				return false;
-			}
-			try
-			{
-				newName = FileUtility.MakeValidFilename(newName);
-				string text = Path.Combine(FileDirectory, newName + Path.GetExtension(FilePath));
-				if (string.Equals(FilePath, text, StringComparison.OrdinalIgnoreCase))
-				{
-					return true;
-				}
-				File.Move(FilePath, text);
-				FilePath = text;
-				return true;
-			}
-			catch
-			{
-				return false;
-			}
-		}
+        public bool RenameFile(string newName)
+        {
+            if (!IsLinked || !EditMode.IsLocalComic())
+            {
+                return false;
+            }
+            try
+            {
+                newName = FileUtility.MakeValidFilename(newName);
+                string text = Path.Combine(FileDirectory, newName + Path.GetExtension(FilePath));
+                if (string.Equals(FilePath, text, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+                File.Move(FilePath, text);
+                FilePath = text;
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
 
-		public ComicBookNavigator CreateNavigator()
-		{
-			try
-			{
-				ComicBookNavigator comicBookNavigator = new ComicBookNavigator(this);
-				switch (base.Manga)
-				{
-					case MangaYesNo.Unknown:
-						comicBookNavigator.RightToLeftReading = YesNo.Unknown;
-						break;
-					case MangaYesNo.No:
-					case MangaYesNo.Yes:
-						comicBookNavigator.RightToLeftReading = YesNo.No;
-						break;
-					case MangaYesNo.YesAndRightToLeft:
-						comicBookNavigator.RightToLeftReading = YesNo.Yes;
-						break;
-				}
-				return comicBookNavigator;
-			}
-			catch
-			{
-				return null;
-			}
-		}
+        public ComicBookNavigator CreateNavigator()
+        {
+            try
+            {
+                ComicBookNavigator comicBookNavigator = new ComicBookNavigator(this);
+                switch (base.Manga)
+                {
+                    case MangaYesNo.Unknown:
+                        comicBookNavigator.RightToLeftReading = YesNo.Unknown;
+                        break;
+                    case MangaYesNo.No:
+                    case MangaYesNo.Yes:
+                        comicBookNavigator.RightToLeftReading = YesNo.No;
+                        break;
+                    case MangaYesNo.YesAndRightToLeft:
+                        comicBookNavigator.RightToLeftReading = YesNo.Yes;
+                        break;
+                }
+                return comicBookNavigator;
+            }
+            catch
+            {
+                return null;
+            }
+        }
 
-		public void SetValue(string propertyName, object value)
-		{
-			try
-			{
-				GetType().GetProperty(propertyName).SetValue(this, value, null);
-			}
-			catch (Exception)
-			{
-			}
-		}
+        public void SetValue(string propertyName, object value)
+        {
+            try
+            {
+                GetType().GetProperty(propertyName).SetValue(this, value, null);
+            }
+            catch (Exception)
+            {
+            }
+        }
 
-		public string Hash()
-		{
-			try
-			{
-				if (EditMode.IsLocalComic() && !string.IsNullOrEmpty(FilePath) && File.Exists(FilePath))
-				{
-					return CreateFileHash();
-				}
-			}
-			catch
-			{
-			}
-			return null;
-		}
+        public string Hash()
+        {
+            try
+            {
+                if (EditMode.IsLocalComic() && !string.IsNullOrEmpty(FilePath) && File.Exists(FilePath))
+                {
+                    return CreateFileHash();
+                }
+            }
+            catch
+            {
+            }
+            return null;
+        }
 
-		public void CopyDataFrom(ComicBook data, IEnumerable<string> properties)
-		{
-			Type type = data.GetType();
-			foreach (string property2 in properties)
-			{
-				try
-				{
-					if (property2.StartsWith("{"))
-					{
-						string key = property2.Substring(1, property2.Length - 2);
-						SetCustomValue(key, data.GetCustomValue(key));
-					}
-					else
-					{
-						PropertyInfo property = type.GetProperty(property2);
-						property.SetValue(this, property.GetValue(data, null), null);
-					}
-				}
-				catch
-				{
-				}
-			}
-		}
+        public void CopyDataFrom(ComicBook data, IEnumerable<string> properties)
+        {
+            Type type = data.GetType();
+            foreach (string property2 in properties)
+            {
+                try
+                {
+                    if (property2.StartsWith("{"))
+                    {
+                        string key = property2.Substring(1, property2.Length - 2);
+                        SetCustomValue(key, data.GetCustomValue(key));
+                    }
+                    else
+                    {
+                        PropertyInfo property = type.GetProperty(property2);
+                        property.SetValue(this, property.GetValue(data, null), null);
+                    }
+                }
+                catch
+                {
+                }
+            }
+        }
 
-		public void ToClipboard()
-		{
-			ComicBook comicBook = CloneUtility.Clone(this);
-			comicBook.Id = Guid.NewGuid();
-			comicBook.UnparsedElements = null;
-			DataObject dataObject = new DataObject();
-			dataObject.SetData(DataFormats.UnicodeText, GetInfo().ToXml());
-			dataObject.SetData(ClipboardFormat, comicBook);
-			Clipboard.SetDataObject(dataObject);
-		}
+        public void ToClipboard()
+        {
+            ComicBook comicBook = CloneUtility.Clone(this);
+            comicBook.Id = Guid.NewGuid();
+            comicBook.UnparsedElements = null;
+            DataObject dataObject = new DataObject();
+            dataObject.SetData(DataFormats.UnicodeText, GetInfo().ToXml());
+            dataObject.SetData(ClipboardFormat, comicBook);
+            Clipboard.SetDataObject(dataObject);
+        }
 
-		public bool IsDefaultValue(string property)
-		{
-			PropertyInfo property2 = GetType().GetProperty(property);
-			return object.Equals(property2.GetValue(Default, null), property2.GetValue(this, null));
-		}
+        public bool IsDefaultValue(string property)
+        {
+            PropertyInfo property2 = GetType().GetProperty(property);
+            return object.Equals(property2.GetValue(Default, null), property2.GetValue(this, null));
+        }
 
-		public void ValidateData()
-		{
-			TrimExcessPageInfo();
-			if (!FileIsMissing && FileCreationTime == DateTime.MinValue)
-			{
-				try
-				{
-					FileCreationTime = File.GetCreationTimeUtc(FilePath);
-				}
-				catch (Exception)
-				{
-				}
-			}
-		}
+        public void ValidateData()
+        {
+            TrimExcessPageInfo();
+            if (!FileIsMissing && FileCreationTime == DateTime.MinValue)
+            {
+                try
+                {
+                    FileCreationTime = File.GetCreationTimeUtc(FilePath);
+                }
+                catch (Exception)
+                {
+                }
+            }
+        }
 
-		public void UpdateDynamicPageCount(bool refresh, IProgressState ps = null)
-		{
-			try
-			{
-				using (ImageProvider imageProvider = Providers.Readers.CreateSourceProvider(FilePath))
-				{
-					IDynamicImages dynamicImages = imageProvider as IDynamicImages;
-					if (dynamicImages != null)
-					{
-						dynamicImages.RefreshMode = refresh;
-					}
-					if (ps != null)
-					{
-						imageProvider.ImageReady += delegate (object s, ImageIndexReadyEventArgs e)
-						{
-							ps.ProgressAvailable = base.PageCount > 0;
-							if (ps.ProgressAvailable)
-							{
-								ps.ProgressPercentage = 100 * e.ImageNumber / base.PageCount;
-							}
-						};
-					}
-					imageProvider.Open(async: false);
-					NewPages = Math.Max(imageProvider.Count - base.PageCount, 0);
-				}
-			}
-			catch (Exception)
-			{
-			}
-		}
+        public void UpdateDynamicPageCount(bool refresh, IProgressState ps = null)
+        {
+            try
+            {
+                using (ImageProvider imageProvider = Providers.Readers.CreateSourceProvider(FilePath))
+                {
+                    IDynamicImages dynamicImages = imageProvider as IDynamicImages;
+                    if (dynamicImages != null)
+                    {
+                        dynamicImages.RefreshMode = refresh;
+                    }
+                    if (ps != null)
+                    {
+                        imageProvider.ImageReady += delegate (object s, ImageIndexReadyEventArgs e)
+                        {
+                            ps.ProgressAvailable = base.PageCount > 0;
+                            if (ps.ProgressAvailable)
+                            {
+                                ps.ProgressPercentage = 100 * e.ImageNumber / base.PageCount;
+                            }
+                        };
+                    }
+                    imageProvider.Open(async: false);
+                    NewPages = Math.Max(imageProvider.Count - base.PageCount, 0);
+                }
+            }
+            catch (Exception)
+            {
+            }
+        }
 
-		public bool WriteInfoToFile(bool withRefreshFileProperties = true)
-		{
-			bool success = false;
-			if (!EditMode.IsLocalComic())
-				return false;
+        public bool WriteInfoToFile(bool withRefreshFileProperties = true)
+        {
+            bool success = false;
+            if (!EditMode.IsLocalComic())
+                return false;
 
-			FileInfo fileInfo = new FileInfo(FilePath);
-			if (!fileInfo.Exists || fileInfo.IsReadOnly)
-				return false;
+            FileInfo fileInfo = new FileInfo(FilePath);
+            if (!fileInfo.Exists || fileInfo.IsReadOnly)
+                return false;
 
-			using (ImageProvider imageProvider = CreateImageProvider())
-			{
-				IInfoStorage infoStorage = imageProvider as IInfoStorage;
-				if (infoStorage == null)
-					return false;
+            using (ImageProvider imageProvider = CreateImageProvider())
+            {
+                IInfoStorage infoStorage = imageProvider as IInfoStorage;
+                if (infoStorage == null)
+                    return false;
 
                 EventHandler<IO.Provider.ErrorEventArgs> handler = (object s, IO.Provider.ErrorEventArgs e) => OnWriteError(e.Message);
                 infoStorage.Error += handler; // Trigger event if there's an error during writing info to file
 
                 try
-				{
-					// TODO: find a way that both are updated a the same time
+                {
+                    // TODO: find a way that both are updated a the same time
 					bool updateComicBook = true; // TODO: connect setting
-					success = infoStorage.StoreInfo(GetInfo());
+                    success = infoStorage.StoreInfo(GetInfo());
 
-					// if option to save ComicBook is enabled update the ComicBook.xml
-					if (updateComicBook)
+                    // if option to save ComicBook is enabled update the ComicBook.xml
+                    if (updateComicBook)
                         success &= infoStorage.StoreBook(this.Clone<ComicBook>());
 
                     FileInfoRetrieved = true;
-				}
-				finally
-				{
-					infoStorage.Error -= handler;
                 }
-			}
-			if (withRefreshFileProperties)
-				RefreshFileProperties();
+                finally
+                {
+                    infoStorage.Error -= handler;
+                }
+            }
+            if (withRefreshFileProperties)
+                RefreshFileProperties();
 
-			return success;
-		}
+            return success;
+        }
 
         public void ResetInfoRetrieved()
-		{
-			FileInfoRetrieved = false;
-		}
+        {
+            FileInfoRetrieved = false;
+        }
 
-		public void RefreshInfoFromFile(RefreshInfoOptions options)
-		{
-			if ((options & RefreshInfoOptions.DontReadInformation) != 0 || !EditMode.IsLocalComic() || !IsLinked)
-			{
-				return;
-			}
-			DateTime d = FileModifiedTime;
-			long num = FileSize;
-			RefreshFileProperties(); // Sets FileSize / Timestamps
-			if (FileIsMissing)
-			{
-				return;
-			}
-			bool dateIsModified = FileModifiedTime != d;
-			try
-			{
-				IsDynamicSource = Providers.Readers.GetSourceProviderInfo(FilePath).Formats.All((FileFormat f) => f.Dynamic);
-			}
-			catch (Exception)
-			{
-				IsDynamicSource = false;
-			}
+        public void RefreshInfoFromFile(RefreshInfoOptions options)
+        {
+            if ((options & RefreshInfoOptions.DontReadInformation) != 0 || !EditMode.IsLocalComic() || !IsLinked)
+            {
+                return;
+            }
+            DateTime d = FileModifiedTime;
+            long num = FileSize;
+            RefreshFileProperties(); // Sets FileSize / Timestamps
+            if (FileIsMissing)
+            {
+                return;
+            }
+            bool dateIsModified = FileModifiedTime != d;
+            try
+            {
+                IsDynamicSource = Providers.Readers.GetSourceProviderInfo(FilePath).Formats.All((FileFormat f) => f.Dynamic);
+            }
+            catch (Exception)
+            {
+                IsDynamicSource = false;
+            }
 
-			bool fileInfoIsUpToDate = FileInfoRetrieved && !dateIsModified; //file info has been retrieved and file date has not been modified
-			bool noForceRefresh = options.IsNotSet(RefreshInfoOptions.ForceRefresh); // no force refresh option is requested
-			bool pageCountAlreadyAvailable = options.IsNotSet(RefreshInfoOptions.GetFastPageCount | RefreshInfoOptions.GetPageCount, all: false) || base.PageCount != 0; // page count is already available or the options GetPageCount & GetFastPageCount are not requested // all: false means that if either are set (any) it will return true, without it only does so when both are not set
+            bool fileInfoIsUpToDate = FileInfoRetrieved && !dateIsModified; //file info has been retrieved and file date has not been modified
+            bool noForceRefresh = options.IsNotSet(RefreshInfoOptions.ForceRefresh); // no force refresh option is requested
+            bool pageCountAlreadyAvailable = options.IsNotSet(RefreshInfoOptions.GetFastPageCount | RefreshInfoOptions.GetPageCount, all: false) || base.PageCount != 0; // page count is already available or the options GetPageCount & GetFastPageCount are not requested // all: false means that if either are set (any) it will return true, without it only does so when both are not set
 
-			// Continue refreshing if:
-			// - File info has not been retrieved OR has been modified
-			// - OR ForceRefresh option is set
-			// - OR PageCount is 0 AND a page count option is requested
-			if (fileInfoIsUpToDate && noForceRefresh && pageCountAlreadyAvailable)
-				return;
+            // Continue refreshing if:
+            // - File info has not been retrieved OR has been modified
+            // - OR ForceRefresh option is set
+            // - OR PageCount is 0 AND a page count option is requested
+            if (fileInfoIsUpToDate && noForceRefresh && pageCountAlreadyAvailable)
+                return;
 
-			using (ImageProvider imageProvider = CreateImageProvider())
-			{
-				IInfoStorage infoStorage = imageProvider as IInfoStorage;
-				if (infoStorage == null)
-				{
-					return;
-				}
-				bool forceRefreshInfo = options.HasFlag(RefreshInfoOptions.ForceRefresh);
-				if (forceRefreshInfo || !ComicInfoIsDirty)
-				{
+            using (ImageProvider imageProvider = CreateImageProvider())
+            {
+                IInfoStorage infoStorage = imageProvider as IInfoStorage;
+                if (infoStorage == null)
+                {
+                    return;
+                }
+                bool forceRefreshInfo = options.HasFlag(RefreshInfoOptions.ForceRefresh);
+                if (forceRefreshInfo || !ComicInfoIsDirty)
+                {
                     InfoLoadingMethod method = (dateIsModified || !FileInfoRetrieved) ? InfoLoadingMethod.Complete : InfoLoadingMethod.Fast;
                     ComicInfo ci = infoStorage.LoadInfo(method); // Read ComicInfo.xml
                     SetInfo(ci, !forceRefreshInfo);
@@ -2456,183 +2456,183 @@ namespace cYo.Projects.ComicRack.Engine
                     bool preferComicBook = true; // TODO: connect to a setting
                     if (preferComicBook)
                     {
-						ComicBook cb = infoStorage.LoadBook(method); // Read ComicBook.xml
-						if (cb != null)
-						{
-							cb.SetInfo(ci, onlyUpdateEmpty: false); // Replace ComicBook properties with the ComicInfo ones. In case they differ, info should always have the most up to date information
-							SetBook(cb);  // Copy all properties from the file, not only the ComicInfo ones
+                        ComicBook cb = infoStorage.LoadBook(method); // Read ComicBook.xml
+                        if (cb != null)
+                        {
+                            cb.SetInfo(ci, onlyUpdateEmpty: false); // Replace ComicBook properties with the ComicInfo ones. In case they differ, info should always have the most up to date information
+                            SetBook(cb);  // Copy all properties from the file, not only the ComicInfo ones
                         }
                     }
 
                     if (forceRefreshInfo)
-						ComicInfoIsDirty = false;
-				}
+                        ComicInfoIsDirty = false;
+                }
 
-				// Refresh page count info if:
-				// - The image provider is fast (not slow),
-				// - Either the current page count is unknown or the file size has changed,
-				// - And either:
-				//     - Fast page count is requested and supported by the image provider, or
-				//     - A full page count is explicitly requested
-				bool needsPageCountRefresh = base.PageCount == 0 || num != FileSize;
-				bool wantsFastPageCount = options.HasFlag(RefreshInfoOptions.GetFastPageCount);
-				bool canUseFastPageCount = imageProvider.Capabilities.HasFlag(ImageProviderCapabilities.FastPageInfo);
-				bool wantsFullPageCount = options.HasFlag(RefreshInfoOptions.GetPageCount);
+                // Refresh page count info if:
+                // - The image provider is fast (not slow),
+                // - Either the current page count is unknown or the file size has changed,
+                // - And either:
+                //     - Fast page count is requested and supported by the image provider, or
+                //     - A full page count is explicitly requested
+                bool needsPageCountRefresh = base.PageCount == 0 || num != FileSize;
+                bool wantsFastPageCount = options.HasFlag(RefreshInfoOptions.GetFastPageCount);
+                bool canUseFastPageCount = imageProvider.Capabilities.HasFlag(ImageProviderCapabilities.FastPageInfo);
+                bool wantsFullPageCount = options.HasFlag(RefreshInfoOptions.GetPageCount);
 
-				if (!imageProvider.IsSlow && needsPageCountRefresh && ((wantsFastPageCount && canUseFastPageCount) || wantsFullPageCount))
-				{
-					try
-					{
-						imageProvider.Open(async: false);
-						if (imageProvider.Count > 0)
-						{
-							base.PageCount = imageProvider.Count;
-						}
-					}
-					catch
-					{
-					}
-				}
-			}
-			FileInfoRetrieved = true;
-		}
+                if (!imageProvider.IsSlow && needsPageCountRefresh && ((wantsFastPageCount && canUseFastPageCount) || wantsFullPageCount))
+                {
+                    try
+                    {
+                        imageProvider.Open(async: false);
+                        if (imageProvider.Count > 0)
+                        {
+                            base.PageCount = imageProvider.Count;
+                        }
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+            FileInfoRetrieved = true;
+        }
 
-		public void RefreshInfoFromFile()
-		{
-			RefreshInfoFromFile(RefreshInfoOptions.GetFastPageCount);
-		}
+        public void RefreshInfoFromFile()
+        {
+            RefreshInfoFromFile(RefreshInfoOptions.GetFastPageCount);
+        }
 
-		public string CreateFileHash()
-		{
-			using (ImageProvider imageProvider = CreateImageProvider())
-			{
-				imageProvider.Open(async: false);
-				return imageProvider.CreateHash();
-			}
-		}
+        public string CreateFileHash()
+        {
+            using (ImageProvider imageProvider = CreateImageProvider())
+            {
+                imageProvider.Open(async: false);
+                return imageProvider.CreateHash();
+            }
+        }
 
-		public void RefreshFileProperties()
-		{
-			if (!EditMode.IsLocalComic())
-			{
-				return;
-			}
-			try
-			{
-				FileInfo fileInfo = new FileInfo(FilePath);
-				FileIsMissing = !fileInfo.Exists;
-				if (fileInfo.Exists)
-				{
-					bool flag = fileSize != fileInfo.Length;
-					bool flag2 = fileModifiedTime != fileInfo.LastWriteTimeUtc;
-					fileSize = fileInfo.Length;
-					fileModifiedTime = fileInfo.LastWriteTimeUtc;
-					if (flag)
-					{
-						FireBookChanged("FileSize");
-					}
-					if (flag2)
-					{
-						FireBookChanged("FileModifiedTime");
-					}
-					FileCreationTime = fileInfo.CreationTimeUtc;
-				}
-			}
-			catch
-			{
-				FileIsMissing = true;
-			}
-		}
+        public void RefreshFileProperties()
+        {
+            if (!EditMode.IsLocalComic())
+            {
+                return;
+            }
+            try
+            {
+                FileInfo fileInfo = new FileInfo(FilePath);
+                FileIsMissing = !fileInfo.Exists;
+                if (fileInfo.Exists)
+                {
+                    bool flag = fileSize != fileInfo.Length;
+                    bool flag2 = fileModifiedTime != fileInfo.LastWriteTimeUtc;
+                    fileSize = fileInfo.Length;
+                    fileModifiedTime = fileInfo.LastWriteTimeUtc;
+                    if (flag)
+                    {
+                        FireBookChanged("FileSize");
+                    }
+                    if (flag2)
+                    {
+                        FireBookChanged("FileModifiedTime");
+                    }
+                    FileCreationTime = fileInfo.CreationTimeUtc;
+                }
+            }
+            catch
+            {
+                FileIsMissing = true;
+            }
+        }
 
-		private bool SetProperty<T>(string name, ref T property, T value, bool lockItem = false, bool addUndo = true)
-		{
-			if (object.Equals(property, value))
-				return false;
+        private bool SetProperty<T>(string name, ref T property, T value, bool lockItem = false, bool addUndo = true)
+        {
+            if (object.Equals(property, value))
+                return false;
 
-			if (CheckMultilineEquality(property, value))
-				return false;
+            if (CheckMultilineEquality(property, value))
+                return false;
 
-			T val = property;
-			using (lockItem ? ItemMonitor.Lock(this) : null)
-			{
-				property = value;
-			}
+            T val = property;
+            using (lockItem ? ItemMonitor.Lock(this) : null)
+            {
+                property = value;
+            }
 
-			if (addUndo)
-				FireBookChanged(name, val, value);
-			else
-				FireBookChanged(name);
+            if (addUndo)
+                FireBookChanged(name, val, value);
+            else
+                FireBookChanged(name);
 
-			return true;
-		}
+            return true;
+        }
 
-		private void FireBookChanged(string name)
-		{
-			OnBookChanged(new BookChangedEventArgs(name, isComicInfo: false));
-		}
+        private void FireBookChanged(string name)
+        {
+            OnBookChanged(new BookChangedEventArgs(name, isComicInfo: false));
+        }
 
-		private void FireBookChanged(string name, object oldValue, object newValue)
-		{
-			OnBookChanged(new BookChangedEventArgs(name, isComicInfo: false, oldValue, newValue));
-		}
+        private void FireBookChanged(string name, object oldValue, object newValue)
+        {
+            OnBookChanged(new BookChangedEventArgs(name, isComicInfo: false, oldValue, newValue));
+        }
 
-		private void UpdateProposed()
-		{
-			if (proposed == null)
-			{
-				OnParseFilePath();
-			}
-		}
+        private void UpdateProposed()
+        {
+            if (proposed == null)
+            {
+                OnParseFilePath();
+            }
+        }
 
-		protected virtual void OnFileRenamed(ComicBookFileRenameEventArgs e)
-		{
-			if (this.FileRenamed != null)
-			{
-				this.FileRenamed(this, e);
-			}
-		}
+        protected virtual void OnFileRenamed(ComicBookFileRenameEventArgs e)
+        {
+            if (this.FileRenamed != null)
+            {
+                this.FileRenamed(this, e);
+            }
+        }
 
-		protected virtual void OnCreateComicProvider(CreateComicProviderEventArgs cpea)
-		{
-			if (this.CreateComicProvider != null)
-			{
-				this.CreateComicProvider(this, cpea);
-			}
-		}
+        protected virtual void OnCreateComicProvider(CreateComicProviderEventArgs cpea)
+        {
+            if (this.CreateComicProvider != null)
+            {
+                this.CreateComicProvider(this, cpea);
+            }
+        }
 
-		protected virtual void OnComicProviderCreated(CreateComicProviderEventArgs cpea)
-		{
-			if (this.ComicProviderCreated != null)
-			{
-				this.ComicProviderCreated(this, cpea);
-			}
-		}
+        protected virtual void OnComicProviderCreated(CreateComicProviderEventArgs cpea)
+        {
+            if (this.ComicProviderCreated != null)
+            {
+                this.ComicProviderCreated(this, cpea);
+            }
+        }
 
         protected virtual void OnWriteError(string errorMessage) => this.WriteError?.Invoke(this, new IO.Provider.ErrorEventArgs(errorMessage));
 
         protected override void OnBookChanged(BookChangedEventArgs e)
-		{
-			base.OnBookChanged(e);
-			if (e.PropertyName == "FilePath" || e.PropertyName == "Number" || e.PropertyName == "EnableProposed")
-			{
-				compareNumber = null;
-			}
-			else if (e.PropertyName == "AlternateNumber")
-			{
-				compareAlternateNumber = null;
-			}
-			ClearVirtualTagsCache();
-		}
+        {
+            base.OnBookChanged(e);
+            if (e.PropertyName == "FilePath" || e.PropertyName == "Number" || e.PropertyName == "EnableProposed")
+            {
+                compareNumber = null;
+            }
+            else if (e.PropertyName == "AlternateNumber")
+            {
+                compareAlternateNumber = null;
+            }
+            ClearVirtualTagsCache();
+        }
 
-		public override void SetInfo(ComicInfo ci, bool onlyUpdateEmpty = true, bool updatePages = true)
-		{
-			base.SetInfo(ci, onlyUpdateEmpty, updatePages);
-			LastPageRead = Math.Min(base.PageCount - 1, LastPageRead);
-			CurrentPage = Math.Min(base.PageCount - 1, CurrentPage);
-		}
+        public override void SetInfo(ComicInfo ci, bool onlyUpdateEmpty = true, bool updatePages = true)
+        {
+            base.SetInfo(ci, onlyUpdateEmpty, updatePages);
+            LastPageRead = Math.Min(base.PageCount - 1, LastPageRead);
+            CurrentPage = Math.Min(base.PageCount - 1, CurrentPage);
+        }
 
-		public void SetBook(ComicBook cb)
-		{
+        public void SetBook(ComicBook cb)
+        {
             // Sets these so they are kept and not overwritten by CopyFrom, they are determined by the file and should not be embeded in the ComicBook.xml
             if (!cb.LastOpenedFromListIdSpecified) cb.LastOpenedFromListId = LastOpenedFromListId; // Keep the same ID, unless specified
             cb.FilePath = FilePath; // Keep the same file path
@@ -2643,28 +2643,57 @@ namespace cYo.Projects.ComicRack.Engine
         }
 
         protected override ComicPageInfo OnNewComicPageAdded(ComicPageInfo info)
-		{
-			if (proposed != null && info.ImageIndex < proposed.CoverCount)
-			{
-				info.PageType = ComicPageType.FrontCover;
-			}
-			return info;
-		}
+        {
+            if (proposed != null && info.ImageIndex < proposed.CoverCount)
+            {
+                info.PageType = ComicPageType.FrontCover;
+            }
+            return info;
+        }
 
-		public static ComicBook DeserializeFull(Stream stream)
-		{
-			return XmlUtility.Load<ComicBook>(stream, compressed: false);
-		}
+        public override bool IsSameContent(ComicInfo ci, bool withPages = true)
+        {
+            ComicBook cb = ci as ComicBook;
+            // The commented poperties are not included in the comparison as they are determined by the file and should not be embeded in the ComicBook.xml, so they should not be compared when comparing the content of two ComicBook objects, as they can differ even if the content is the same
+            return cb != null
+                && base.IsSameContent(cb, withPages)
+                //&& Id == cb.Id
+                && AddedTime == cb.AddedTime
+                && ReleasedTime == cb.ReleasedTime
+                && OpenedTime == cb.OpenedTime
+                && OpenedCount == cb.OpenedCount
+                && CurrentPage == cb.CurrentPage
+                && LastPageRead == cb.LastPageRead
+                && Rating == cb.Rating
+                && ColorAdjustment == cb.ColorAdjustment
+                && EnableDynamicUpdate == cb.EnableDynamicUpdate
+                && EnableProposed == cb.EnableProposed
+                && SeriesComplete == cb.SeriesComplete
+                && Checked == cb.Checked
+                //&& FilePath == cb.FilePath
+                //&& FileSize == cb.FileSize
+                //&& FileModifiedTime == cb.FileModifiedTime
+                //&& FileCreationTime == cb.FileCreationTime
+                //&& fileLocation == cb.FileLocation
+                //&& customThumbnailKey == cb.CustomThumbnailKey
+                //&& LastOpenedFromListId == cb.LastOpenedFromListId
+                && CustomValuesStore == cb.CustomValuesStore;
+        }
 
-		public static ComicBook DeserializeFull(string file)
-		{
-			return XmlUtility.Load<ComicBook>(file, compressed: false);
-		}
+        public static ComicBook DeserializeFull(Stream stream)
+        {
+            return XmlUtility.Load<ComicBook>(stream, compressed: false);
+        }
+
+        public static ComicBook DeserializeFull(string file)
+        {
+            return XmlUtility.Load<ComicBook>(file, compressed: false);
+        }
 
         public override void Serialize(Stream outStream)
         {
-			try
-			{
+            try
+            {
                 // Don't include these properties in the exported ComicBook.xml
                 Id = Guid.Empty;
                 FilePath = string.Empty;
@@ -2678,12 +2707,12 @@ namespace cYo.Projects.ComicRack.Engine
                 // TODO: Also Ignore EnableProposed?
 
                 XmlUtility.Store(outStream, this, compressed: false);
-			}
-			catch (Exception)
-			{
+            }
+            catch (Exception)
+            {
 
-				throw;
-			}
+                throw;
+            }
         }
 
         public void SerializeFull(Stream stream)
@@ -2692,286 +2721,286 @@ namespace cYo.Projects.ComicRack.Engine
         }
 
         public void SerializeFull(string file)
-		{
-			XmlUtility.Store(file, this, compressed: false);
-		}
+        {
+            XmlUtility.Store(file, this, compressed: false);
+        }
 
         public static string FormatPages(int pages)
-		{
-			if (pages <= 0)
-			{
-				return unkownText.Value;
-			}
-			return StringUtility.Format(pagesText.Value, pages);
-		}
+        {
+            if (pages <= 0)
+            {
+                return unkownText.Value;
+            }
+            return StringUtility.Format(pagesText.Value, pages);
+        }
 
-		public static string FormatRating(float rating)
-		{
-			if (!(rating <= 0f))
-			{
-				return rating.ToString("0.0");
-			}
-			return noneText.Value;
-		}
+        public static string FormatRating(float rating)
+        {
+            if (!(rating <= 0f))
+            {
+                return rating.ToString("0.0");
+            }
+            return noneText.Value;
+        }
 
-		public static string FormatYear(int year)
-		{
-			if (year != -1)
-			{
-				return year.ToString();
-			}
-			return string.Empty;
-		}
+        public static string FormatYear(int year)
+        {
+            if (year != -1)
+            {
+                return year.ToString();
+            }
+            return string.Empty;
+        }
 
-		public static string FormatNumber(string number, int count)
-		{
-			if (string.IsNullOrEmpty(number))
-			{
-				return string.Empty;
-			}
-			string text = ((number == "-") ? string.Empty : number);
-			if (count >= 0)
-			{
-				text += StringUtility.Format(" ({0} {1})", ofText.Value, count);
-			}
-			return text;
-		}
+        public static string FormatNumber(string number, int count)
+        {
+            if (string.IsNullOrEmpty(number))
+            {
+                return string.Empty;
+            }
+            string text = ((number == "-") ? string.Empty : number);
+            if (count >= 0)
+            {
+                text += StringUtility.Format(" ({0} {1})", ofText.Value, count);
+            }
+            return text;
+        }
 
-		public static string FormatVolume(int volume)
-		{
-			if (volume != -1)
-			{
-				return StringUtility.Format(volumeFormat.Value, volume);
-			}
-			return string.Empty;
-		}
+        public static string FormatVolume(int volume)
+        {
+            if (volume != -1)
+            {
+                return StringUtility.Format(volumeFormat.Value, volume);
+            }
+            return string.Empty;
+        }
 
-		public static string FormatTitle(string textFormat, string series, string title = null, string volumeText = null, string numberText = null, string yearText = null, string monthText = null, string dayText = null, string format = null, string fileName = null)
-		{
-			if (!string.IsNullOrEmpty(series))
-			{
-				try
-				{
-					return ExtendedStringFormater.Format(textFormat, delegate (string s)
-					{
-						switch (s)
-						{
-							case "filename":
-								return fileName;
-							case "series":
-								return series;
-							case "title":
-								return title;
-							case "volume":
-								return volumeText;
-							case "number":
-								return numberText;
-							case "year":
-								return yearText;
-							case "month":
-								return monthText;
-							case "day":
-								return dayText;
-							case "format":
-								if (!series.Contains(format, StringComparison.OrdinalIgnoreCase))
-								{
-									return format;
-								}
-								return string.Empty;
-							default:
-								return null;
-						}
-					}).Trim();
-				}
-				catch
-				{
-				}
-			}
-			return fileName ?? string.Empty;
-		}
+        public static string FormatTitle(string textFormat, string series, string title = null, string volumeText = null, string numberText = null, string yearText = null, string monthText = null, string dayText = null, string format = null, string fileName = null)
+        {
+            if (!string.IsNullOrEmpty(series))
+            {
+                try
+                {
+                    return ExtendedStringFormater.Format(textFormat, delegate (string s)
+                    {
+                        switch (s)
+                        {
+                            case "filename":
+                                return fileName;
+                            case "series":
+                                return series;
+                            case "title":
+                                return title;
+                            case "volume":
+                                return volumeText;
+                            case "number":
+                                return numberText;
+                            case "year":
+                                return yearText;
+                            case "month":
+                                return monthText;
+                            case "day":
+                                return dayText;
+                            case "format":
+                                if (!series.Contains(format, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    return format;
+                                }
+                                return string.Empty;
+                            default:
+                                return null;
+                        }
+                    }).Trim();
+                }
+                catch
+                {
+                }
+            }
+            return fileName ?? string.Empty;
+        }
 
-		private static void AppendUniqueName(StringBuilder s, string delimiter, string text, HashSet<string> uniqueNames)
-		{
-			if (!string.IsNullOrEmpty(text))
-			{
-				var names = text.Split(',', StringSplitOptions.RemoveEmptyEntries);
-				foreach (var name in names)
-				{
-					var trimmedName = name.Trim();
-					if (!string.IsNullOrEmpty(trimmedName) && uniqueNames.Add(trimmedName))
-					{
-						if (s.Length != 0)
-						{
-							s.Append(delimiter);
-						}
-						s.Append(trimmedName);
-					}
-				}
-			}
-		}
+        private static void AppendUniqueName(StringBuilder s, string delimiter, string text, HashSet<string> uniqueNames)
+        {
+            if (!string.IsNullOrEmpty(text))
+            {
+                var names = text.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                foreach (var name in names)
+                {
+                    var trimmedName = name.Trim();
+                    if (!string.IsNullOrEmpty(trimmedName) && uniqueNames.Add(trimmedName))
+                    {
+                        if (s.Length != 0)
+                        {
+                            s.Append(delimiter);
+                        }
+                        s.Append(trimmedName);
+                    }
+                }
+            }
+        }
 
-		public static string FormatDate(DateTime date, ComicDateFormat dateFormat = ComicDateFormat.Long, bool toLocal = false, string missingText = null)
-		{
-			if (date == DateTime.MinValue)
-			{
-				return missingText ?? neverText.Value;
-			}
-			if (toLocal)
-			{
-				date = date.ToLocalTime();
-			}
-			switch (dateFormat)
-			{
-				default:
-					if (!date.IsDateOnly())
-					{
-						return date.ToString();
-					}
-					return date.ToShortDateString();
-				case ComicDateFormat.Short:
-					return date.ToShortDateString();
-				case ComicDateFormat.Long:
-					return date.ToLongDateString();
+        public static string FormatDate(DateTime date, ComicDateFormat dateFormat = ComicDateFormat.Long, bool toLocal = false, string missingText = null)
+        {
+            if (date == DateTime.MinValue)
+            {
+                return missingText ?? neverText.Value;
+            }
+            if (toLocal)
+            {
+                date = date.ToLocalTime();
+            }
+            switch (dateFormat)
+            {
+                default:
+                    if (!date.IsDateOnly())
+                    {
+                        return date.ToString();
+                    }
+                    return date.ToShortDateString();
+                case ComicDateFormat.Short:
+                    return date.ToShortDateString();
+                case ComicDateFormat.Long:
+                    return date.ToLongDateString();
                 case ComicDateFormat.Relative:
-					return date.ToRelativeDateString(DateTime.Now);
-			}
-		}
+                    return date.ToRelativeDateString(DateTime.Now);
+            }
+        }
 
-		public static string FormatFileDate(DateTime date, ComicDateFormat dateFormat = ComicDateFormat.Long)
-		{
-			return FormatDate(date, dateFormat, toLocal: true, notFoundText.Value);
-		}
+        public static string FormatFileDate(DateTime date, ComicDateFormat dateFormat = ComicDateFormat.Long)
+        {
+            return FormatDate(date, dateFormat, toLocal: true, notFoundText.Value);
+        }
 
-		public static string GetLanguageName(string iso)
-		{
-			try
-			{
-				return GetIsoCulture(iso).DisplayName;
-			}
-			catch
-			{
-				return string.Empty;
-			}
-		}
+        public static string GetLanguageName(string iso)
+        {
+            try
+            {
+                return GetIsoCulture(iso).DisplayName;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
 
-		public static CultureInfo GetIsoCulture(string iso)
-		{
-			iso = iso.ToLower();
-			if (languages == null)
-			{
-				languages = new Dictionary<string, CultureInfo>();
-			}
-			new Dictionary<string, CultureInfo>();
-			if (languages.TryGetValue(iso, out var value))
-			{
-				return value;
-			}
-			CultureInfo cultureInfo = CultureInfo.GetCultures(CultureTypes.NeutralCultures).FirstOrDefault((CultureInfo info) => info.TwoLetterISOLanguageName == iso);
-			if (cultureInfo != null)
-			{
-				return languages[iso] = cultureInfo;
-			}
-			return new CultureInfo(string.Empty);
-		}
+        public static CultureInfo GetIsoCulture(string iso)
+        {
+            iso = iso.ToLower();
+            if (languages == null)
+            {
+                languages = new Dictionary<string, CultureInfo>();
+            }
+            new Dictionary<string, CultureInfo>();
+            if (languages.TryGetValue(iso, out var value))
+            {
+                return value;
+            }
+            CultureInfo cultureInfo = CultureInfo.GetCultures(CultureTypes.NeutralCultures).FirstOrDefault((CultureInfo info) => info.TwoLetterISOLanguageName == iso);
+            if (cultureInfo != null)
+            {
+                return languages[iso] = cultureInfo;
+            }
+            return new CultureInfo(string.Empty);
+        }
 
-		public static IEnumerable<string> GetProperties(bool onlyWritable, Type t = null)
-		{
-			return from pi in typeof(ComicBook).GetProperties(BindingFlags.Instance | BindingFlags.Public)
-				   where pi.CanRead && (pi.CanWrite || !onlyWritable) && (t == null || pi.PropertyType == t) && pi.Browsable(forced: true)
-				   select pi.Name;
-		}
+        public static IEnumerable<string> GetProperties(bool onlyWritable, Type t = null)
+        {
+            return from pi in typeof(ComicBook).GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                   where pi.CanRead && (pi.CanWrite || !onlyWritable) && (t == null || pi.PropertyType == t) && pi.Browsable(forced: true)
+                   select pi.Name;
+        }
 
-		public static IEnumerable<string> GetWritableStringProperties()
-		{
-			return GetProperties(onlyWritable: true, typeof(string));
-		}
+        public static IEnumerable<string> GetWritableStringProperties()
+        {
+            return GetProperties(onlyWritable: true, typeof(string));
+        }
 
-		public static IDictionary<string, string> GetTranslatedWritableStringProperties()
-		{
-			TR tr = TR.Load("Columns");
-			return GetWritableStringProperties().ToDictionary((string s) => tr[s].PascalToSpaced());
-		}
+        public static IDictionary<string, string> GetTranslatedWritableStringProperties()
+        {
+            TR tr = TR.Load("Columns");
+            return GetWritableStringProperties().ToDictionary((string s) => tr[s].PascalToSpaced());
+        }
 
-		public static bool MapPropertyName(string propName, out string newName, ComicValueType cvt)
-		{
-			string text = propName.ToLower();
-			if (text == "cover" || text == "rating")
-			{
-				propName += "AsText";
-			}
-			if (cvt != 0)
-			{
-				switch (text)
-				{
-					case "series":
-					case "title":
-					case "format":
-					case "count":
-					case "year":
-					case "number":
-					case "yearastext":
-					case "numberastext":
-					case "volumeastext":
-					case "countastext":
-						newName = ((cvt == ComicValueType.Proposed) ? "Proposed" : "Shadow") + propName;
-						return true;
-				}
-			}
-			newName = propName;
-			return false;
-		}
+        public static bool MapPropertyName(string propName, out string newName, ComicValueType cvt)
+        {
+            string text = propName.ToLower();
+            if (text == "cover" || text == "rating")
+            {
+                propName += "AsText";
+            }
+            if (cvt != 0)
+            {
+                switch (text)
+                {
+                    case "series":
+                    case "title":
+                    case "format":
+                    case "count":
+                    case "year":
+                    case "number":
+                    case "yearastext":
+                    case "numberastext":
+                    case "volumeastext":
+                    case "countastext":
+                        newName = ((cvt == ComicValueType.Proposed) ? "Proposed" : "Shadow") + propName;
+                        return true;
+                }
+            }
+            newName = propName;
+            return false;
+        }
 
-		public static bool MapPropertyNameToAsText(string propName, out string newName)
-		{
-			using (ItemMonitor.Lock(hasAsText))
-			{
-				string text = propName + "AsText";
-				if (hasAsText.TryGetValue(text, out newName) || hasAsText.TryGetValue(propName, out newName))
-					return true;
+        public static bool MapPropertyNameToAsText(string propName, out string newName)
+        {
+            using (ItemMonitor.Lock(hasAsText))
+            {
+                string text = propName + "AsText";
+                if (hasAsText.TryGetValue(text, out newName) || hasAsText.TryGetValue(propName, out newName))
+                    return true;
 
-				if (typeof(ComicBook).GetProperty(text, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Public) != null)
-					propName = text;
+                if (typeof(ComicBook).GetProperty(text, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Public) != null)
+                    propName = text;
 
-				hasAsText[propName] = propName;
-				newName = propName;
-				return true; 
-			}
-		}
+                hasAsText[propName] = propName;
+                newName = propName;
+                return true;
+            }
+        }
 
-		public static bool IsDefaultPropertyValue(object value)
-		{
-			if (value == null)
-			{
-				return true;
-			}
-			if (value is string)
-			{
-				return string.IsNullOrEmpty((string)value);
-			}
-			if (value is int || value is double || value is float)
-			{
-				return (int)value == -1;
-			}
-			if (value is DateTime)
-			{
-				return (DateTime)value == DateTime.MinValue;
-			}
-			return false;
-		}
+        public static bool IsDefaultPropertyValue(object value)
+        {
+            if (value == null)
+            {
+                return true;
+            }
+            if (value is string)
+            {
+                return string.IsNullOrEmpty((string)value);
+            }
+            if (value is int || value is double || value is float)
+            {
+                return (int)value == -1;
+            }
+            if (value is DateTime)
+            {
+                return (DateTime)value == DateTime.MinValue;
+            }
+            return false;
+        }
 
-		protected virtual void OnParseFilePath()
-		{
-			ParseFilePathEventArgs parseFilePathEventArgs = new ParseFilePathEventArgs(FilePath);
-			if (ComicBook.ParseFilePath != null)
-			{
-				ComicBook.ParseFilePath(this, parseFilePathEventArgs);
-			}
-			proposed = parseFilePathEventArgs.NameInfo;
-		}
+        protected virtual void OnParseFilePath()
+        {
+            ParseFilePathEventArgs parseFilePathEventArgs = new ParseFilePathEventArgs(FilePath);
+            if (ComicBook.ParseFilePath != null)
+            {
+                ComicBook.ParseFilePath(this, parseFilePathEventArgs);
+            }
+            proposed = parseFilePathEventArgs.NameInfo;
+        }
 
-		public object Clone()
-		{
-			return new ComicBook(this);
-		}
-	}
+        public object Clone()
+        {
+            return new ComicBook(this);
+        }
+    }
 }

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -2448,8 +2448,7 @@ namespace cYo.Projects.ComicRack.Engine
                     ComicInfo ci = infoStorage.LoadInfo(method); // Read ComicInfo.xml
                     SetInfo(ci, !forceRefreshInfo);
 
-                    bool preferComicBook = true; // TODO: connect to a setting
-                    if (preferComicBook)
+                    if (!EngineConfiguration.Default.IgnoreEmbeddedComicBookXml)
                     {
                         ComicBook cb = infoStorage.LoadBook(method); // Read ComicBook.xml
                         if (cb != null)

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -2380,7 +2380,7 @@ namespace cYo.Projects.ComicRack.Engine
                 try
                 {
 					bool updateComicBook = settings.UpdateComicBookFiles; // Only update if enabled in the Settings
-                    ComicInfo info = updateComicBook ? this.Clone<ComicBook>() : GetInfo();
+                    ComicInfo info = updateComicBook ? this : GetInfo();
                     success = infoStorage.StoreInfo(info); 
                     FileInfoRetrieved = true;
                 }
@@ -2688,19 +2688,25 @@ namespace cYo.Projects.ComicRack.Engine
         {
             try
             {
-                // Don't include these properties in the exported ComicBook.xml
-                Id = Guid.Empty; // related to Library
-                FilePath = string.Empty; // file dependant
-                FileModifiedTime = DateTime.MinValue; // file dependant
-                FileCreationTime = DateTime.MinValue;  // file dependant
-                //AddedTime = DateTime.MinValue; // Keep or not? 
-                FileSize = -1;  // file dependant 
-                LastOpenedFromListId = Guid.Empty; // related to Library
-                CustomThumbnailKey = null; // related to Library
-                ComicInfoIsDirty = false;
-                // Also Ignore EnableProposed?
+                ComicBook cb = this.Clone<ComicBook>(); // Make sure to create a clone so we don't modify the current object by setting these properties to default values
 
-                XmlUtility.Store(outStream, this, compressed: false);
+                // Don't include these properties in the exported ComicBook.xml
+                cb.Id = Guid.Empty; // related to Library
+                cb.FilePath = string.Empty; // file dependant
+                cb.FileModifiedTime = DateTime.MinValue; // file dependant
+                cb.FileCreationTime = DateTime.MinValue;  // file dependant
+                // cb.AddedTime = DateTime.MinValue; // Keep or not? 
+                cb.FileSize = -1;  // file dependant 
+                cb.LastOpenedFromListId = Guid.Empty; // related to Library
+                cb.CustomThumbnailKey = null; // related to Library
+                cb.ComicInfoIsDirty = false;
+                cb.FileInfoRetrieved = false;
+                cb.FileIsMissing = false; // file dependant
+                cb.ExtraSyncInformation = null; // related to sync, probably always null anyway
+                cb.NewPages = 0; // related to dynamic page count, probably should not be included
+                // cb.EnableProposed = true // Also Ignore EnableProposed?
+
+                XmlUtility.Store(outStream, cb, compressed: false);
             }
             catch (Exception)
             {

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -2379,14 +2379,9 @@ namespace cYo.Projects.ComicRack.Engine
 
                 try
                 {
-                    // TODO: find a way that both are updated a the same time
 					bool updateComicBook = true; // TODO: connect setting
-                    bool successBook = true; // Always true so that the final check passes even when updateComicBook is false, otherwise it will be set to the result of StoreBook
-
-                    if (updateComicBook)
-                        successBook = infoStorage.StoreBook(this.Clone<ComicBook>());
-
-                    success = successBook & infoStorage.StoreInfo(GetInfo()); // Do last so that the NTFS Stream of ComicInfo is the one kept. 7-Zip replaces the whole file when updating ComicInfo, so if ComicBook is updated after it, its NTFS Stream will be lost.
+                    ComicInfo info = updateComicBook ? this.Clone<ComicBook>() : GetInfo();
+                    success = infoStorage.StoreInfo(info); 
                     FileInfoRetrieved = true;
                 }
                 finally

--- a/ComicRack.Engine/ComicBook.cs
+++ b/ComicRack.Engine/ComicBook.cs
@@ -487,7 +487,7 @@ namespace cYo.Projects.ComicRack.Engine
 
         public bool ShouldSerializeLastOpenedFromListId() => LastOpenedFromListId != Guid.Empty; // Don't serialize the Id if it's empty
 
-		[XmlAttribute]
+        [XmlAttribute]
 		[DefaultValue(true)]
 		public bool Checked
 		{
@@ -650,7 +650,7 @@ namespace cYo.Projects.ComicRack.Engine
 			}
 		}
 
-		[DefaultValue(null)]
+        [DefaultValue(null)]
 		[ResetValue(0)]
 		public string CustomThumbnailKey
 		{
@@ -2019,7 +2019,7 @@ namespace cYo.Projects.ComicRack.Engine
 			CustomValuesStore = cb.CustomValuesStore;
 		}
 
-		public void CopyTo(ComicBook cb)
+        public void CopyTo(ComicBook cb)
 		{
 			cb.CopyFrom(this);
 		}
@@ -2379,8 +2379,15 @@ namespace cYo.Projects.ComicRack.Engine
 
                 try
 				{
+					// TODO: find a way that both are updated a the same time
+					bool updateComicBook = true; // TODO: connect setting
 					success = infoStorage.StoreInfo(GetInfo());
-					FileInfoRetrieved = true;
+
+					// if option to save ComicBook is enabled update the ComicBook.xml
+					if (updateComicBook)
+                        success &= infoStorage.StoreBook(this.Clone<ComicBook>());
+
+                    FileInfoRetrieved = true;
 				}
 				finally
 				{
@@ -2457,7 +2464,7 @@ namespace cYo.Projects.ComicRack.Engine
                         }
                     }
 
-					if (forceRefreshInfo)
+                    if (forceRefreshInfo)
 						ComicInfoIsDirty = false;
 				}
 
@@ -2635,7 +2642,7 @@ namespace cYo.Projects.ComicRack.Engine
             CopyFrom(cb);
         }
 
-		protected override ComicPageInfo OnNewComicPageAdded(ComicPageInfo info)
+        protected override ComicPageInfo OnNewComicPageAdded(ComicPageInfo info)
 		{
 			if (proposed != null && info.ImageIndex < proposed.CoverCount)
 			{
@@ -2654,9 +2661,24 @@ namespace cYo.Projects.ComicRack.Engine
 			return XmlUtility.Load<ComicBook>(file, compressed: false);
 		}
 
-		public void SerializeFull(Stream stream)
+		public void SerializeFull(Stream stream, bool onlyPortable = false)
 		{
-			XmlUtility.Store(stream, this, compressed: false);
+            if (onlyPortable)
+            {
+                // Don't include these properties in the exported ComicBook.xml
+                Id = Guid.Empty;
+                FilePath = string.Empty;
+                FileModifiedTime = DateTime.MinValue;
+                FileCreationTime = DateTime.MinValue;
+                AddedTime = DateTime.MinValue; // Keep or not?
+                FileSize = -1;
+                LastOpenedFromListId = Guid.Empty;
+                CustomThumbnailKey = null;
+                ComicInfoIsDirty = false;
+                // TODO: Also Ignore EnableProposed? 
+            }
+
+            XmlUtility.Store(stream, this, compressed: false);
 		}
 
 		public void SerializeFull(string file)
@@ -2666,24 +2688,9 @@ namespace cYo.Projects.ComicRack.Engine
 
         public byte[] ToArrayFull(bool onlyPortable = false)
         {
-			if (onlyPortable)
-			{
-				// Don't include these properties in the exported ComicBook.xml
-				Id = Guid.Empty;
-				FilePath = string.Empty;
-				FileModifiedTime = DateTime.MinValue;
-				FileCreationTime = DateTime.MinValue;
-				AddedTime = DateTime.MinValue; // Keep or not?
-				FileSize = -1;
-				LastOpenedFromListId = Guid.Empty;
-				CustomThumbnailKey = null;
-				ComicInfoIsDirty = false;
-				// TODO: Also Ignore EnableProposed? 
-			}
-
             using (MemoryStream memoryStream = new MemoryStream())
             {
-                SerializeFull(memoryStream);
+                SerializeFull(memoryStream, onlyPortable);
                 return memoryStream.ToArray();
             }
         }

--- a/ComicRack.Engine/ComicInfo.cs
+++ b/ComicRack.Engine/ComicInfo.cs
@@ -1486,7 +1486,7 @@ namespace cYo.Projects.ComicRack.Engine
 			return false;
 		}
 
-		public void Serialize(Stream outStream)
+		public virtual void Serialize(Stream outStream)
 		{
 			try
 			{

--- a/ComicRack.Engine/ComicInfo.cs
+++ b/ComicRack.Engine/ComicInfo.cs
@@ -1473,7 +1473,7 @@ namespace cYo.Projects.ComicRack.Engine
 			}
 		}
 
-		public virtual bool IsSameContent(ComicInfo ci, bool withPages = true)
+		public virtual bool IsSameContent(ComicInfo ci, bool withPages = true, bool onlyComicInfo = true)
 		{
 			if (ci != null && ci.Writer == Writer && ci.Publisher == Publisher && ci.Imprint == Imprint && ci.Inker == Inker && ci.Penciller == Penciller && ci.Title == Title && ci.Number == Number && ci.Count == Count && ci.Summary == Summary && ci.Series == Series && ci.Volume == Volume && ci.AlternateSeries == AlternateSeries && ci.AlternateNumber == AlternateNumber && ci.AlternateCount == AlternateCount && ci.StoryArc == StoryArc && ci.SeriesGroup == SeriesGroup && ci.Year == Year && ci.Month == Month && ci.Day == Day && ci.Notes == Notes && ci.Review == Review && ci.Genre == Genre && ci.Colorist == Colorist && ci.Editor == Editor && ci.Translator == Translator && ci.Letterer == Letterer && ci.CoverArtist == CoverArtist && ci.Web == Web && ci.LanguageISO == LanguageISO && ci.PageCount == PageCount && ci.Format == Format && ci.AgeRating == AgeRating && ci.BlackAndWhite == BlackAndWhite && ci.Manga == Manga && ci.Characters == Characters && ci.Teams == Teams && ci.MainCharacterOrTeam == MainCharacterOrTeam && ci.Locations == Locations && ci.ScanInformation == ScanInformation && ci.Tags == Tags)
 			{

--- a/ComicRack.Engine/ComicInfo.cs
+++ b/ComicRack.Engine/ComicInfo.cs
@@ -1473,7 +1473,7 @@ namespace cYo.Projects.ComicRack.Engine
 			}
 		}
 
-		public bool IsSameContent(ComicInfo ci, bool withPages = true)
+		public virtual bool IsSameContent(ComicInfo ci, bool withPages = true)
 		{
 			if (ci != null && ci.Writer == Writer && ci.Publisher == Publisher && ci.Imprint == Imprint && ci.Inker == Inker && ci.Penciller == Penciller && ci.Title == Title && ci.Number == Number && ci.Count == Count && ci.Summary == Summary && ci.Series == Series && ci.Volume == Volume && ci.AlternateSeries == AlternateSeries && ci.AlternateNumber == AlternateNumber && ci.AlternateCount == AlternateCount && ci.StoryArc == StoryArc && ci.SeriesGroup == SeriesGroup && ci.Year == Year && ci.Month == Month && ci.Day == Day && ci.Notes == Notes && ci.Review == Review && ci.Genre == Genre && ci.Colorist == Colorist && ci.Editor == Editor && ci.Translator == Translator && ci.Letterer == Letterer && ci.CoverArtist == CoverArtist && ci.Web == Web && ci.LanguageISO == LanguageISO && ci.PageCount == PageCount && ci.Format == Format && ci.AgeRating == AgeRating && ci.BlackAndWhite == BlackAndWhite && ci.Manga == Manga && ci.Characters == Characters && ci.Teams == Teams && ci.MainCharacterOrTeam == MainCharacterOrTeam && ci.Locations == Locations && ci.ScanInformation == ScanInformation && ci.Tags == Tags)
 			{
@@ -1510,7 +1510,7 @@ namespace cYo.Projects.ComicRack.Engine
 			}
 		}
 
-		public static ComicInfo LoadFromSidecar(string file)
+		public static T LoadFromSidecar<T>(string file, Func<Stream, T> deserializeDelegate)
 		{
 			try
 			{
@@ -1519,12 +1519,12 @@ namespace cYo.Projects.ComicRack.Engine
 				string sidecarFile = File.Exists(sidecar1) ? sidecar1 : sidecar2;
 				using (FileStream inStream = File.OpenRead(sidecarFile))
 				{
-					return Deserialize(inStream);
+					return deserializeDelegate(inStream);
 				} 
 			}
 			catch (Exception)
 			{
-				return null;
+				return default;
 			}
 		}
 

--- a/ComicRack.Engine/ComicInfo.cs
+++ b/ComicRack.Engine/ComicInfo.cs
@@ -1173,13 +1173,14 @@ namespace cYo.Projects.ComicRack.Engine
 
 		private void FireBookChanged(string name, object oldValue, object newValue)
 		{
-			OnBookChanged(new BookChangedEventArgs(name, isComicInfo: true, oldValue, newValue));
+			OnBookChanged(new BookChangedEventArgs(name, comicInfoType: ComicInfoType.ComicInfo, oldValue, newValue));
 		}
 
 		private void FirePageChanged(int page, bool updateComicInfo = true)
 		{
+			ComicInfoType infoType = updateComicInfo ? ComicInfoType.ComicInfo : ComicInfoType.None;
 			cachedFrontCoverPageIndex = (cachedFrontCoverCount = -1);
-			OnBookChanged(new BookChangedEventArgs("Pages", page, updateComicInfo));
+			OnBookChanged(new BookChangedEventArgs("Pages", page, infoType));
 		}
 
 		protected virtual void OnBookChanged(BookChangedEventArgs e)

--- a/ComicRack.Engine/ComicInfo.cs
+++ b/ComicRack.Engine/ComicInfo.cs
@@ -1537,7 +1537,7 @@ namespace cYo.Projects.ComicRack.Engine
 			}
 		}
 
-		public string ToXml()
+        public string ToXml()
 		{
 			return Encoding.Default.GetString(ToArray());
 		}

--- a/ComicRack.Engine/Database/ComicLibrary.cs
+++ b/ComicRack.Engine/Database/ComicLibrary.cs
@@ -271,8 +271,9 @@ namespace cYo.Projects.ComicRack.Engine.Database
 			comicListItemFolder.Items.Add(comicSmartListItem);
 			comicSmartListItem = new ComicSmartListItem(ComicBook.TR["FilesUpdateList", "Files to update"]);
 			comicSmartListItem.Matchers.Add(typeof(ComicBookModifiedInfoMatcher), 0, "", "");
-			comicListItemFolder.Items.Add(comicSmartListItem);
-		}
+            //comicSmartListItem.Matchers.Add(typeof(ComicBookModifiedLibraryInfoMatcher), 0, "", ""); // Disabled by default, can be added manually instead
+            comicListItemFolder.Items.Add(comicSmartListItem);
+        }
 
 		public static ShareableComicListItem DefaultReadingList(ComicLibrary lib = null)
 		{

--- a/ComicRack.Engine/EngineConfiguration.cs
+++ b/ComicRack.Engine/EngineConfiguration.cs
@@ -614,6 +614,9 @@ namespace cYo.Projects.ComicRack.Engine
 		[DefaultValue(false)]
 		public bool UseLegacyZipConfiguration { get; set; } // If true, will use the old configuration when creating CBZ files. When false, will use the new configuration which sets the NTFS extra field and sets the compression method to Stored when no compression is used.
 
+        [DefaultValue(false)]
+        public bool IgnoreEmbeddedComicBookXml { get; set; } // If true, the embedded ComicBook.xml file in CBZ/CBR/CB7/CBT files will be ignored when reading comic books.
+
         public EngineConfiguration()
 		{
 			PageScrollingDuration = 1000;
@@ -677,6 +680,7 @@ namespace cYo.Projects.ComicRack.Engine
 			JpegXLEncoderEffort = 7;
             ForceJpegReconstruction = false;
 			UseLegacyZipConfiguration = false;
+            IgnoreEmbeddedComicBookXml = false;
         }
 
         public string GetTempFileName()

--- a/ComicRack.Engine/IComicUpdateSettings.cs
+++ b/ComicRack.Engine/IComicUpdateSettings.cs
@@ -13,5 +13,11 @@ namespace cYo.Projects.ComicRack.Engine
 			get;
 			set;
 		}
-	}
+
+		bool UpdateComicBookFiles
+		{
+			get;
+			set;
+        }
+    }
 }

--- a/ComicRack.Engine/IO/ComicExporter.cs
+++ b/ComicRack.Engine/IO/ComicExporter.cs
@@ -21,19 +21,21 @@ namespace cYo.Projects.ComicRack.Engine.IO
 
 		private ComicInfo comicInfo;
 
-		private volatile string lastError;
+		private ComicBook comicBook;
+
+        private volatile string lastError;
 
 		private readonly int sequence;
 
 		public ExportSetting Setting => setting;
 
-		public ComicBook ComicBook => comicBooks[0];
+		public ComicBook ComicBook => comicBook;
 
-		public List<ComicBook> ComicBooks => comicBooks;
+        public List<ComicBook> ComicBooks => comicBooks;
 
 		public ComicInfo ComicInfo => comicInfo;
 
-		public string LastError => lastError;
+        public string LastError => lastError;
 
 		public int Sequence => sequence;
 
@@ -46,9 +48,11 @@ namespace cYo.Projects.ComicRack.Engine.IO
 		public ComicExporter(IEnumerable<ComicBook> books, ExportSetting setting, int sequence)
 		{
 			comicBooks = books.ToList();
-			comicInfo = CombinedComics.GetComicInfo(comicBooks);
+            comicBook = comicBooks[0].Clone<ComicBook>();
+			comicInfo = CombinedComics.GetComicInfo(comicBooks); // This returns a new instance
 			comicInfo.Tags = comicInfo.Tags.AppendUniqueValueToList(setting.TagsToAppend);
-			this.setting = setting;
+            comicBook.SetInfo(comicInfo, onlyUpdateEmpty: false); // Replace values in the ComicBook with the new Combined ComicInfo
+            this.setting = setting;
 			this.sequence = sequence;
 		}
 
@@ -99,15 +103,16 @@ namespace cYo.Projects.ComicRack.Engine.IO
 								if (File.Exists(targetPath))
 								{
 									tempFile = EngineConfiguration.Default.GetTempFileName();
-									comicInfo = storageProvider.Store(provider, comicInfo, tempFile, setting);
-									ShellFile.DeleteFile(targetPath);
+                                    // Pass comicBook instead of comicInfo because it may export a ComicBook.xml and comicInfo is a new instance
+                                    comicInfo = storageProvider.Store(provider, comicBook, tempFile, setting); 
+                                    ShellFile.DeleteFile(targetPath);
 									File.Move(tempFile, targetPath);
 								}
 								else
 								{
-									comicInfo = storageProvider.Store(provider, comicInfo, targetPath, setting);
+                                    comicInfo = storageProvider.Store(provider, comicBook, targetPath, setting);
 								}
-							}
+                            }
 							finally
 							{
 								storageProvider.Progress -= writer_Progress;

--- a/ComicRack.Engine/IO/Network/ComicLibraryClient.cs
+++ b/ComicRack.Engine/IO/Network/ComicLibraryClient.cs
@@ -103,6 +103,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Network
 				{
 					book.FileInfoRetrieved = true;
 					book.ComicInfoIsDirty = false;
+					book.ComicBookIsDirty = false;
 					book.SetFileLocation($"REMOTE:{comicLibrary.Id}\\{book.FilePath}");
 					book.CreateComicProvider += CreateComicProvider;
 					if (ShareInformation.IsEditable)

--- a/ComicRack.Engine/IO/Provider/IInfoStorage.cs
+++ b/ComicRack.Engine/IO/Provider/IInfoStorage.cs
@@ -9,5 +9,6 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
         bool StoreInfo(ComicInfo comicInfo);
 
 		ComicInfo LoadInfo(InfoLoadingMethod method);
+        ComicBook LoadBook(InfoLoadingMethod method);
 	}
 }

--- a/ComicRack.Engine/IO/Provider/IInfoStorage.cs
+++ b/ComicRack.Engine/IO/Provider/IInfoStorage.cs
@@ -7,7 +7,6 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
         event EventHandler<ErrorEventArgs> Error;
 
         bool StoreInfo(ComicInfo comicInfo);
-        bool StoreBook(ComicBook comicInfo);
 
         ComicInfo LoadInfo(InfoLoadingMethod method);
         ComicBook LoadBook(InfoLoadingMethod method);

--- a/ComicRack.Engine/IO/Provider/IInfoStorage.cs
+++ b/ComicRack.Engine/IO/Provider/IInfoStorage.cs
@@ -7,8 +7,9 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
         event EventHandler<ErrorEventArgs> Error;
 
         bool StoreInfo(ComicInfo comicInfo);
+        bool StoreBook(ComicBook comicInfo);
 
-		ComicInfo LoadInfo(InfoLoadingMethod method);
+        ComicInfo LoadInfo(InfoLoadingMethod method);
         ComicBook LoadBook(InfoLoadingMethod method);
-	}
+    }
 }

--- a/ComicRack.Engine/IO/Provider/NtfsInfoStorage.cs
+++ b/ComicRack.Engine/IO/Provider/NtfsInfoStorage.cs
@@ -26,7 +26,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 		private static bool Store<T>(string file, T comicInfo, string stream, Func<Stream, T> deserializationDelegate, bool append = false) where T: ComicInfo
 		{
 			T ci = Load(file, stream, deserializationDelegate);
-			if (comicInfo.IsSameContent(ci))
+			if (comicInfo.IsSameContent(ci, onlyComicInfo: false))
 				return false;
 
 			try

--- a/ComicRack.Engine/IO/Provider/NtfsInfoStorage.cs
+++ b/ComicRack.Engine/IO/Provider/NtfsInfoStorage.cs
@@ -36,8 +36,16 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 		}
 
 
-		public static ComicInfo LoadInfo(string file) => Load(file, ComicBookInfoStream, comicInfoDeserializationDelegate);
-		public static ComicBook LoadBook(string file) => Load(file, ComicBookStream, comicBookDeserializationDelegate);
+		public static T LoadInfo<T>(string file) where T : ComicInfo
+		{
+			return typeof(T) switch
+			{
+				Type t when t == typeof(ComicInfo) => Load(file, ComicBookInfoStream, comicInfoDeserializationDelegate) as T,
+				Type t when t == typeof(ComicBook) => Load(file, ComicBookStream, comicBookDeserializationDelegate) as T,
+				_ => throw new NotSupportedException($"Type {typeof(T).FullName} is not supported for loading.")
+			};
+		}
+
 		public static T Load<T>(string file, string stream, Func<Stream, T> deserializationDelegate)
 		{
 			try

--- a/ComicRack.Engine/IO/Provider/NtfsInfoStorage.cs
+++ b/ComicRack.Engine/IO/Provider/NtfsInfoStorage.cs
@@ -12,8 +12,17 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 		private static Func<Stream, ComicInfo> comicInfoDeserializationDelegate => ComicInfo.Deserialize;
 		private static Func<Stream, ComicBook> comicBookDeserializationDelegate => ComicBook.DeserializeFull;
 
-		public static bool StoreInfo(string file, ComicInfo comicInfo) => Store(file, comicInfo, ComicBookInfoStream, comicInfoDeserializationDelegate);
-        public static bool StoreBook(string file, ComicBook comicbook) => Store(file, comicbook, ComicBookStream, comicBookDeserializationDelegate);
+
+		public static bool StoreInfo(string file, ComicInfo comicInfo)
+		{
+			bool success = false;
+            success = Store(file, new ComicInfo(comicInfo), ComicBookInfoStream, comicInfoDeserializationDelegate); // Store ComicInfo.xml
+            if (comicInfo is ComicBook) // When it's a ComicBook we also want to store the ComicBook stream
+                success &= Store(file, comicInfo, ComicBookStream, comicBookDeserializationDelegate); // ComicBook.xml
+
+			return success;
+        }
+
 		private static bool Store<T>(string file, T comicInfo, string stream, Func<Stream, T> deserializationDelegate, bool append = false) where T: ComicInfo
 		{
 			T ci = Load(file, stream, deserializationDelegate);

--- a/ComicRack.Engine/IO/Provider/NtfsInfoStorage.cs
+++ b/ComicRack.Engine/IO/Provider/NtfsInfoStorage.cs
@@ -7,21 +7,26 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 	public static class NtfsInfoStorage
 	{
 		public const string ComicBookInfoStream = "ComicRackInfo";
+		public const string ComicBookStream = "ComicRackBook";
 
-		public static bool StoreInfo(string file, ComicInfo comicInfo)
+		private static Func<Stream, ComicInfo> comicInfoDeserializationDelegate => ComicInfo.Deserialize;
+		private static Func<Stream, ComicBook> comicBookDeserializationDelegate => ComicBook.DeserializeFull;
+
+		public static bool StoreInfo(string file, ComicInfo comicInfo) => Store(file, comicInfo, ComicBookInfoStream, comicInfoDeserializationDelegate);
+        public static bool StoreBook(string file, ComicBook comicbook) => Store(file, comicbook, ComicBookStream, comicBookDeserializationDelegate);
+		private static bool Store<T>(string file, T comicInfo, string stream, Func<Stream, T> deserializationDelegate, bool append = false) where T: ComicInfo
 		{
-			ComicInfo ci = LoadInfo(file);
+			T ci = Load(file, stream, deserializationDelegate);
 			if (comicInfo.IsSameContent(ci))
-			{
 				return false;
-			}
+
 			try
 			{
 				FileInfo fileInfo = new FileInfo(file);
-				using (StreamWriter streamWriter = AlternateDataStreamFile.CreateText(file, ComicBookInfoStream))
+				using (StreamWriter streamWriter = AlternateDataStreamFile.CreateText(file, stream))
 				{
-					comicInfo.Serialize(streamWriter.BaseStream);
-					return true;
+                    comicInfo.Serialize(streamWriter.BaseStream);
+                    return true;
 				}
 			}
 			catch (Exception)
@@ -30,33 +35,36 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider
 			}
 		}
 
-		public static ComicInfo LoadInfo(string file)
+
+		public static ComicInfo LoadInfo(string file) => Load(file, ComicBookInfoStream, comicInfoDeserializationDelegate);
+		public static ComicBook LoadBook(string file) => Load(file, ComicBookStream, comicBookDeserializationDelegate);
+		public static T Load<T>(string file, string stream, Func<Stream, T> deserializationDelegate)
 		{
 			try
 			{
-				if (!AlternateDataStreamFile.Exists(file, ComicBookInfoStream))
+				if (!AlternateDataStreamFile.Exists(file, stream))
+					return default;
+
+				using (StreamReader streamReader = AlternateDataStreamFile.OpenText(file, stream))
 				{
-					return null;
-				}
-				using (StreamReader streamReader = AlternateDataStreamFile.OpenText(file, ComicBookInfoStream))
-				{
-					return ComicInfo.Deserialize(streamReader.BaseStream);
+					return deserializationDelegate(streamReader.BaseStream);
 				}
 			}
 			catch (Exception)
 			{
-				return null;
+				return default;
 			}
 		}
 
-		public static void ClearInfo(string file)
+
+		public static void ClearInfo(string file) => Clear(file, ComicBookInfoStream);
+		public static void ClearBook(string file) => Clear(file, ComicBookStream);
+		public static void Clear(string file, string stream)
 		{
 			try
 			{
-				if (AlternateDataStreamFile.Exists(file, ComicBookInfoStream))
-				{
-					AlternateDataStreamFile.Delete(file, ComicBookInfoStream);
-				}
+				if (AlternateDataStreamFile.Exists(file, stream))
+					AlternateDataStreamFile.Delete(file, stream);
 			}
 			catch (Exception)
 			{

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/ArchiveComicProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/ArchiveComicProvider.cs
@@ -33,17 +33,12 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
 			return imageArchive.ReadByteImage(base.Source, GetFile(index));
 		}
 
-		protected override ComicInfo OnLoadInfo()
+		protected override T OnLoadInfo<T>()
 		{
-			return imageArchive.ReadInfo(base.Source);
+			return imageArchive.ReadInfo<T>(base.Source);
 		}
 
-        protected override ComicBook OnLoadBook()
-        {
-            return imageArchive.ReadBook(base.Source);
-        }
-
-        protected override bool OnStoreInfo(ComicInfo comicInfo)
+		protected override bool OnStoreInfo(ComicInfo comicInfo)
 		{
 			try
 			{
@@ -53,23 +48,10 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
 			{
 				OnError(ex.Message);
 				return false;
-            }
+			}
 		}
 
-		protected override bool OnStoreBook(ComicBook comicBook)
-		{
-			try
-			{
-				return imageArchive.WriteBook(base.Source, comicBook);
-			}
-			catch (WriteErrorException ex)
-			{
-				OnError(ex.Message);
-				return false;
-			}
-        }
-
-        protected override bool OnFastFormatCheck(string source)
+		protected override bool OnFastFormatCheck(string source)
 		{
 			return imageArchive.IsFormat(source);
 		}
@@ -79,8 +61,8 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
 			using (IItemLock<List<ProviderImageInfo>> itemLock = GetCachedFileList())
 			{
 				List<ProviderImageInfo> list = new List<ProviderImageInfo>(itemLock.Item.Where((ProviderImageInfo ii) => IsSupportedImage(ii)));
-                list.Sort((a, b) => cYo.Common.Text.ExtendedStringComparer.Compare(a.Name, b.Name, ExtendedStringComparison.IgnoreCase));
-                foundImageList = list;
+				list.Sort((a, b) => cYo.Common.Text.ExtendedStringComparer.Compare(a.Name, b.Name, ExtendedStringComparison.IgnoreCase));
+				foundImageList = list;
 			}
 			foreach (ProviderImageInfo foundImage in foundImageList)
 			{

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/ArchiveComicProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/ArchiveComicProvider.cs
@@ -38,6 +38,11 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
 			return imageArchive.ReadInfo(base.Source);
 		}
 
+        protected override ComicBook OnLoadBook()
+        {
+            return imageArchive.ReadBook(base.Source);
+        }
+
 		protected override bool OnStoreInfo(ComicInfo comicInfo)
 		{
 			try

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/ArchiveComicProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/ArchiveComicProvider.cs
@@ -43,7 +43,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
             return imageArchive.ReadBook(base.Source);
         }
 
-		protected override bool OnStoreInfo(ComicInfo comicInfo)
+        protected override bool OnStoreInfo(ComicInfo comicInfo)
 		{
 			try
 			{
@@ -56,7 +56,20 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
             }
 		}
 
-		protected override bool OnFastFormatCheck(string source)
+		protected override bool OnStoreBook(ComicBook comicBook)
+		{
+			try
+			{
+				return imageArchive.WriteBook(base.Source, comicBook);
+			}
+			catch (WriteErrorException ex)
+			{
+				OnError(ex.Message);
+				return false;
+			}
+        }
+
+        protected override bool OnFastFormatCheck(string source)
 		{
 			return imageArchive.IsFormat(source);
 		}

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/FileBasedAccessor.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/FileBasedAccessor.cs
@@ -26,9 +26,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
 
 		public abstract byte[] ReadByteImage(string source, ProviderImageInfo info);
 
-		public abstract ComicInfo ReadInfo(string source);
-
-        public abstract ComicBook ReadBook(string source);
+		public abstract T ReadInfo<T>(string source) where T : ComicInfo;
 
 		public virtual bool WriteInfo(string source, ComicInfo info)
 		{

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/FileBasedAccessor.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/FileBasedAccessor.cs
@@ -30,12 +30,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
 
 		public virtual bool WriteInfo(string source, ComicInfo info)
 		{
-			return SevenZipEngine.UpdateComicInfo(source, Format, standalone: false, comicInfo: info); // Since SevenZip is still used for updates when another engine is set and since the format might not be supported by the standalone exe, we need to use the console (32bit) version.
-        }
-
-        public virtual bool WriteBook(string source, ComicBook book)
-        {
-            return SevenZipEngine.UpdateComicInfo(source, Format, standalone: false, comicInfo: book); // Since SevenZip is still used for updates when another engine is set and since the format might not be supported by the standalone exe, we need to use the console (32bit) version.
+			return SevenZipEngine.UpdateComicInfos(source, Format, standalone: false, comicInfo: info); // Since SevenZip is still used for updates when another engine is set and since the format might not be supported by the standalone exe, we need to use the console (32bit) version.
         }
 
         public virtual bool IsFormat(string source)

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/FileBasedAccessor.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/FileBasedAccessor.cs
@@ -28,12 +28,19 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
 
 		public abstract ComicInfo ReadInfo(string source);
 
+        public abstract ComicBook ReadBook(string source);
+
 		public virtual bool WriteInfo(string source, ComicInfo info)
 		{
 			return SevenZipEngine.UpdateComicInfo(source, Format, standalone: false, comicInfo: info); // Since SevenZip is still used for updates when another engine is set and since the format might not be supported by the standalone exe, we need to use the console (32bit) version.
         }
 
-		public virtual bool IsFormat(string source)
+        public virtual bool WriteBook(string source, ComicBook book)
+        {
+            return SevenZipEngine.UpdateComicInfo(source, Format, standalone: false, comicInfo: book); // Since SevenZip is still used for updates when another engine is set and since the format might not be supported by the standalone exe, we need to use the console (32bit) version.
+        }
+
+        public virtual bool IsFormat(string source)
 		{
 			if (signature == null)
 			{
@@ -54,5 +61,6 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
 			}
 			return true;
 		}
-	}
+
+    }
 }

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/SevenZipEngine.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/SevenZipEngine.cs
@@ -262,15 +262,11 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
         {
             try
             {
-                ComicBook comicBook = comicInfo as ComicBook;
-                bool isComicBook = comicBook != null;
-                string filename = isComicBook ? "ComicBook.xml" : "ComicInfo.xml";
-
+                string filename = comicInfo is ComicBook ? "ComicBook.xml" : "ComicInfo.xml";
                 if (updateSetting.InlineUpdate)
                 {
-                    byte[] data = isComicBook ? comicBook?.ToArrayFull(onlyPortable: true) : comicInfo.ToArray();
                     string parameters = $"u -t{updateSetting.arg} -si{filename} \"{file}\"";
-                    return ExecuteUpdateProcess(parameters, standalone, data);
+                    return ExecuteUpdateProcess(parameters, standalone, comicInfo.ToArray());
                 }
                 else
                 {
@@ -282,10 +278,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
                         XmlUtility.Store(tempPath, comicInfo);
                         using (Stream outStream = File.Create(tempPath))
                         {
-                            if (isComicBook)
-                                comicBook?.SerializeFull(outStream, onlyPortable: true);
-                            else
-                                comicInfo.Serialize(outStream);
+                            comicInfo.Serialize(outStream);
                         }
                         string parameters2 = $"u -t{updateSetting.arg} \"{file}\" \"{tempPath}\"";
                         return ExecuteUpdateProcess(parameters2, standalone);

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/SevenZipEngine.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/SevenZipEngine.cs
@@ -290,7 +290,6 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
                     try
                     {
                         Directory.CreateDirectory(tempDir);
-                        XmlUtility.Store(tempPath, comicInfo);
                         using (Stream outStream = File.Create(tempPath))
                         {
                             comicInfo.Serialize(outStream);
@@ -335,7 +334,6 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
                         string filename = ci is ComicBook ? "ComicBook.xml" : "ComicInfo.xml";
                         string tempPath = Path.Combine(tempDir, filename);
                         tempsPaths.Add(tempPath);
-                        XmlUtility.Store(tempPath, ci);
                         using (Stream outStream = File.Create(tempPath))
                         {
                             ci.Serialize(outStream);

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/SevenZipEngine.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/SevenZipEngine.cs
@@ -196,11 +196,11 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
             }
         }
 
-        public override ComicInfo ReadInfo(string source)
+        private T Read<T>(string source) where T : class
         {
             try
             {
-                return XmlInfoProviders.Readers.DeserializeAll(s => new MemoryStream(GetFileData(source, s)));
+                return XmlInfoProviders.Readers.DeserializeAll<T>(s => new MemoryStream(GetFileData(source, s))) as T;
             }
             catch
             {
@@ -208,7 +208,16 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
             }
         }
 
+        public override ComicInfo ReadInfo(string source) => Read<ComicInfo>(source);
+
+        public override ComicBook ReadBook(string source) => Read<ComicBook>(source);
+
         public override bool WriteInfo(string source, ComicInfo comicInfo)
+        {
+            return UpdateComicInfo(source, base.Format, standalone, comicInfo);
+        }
+
+        public override bool WriteBook(string source, ComicBook comicInfo)
         {
             return UpdateComicInfo(source, base.Format, standalone, comicInfo);
         }

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/SevenZipEngine.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/SevenZipEngine.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.RegularExpressions;
 using cYo.Common.ComponentModel;
 using cYo.Common.Compression.SevenZip;
@@ -213,12 +214,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
 
         public override bool WriteInfo(string source, ComicInfo comicInfo)
         {
-            return UpdateComicInfo(source, base.Format, standalone, comicInfo);
-        }
-
-        public override bool WriteBook(string source, ComicBook comicInfo)
-        {
-            return UpdateComicInfo(source, base.Format, standalone, comicInfo);
+            return UpdateComicInfos(source, base.Format, standalone, comicInfo);
         }
 
         private static KnownSevenZipFormat MapFileFormat(int format)
@@ -242,7 +238,6 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
 
         // InlineUpdate: pass the byte[] directly to 7-Zip to update the archive without needing to create a temporary file. Only works with some formats, so for the others we need to create a temporary file.
         record UpdateSettings(bool InlineUpdate, string arg);
-
         public static bool UpdateComicInfo(string file, int format, bool standalone, ComicInfo comicInfo)
         {
             UpdateSettings setting = format switch
@@ -254,6 +249,28 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
             };
 
             return Update(file, standalone, comicInfo, setting);
+        }
+
+        /// <summary>
+        /// Will update both the ComicInfo.xml & ComicBook.xml at the same time if the provided <paramref name="comicInfo"/> is a <see cref="ComicBook"/>. Otherwise only the ComicInfo.xml will be updated.
+        /// </summary>
+        /// <exception cref="NotSupportedException"></exception>
+        public static bool UpdateComicInfos(string file, int format, bool standalone, ComicInfo comicInfo)
+        {
+            UpdateSettings setting = format switch
+            {
+                KnownFileFormats.CBZ => new UpdateSettings(InlineUpdate: false, arg: "zip"),
+                KnownFileFormats.CB7 => new UpdateSettings(InlineUpdate: false, arg: "7z"),
+                KnownFileFormats.CBT => new UpdateSettings(InlineUpdate: false, arg: "tar"),
+                _ => throw new NotSupportedException("Format not supported for updating ComicInfo.xml")
+            };
+
+            List<ComicInfo> infos = new List<ComicInfo>();
+            infos.Add(comicInfo.GetInfo());
+            if (comicInfo is ComicBook cb)
+                infos.Add(cb); // Do a Clone?
+
+            return UpdateAll(file, standalone, infos, setting);
         }
 
         private static bool Update(string file, bool standalone, ComicInfo comicInfo, UpdateSettings updateSetting)
@@ -302,6 +319,64 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
             {
             }
             return false;
+        }
+
+        private static bool UpdateAll(string file, bool standalone, IEnumerable<ComicInfo> infos, UpdateSettings updateSetting)
+        {
+            try
+            {
+                string tempDir = Path.Combine(EngineConfiguration.Default.TempPath, Guid.NewGuid().ToString());
+                List<string> tempsPaths = new List<string>();
+                try
+                {
+                    Directory.CreateDirectory(tempDir);
+                    foreach (var ci in infos)
+                    {
+                        string filename = ci is ComicBook ? "ComicBook.xml" : "ComicInfo.xml";
+                        string tempPath = Path.Combine(tempDir, filename);
+                        tempsPaths.Add(tempPath);
+                        XmlUtility.Store(tempPath, ci);
+                        using (Stream outStream = File.Create(tempPath))
+                        {
+                            ci.Serialize(outStream);
+                        } 
+                    }
+                    string parameters = GetParameters(tempsPaths.ToArray(), updateSetting, file);
+                    return ExecuteUpdateProcess(parameters, standalone);
+                }
+                finally
+                {
+                    try
+                    {
+                        tempsPaths.ForEach(s => FileUtility.SafeDelete(s));
+                        Directory.Delete(tempDir);
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+            catch (WriteErrorException) // We only want the WriteErrorException to be propagated, so that it shows the error message to the user.
+            {
+                throw;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        private static string GetParameters(string[] tempPaths, UpdateSettings updateSetting, string file)
+        {
+            //string parameters2 = $"u -t{updateSetting.arg} \"{file}\" \"{tempPath}\"";
+            StringBuilder sb = new StringBuilder();
+            sb.Append($"u -t{updateSetting.arg} \"{file}\"");
+            foreach (var tempPath in tempPaths)
+            {
+                sb.Append(" ");
+                sb.Append($"\"{tempPath}\"");
+            }
+            return sb.ToString().Trim();
         }
 
         private static bool ExecuteUpdateProcess(string parameters, bool standalone, byte[] inputData = null)

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/SevenZipEngine.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/SevenZipEngine.cs
@@ -209,9 +209,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
             }
         }
 
-        public override ComicInfo ReadInfo(string source) => Read<ComicInfo>(source);
-
-        public override ComicBook ReadBook(string source) => Read<ComicBook>(source);
+        public override T ReadInfo<T>(string source) => Read<T>(source);
 
         public override bool WriteInfo(string source, ComicInfo comicInfo)
         {

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/SevenZipEngine.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/SevenZipEngine.cs
@@ -9,6 +9,7 @@ using cYo.Common.ComponentModel;
 using cYo.Common.Compression.SevenZip;
 using cYo.Common.IO;
 using cYo.Common.Win32;
+using cYo.Common.Xml;
 using cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo;
 
 namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
@@ -241,54 +242,60 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
             }
         }
 
+        // InlineUpdate: pass the byte[] directly to 7-Zip to update the archive without needing to create a temporary file. Only works with some formats, so for the others we need to create a temporary file.
+        record UpdateSettings(bool InlineUpdate, string arg);
+
         public static bool UpdateComicInfo(string file, int format, bool standalone, ComicInfo comicInfo)
         {
-            bool flag;
-            string arg;
-            switch (format)
+            UpdateSettings setting = format switch
             {
-                case KnownFileFormats.CBZ:
-                    flag = false;
-                    arg = "zip";
-                    break;
-                case KnownFileFormats.CB7:
-                    flag = true;
-                    arg = "7z";
-                    break;
-                case KnownFileFormats.CBT:
-                    flag = false;
-                    arg = "tar";
-                    break;
-                default:
-                    return false;
-            }
+                KnownFileFormats.CBZ => new UpdateSettings(InlineUpdate: false, arg: "zip"),
+                KnownFileFormats.CB7 => new UpdateSettings(InlineUpdate: true, arg: "7z"),
+                KnownFileFormats.CBT => new UpdateSettings(InlineUpdate: false, arg: "tar"),
+                _ => throw new NotSupportedException("Format not supported for updating ComicInfo.xml")
+            };
+
+            return Update(file, standalone, comicInfo, setting);
+        }
+
+        private static bool Update(string file, bool standalone, ComicInfo comicInfo, UpdateSettings updateSetting)
+        {
             try
             {
-                if (flag)
+                ComicBook comicBook = comicInfo as ComicBook;
+                bool isComicBook = comicBook != null;
+                string filename = isComicBook ? "ComicBook.xml" : "ComicInfo.xml";
+
+                if (updateSetting.InlineUpdate)
                 {
-                    string parameters = $"u -t{arg} -siComicInfo.xml \"{file}\"";
-                    return ExecuteUpdateProcess(parameters, standalone, comicInfo.ToArray());
+                    byte[] data = isComicBook ? comicBook?.ToArrayFull(onlyPortable: true) : comicInfo.ToArray();
+                    string parameters = $"u -t{updateSetting.arg} -si{filename} \"{file}\"";
+                    return ExecuteUpdateProcess(parameters, standalone, data);
                 }
                 else
                 {
-                    string text = Path.Combine(EngineConfiguration.Default.TempPath, Guid.NewGuid().ToString());
-                    string text2 = Path.Combine(text, "ComicInfo.xml");
+                    string tempDir = Path.Combine(EngineConfiguration.Default.TempPath, Guid.NewGuid().ToString());
+                    string tempPath = Path.Combine(tempDir, filename);
                     try
                     {
-                        Directory.CreateDirectory(text);
-                        using (Stream outStream = File.Create(text2))
+                        Directory.CreateDirectory(tempDir);
+                        XmlUtility.Store(tempPath, comicInfo);
+                        using (Stream outStream = File.Create(tempPath))
                         {
-                            comicInfo.Serialize(outStream);
+                            if (isComicBook)
+                                comicBook?.SerializeFull(outStream, onlyPortable: true);
+                            else
+                                comicInfo.Serialize(outStream);
                         }
-                        string parameters2 = $"u -t{arg} \"{file}\" \"{text2}\"";
+                        string parameters2 = $"u -t{updateSetting.arg} \"{file}\" \"{tempPath}\"";
                         return ExecuteUpdateProcess(parameters2, standalone);
                     }
                     finally
                     {
                         try
                         {
-                            FileUtility.SafeDelete(text2);
-                            Directory.Delete(text);
+                            FileUtility.SafeDelete(tempPath);
+                            Directory.Delete(tempDir);
                         }
                         catch
                         {

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/SharpCompressEngine.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/SharpCompressEngine.cs
@@ -93,8 +93,6 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
             }
         }
 
-        public override ComicInfo ReadInfo(string source) => Read<ComicInfo>(source);
-
-        public override ComicBook ReadBook(string source) => Read<ComicBook>(source);
+        public override T ReadInfo<T>(string source) => Read<T>(source);
     }
 }

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/SharpCompressEngine.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/SharpCompressEngine.cs
@@ -77,11 +77,11 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
             }
         }
 
-        public override ComicInfo ReadInfo(string source)
+        private T Read<T>(string source) where T : class
         {
             using (IArchive archive = ArchiveFactory.OpenArchive(source))
             {
-                return XmlInfoProviders.Readers.DeserializeAll(s =>
+                return XmlInfoProviders.Readers.DeserializeAll<T>(s =>
                 {
                     IArchiveEntry archiveEntry = archive.Entries.FirstOrDefault((IArchiveEntry e) => Path.GetFileName(e.Key).Equals(s, StringComparison.OrdinalIgnoreCase));
 
@@ -89,8 +89,12 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
                         return null;
 
                     return archiveEntry.OpenEntryStream();
-                });
+                }) as T;
             }
         }
+
+        public override ComicInfo ReadInfo(string source) => Read<ComicInfo>(source);
+
+        public override ComicBook ReadBook(string source) => Read<ComicBook>(source);
     }
 }

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/TarSharpZipEngine.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/TarSharpZipEngine.cs
@@ -122,7 +122,6 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
             }
         }
 
-        public override ComicInfo ReadInfo(string source) => Read<ComicInfo>(source);
-        public override ComicBook ReadBook(string source) => Read<ComicBook>(source);
+        public override T ReadInfo<T>(string source) => Read<T>(source);
     }
 }

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/TarSharpZipEngine.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/TarSharpZipEngine.cs
@@ -86,7 +86,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
             }
         }
 
-        public override ComicInfo ReadInfo(string source)
+        private T Read<T>(string source) where T : class
         {
             try
             {
@@ -95,7 +95,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
                 using (FileStream inputStream = new FileStream(source, FileMode.Open, FileAccess.Read, FileShare.Read, BufferSize))
                 using (TarInputStream tarInputStream = new TarInputStream(inputStream, Encoding.UTF8))
                 {
-                    return XmlInfoProviders.Readers.DeserializeAll(s =>
+                    return XmlInfoProviders.Readers.DeserializeAll<T>(s =>
                     {
                         TarEntry nextEntry;
                         do
@@ -113,13 +113,16 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
                         inStream.Position = 0;
 
                         return inStream;
-                    });
+                    }) as T;
                 }
             }
             catch
             {
-                return null;
+                return default;
             }
         }
+
+        public override ComicInfo ReadInfo(string source) => Read<ComicInfo>(source);
+        public override ComicBook ReadBook(string source) => Read<ComicBook>(source);
     }
 }

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/ZipSharpZipEngine.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/ZipSharpZipEngine.cs
@@ -82,8 +82,6 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
             }
         }
 
-        public override ComicInfo ReadInfo(string source) => Read<ComicInfo>(source);
-
-        public override ComicBook ReadBook(string source) => Read<ComicBook>(source);
+        public override T ReadInfo<T>(string source) => Read<T>(source);
     }
 }

--- a/ComicRack.Engine/IO/Provider/Readers/Archive/ZipSharpZipEngine.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Archive/ZipSharpZipEngine.cs
@@ -56,7 +56,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
 			}
 		}
 
-		public override ComicInfo ReadInfo(string source)
+        private T Read<T>(string source) where T : class
 		{
 			try
 			{
@@ -64,7 +64,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
 				{
 					using (ZipFile zipFile = new ZipFile(file))
 					{
-						return XmlInfoProviders.Readers.DeserializeAll(s =>
+						return XmlInfoProviders.Readers.DeserializeAll<T>(s =>
 						{
 							int num = zipFile.FindEntry(s, ignoreCase: true);
 							if (num != -1)
@@ -72,14 +72,18 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Archive
 								return zipFile.GetInputStream(num);
 							}
 							return null;
-						});
+						}) as T;
 					}
 				}
 			}
 			catch (Exception)
 			{
-			}
-			return null;
-		}
-	}
+				return null;
+            }
+        }
+
+        public override ComicInfo ReadInfo(string source) => Read<ComicInfo>(source);
+
+        public override ComicBook ReadBook(string source) => Read<ComicBook>(source);
+    }
 }

--- a/ComicRack.Engine/IO/Provider/Readers/ComicProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/ComicProvider.cs
@@ -6,95 +6,100 @@ using cYo.Common.Reflection;
 
 namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 {
-	public abstract class ComicProvider : ImageProvider, IInfoStorage
-	{
-		private static readonly string[] supportedTypes = new string[]
-		{
-			"jpg",
-			"jpeg",
-			"jif",
-			"jiff",
-			"gif",
-			"png",
-			"tif",
-			"tiff",
-			"bmp",
-			"djvu",
-			"webp",
-			"heic",
-			"heif",
-			"avif",
-			"jp2",
-			"j2k",
-			"jxl",
-		};
+    public abstract class ComicProvider : ImageProvider, IInfoStorage
+    {
+        private static readonly string[] supportedTypes = new string[]
+        {
+            "jpg",
+            "jpeg",
+            "jif",
+            "jiff",
+            "gif",
+            "png",
+            "tif",
+            "tiff",
+            "bmp",
+            "djvu",
+            "webp",
+            "heic",
+            "heif",
+            "avif",
+            "jp2",
+            "j2k",
+            "jxl",
+        };
 
-		public bool UpdateEnabled => GetType().GetAttributes<FileFormatAttribute>().FirstOrDefault((FileFormatAttribute f) => f.Format.Supports(base.Source))?.EnableUpdate ?? false;
+        public bool UpdateEnabled => GetType().GetAttributes<FileFormatAttribute>().FirstOrDefault((FileFormatAttribute f) => f.Format.Supports(base.Source))?.EnableUpdate ?? false;
 
-		private bool disableNtfs = false;
+        private bool disableNtfs = false;
 
         public event EventHandler<ErrorEventArgs> Error;
         public virtual void OnError(string errorMessage) => Error?.Invoke(this, new ErrorEventArgs(errorMessage));
 
         protected bool DisableNtfs
-		{
-			get
-			{
-				if (disableNtfs)
-					return true;
+        {
+            get
+            {
+                if (disableNtfs)
+                    return true;
 
-				return EngineConfiguration.Default.DisableNTFS;
-			}
+                return EngineConfiguration.Default.DisableNTFS;
+            }
 
-			set => disableNtfs = value;
-		}
+            set => disableNtfs = value;
+        }
 
-		protected bool DisableSidecar
-		{
-			get;
-			set;
-		}
+        protected bool DisableSidecar
+        {
+            get;
+            set;
+        }
 
-		public ComicInfo LoadInfo(InfoLoadingMethod method)
-		{
-			using (LockSource(readOnly: true))
-			{
+        public ComicInfo LoadInfo(InfoLoadingMethod method)
+        {
+            using (LockSource(readOnly: true))
+            {
 				ComicInfo comicInfo = (DisableNtfs ? null : NtfsInfoStorage.LoadInfo(base.Source)); 
-				if (comicInfo == null && !DisableSidecar)
-				{
-					comicInfo = ComicInfo.LoadFromSidecar(base.Source);
-                }
-				if (comicInfo != null && method == InfoLoadingMethod.Fast)
-				{
-					return comicInfo;
-				}
-				ComicInfo comicInfo2 = OnLoadInfo();
-				return comicInfo2 ?? comicInfo;
-			}
-		}
+                if (comicInfo == null && !DisableSidecar)
+                    comicInfo = ComicInfo.LoadFromSidecar(base.Source, ComicInfo.Deserialize);
+
+                if (comicInfo != null && method == InfoLoadingMethod.Fast)
+                    return comicInfo;
+
+                ComicInfo comicInfo2 = OnLoadInfo();
+                return comicInfo2 ?? comicInfo;
+            }
+        }
 
         public ComicBook LoadBook(InfoLoadingMethod method)
-		{
-			using (LockSource(readOnly: true))
-			{
-                // TODO: see adding support for ComicBook in NTFS & sidecar
-                return OnLoadBook();
+        {
+            using (LockSource(readOnly: true))
+            {
+                ComicBook comicBook = (DisableNtfs ? null : NtfsInfoStorage.LoadBook(base.Source));
+                if (comicBook == null && !DisableSidecar)
+                    comicBook = ComicInfo.LoadFromSidecar(base.Source, ComicBook.DeserializeFull);
+
+                if (comicBook != null && method == InfoLoadingMethod.Fast)
+                    return comicBook;
+
+                ComicBook comicBook2 = OnLoadBook();
+                return comicBook2 ?? comicBook;
             }
         }
 
 
         public bool StoreInfo(ComicInfo comicInfo)
-		{
-			bool flag = false;
-			using (LockSource(readOnly: false))
+        {
+            bool flag = false;
+            using (LockSource(readOnly: false))
             {
-				if (UpdateEnabled)
-				{
-					if (!OnStoreInfo(comicInfo))
-						return false;
+                if (UpdateEnabled)
+                {
+                    if (!OnStoreInfo(comicInfo))
+                        return false;
 
-					flag = true;
-				}
+                    flag = true;
+                }
                 if (!DisableNtfs)
                     flag |= NtfsInfoStorage.StoreInfo(base.Source, comicInfo);
 
@@ -102,27 +107,29 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
             }
         }
 
-		public bool StoreBook(ComicBook comicBook)
-		{
-			bool flag = false;
-			using (LockSource(readOnly: false))
-			{
-				if (UpdateEnabled)
-				{
-					if (!OnStoreBook(comicBook))
-						return false;
+        public bool StoreBook(ComicBook comicBook)
+        {
+            bool flag = false;
+            using (LockSource(readOnly: false))
+            {
+                if (UpdateEnabled)
+                {
+                    if (!OnStoreBook(comicBook))
+                        return false;
 
-					flag = true;
-				}
+                    flag = true;
+                }
+                if (!DisableNtfs)
+                    flag |= NtfsInfoStorage.StoreBook(base.Source, comicBook);
 
-				return flag;
+                return flag;
             }
-		}
+        }
 
         protected virtual ComicInfo OnLoadInfo()
-		{
-			return null;
-		}
+        {
+            return null;
+        }
 
         protected virtual ComicBook OnLoadBook()
         {
@@ -130,9 +137,9 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
         }
 
         protected virtual bool OnStoreInfo(ComicInfo comicInfo)
-		{
-			return false;
-		}
+        {
+            return false;
+        }
 
         protected virtual bool OnStoreBook(ComicBook comicBook)
         {
@@ -142,7 +149,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
         protected virtual bool IsSupportedImage(ProviderImageInfo file)
         {
             if(IsImageThumbnailFolder(file.Name))
-				return false;
+                return false;
 
             string fileExt = Path.GetExtension(FileUtility.MakeValidFilename(file.Name));
             return supportedTypes.Any((string ext) => string.Equals(fileExt, "." + ext, StringComparison.OrdinalIgnoreCase));
@@ -156,7 +163,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 
         private static bool IsFileTooSmall(long size)
         {
-			long minSize = 256;
+            long minSize = 256;
             return size < minSize;
         }
     }

--- a/ComicRack.Engine/IO/Provider/Readers/ComicProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/ComicProvider.cs
@@ -59,11 +59,11 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 		{
 			using (LockSource(readOnly: true))
 			{
-				ComicInfo comicInfo = (DisableNtfs ? null : NtfsInfoStorage.LoadInfo(base.Source));
+				ComicInfo comicInfo = (DisableNtfs ? null : NtfsInfoStorage.LoadInfo(base.Source)); 
 				if (comicInfo == null && !DisableSidecar)
 				{
 					comicInfo = ComicInfo.LoadFromSidecar(base.Source);
-				}
+                }
 				if (comicInfo != null && method == InfoLoadingMethod.Fast)
 				{
 					return comicInfo;
@@ -83,7 +83,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
         }
 
 
-		public bool StoreInfo(ComicInfo comicInfo)
+        public bool StoreInfo(ComicInfo comicInfo)
 		{
 			bool flag = false;
 			using (LockSource(readOnly: false))
@@ -102,6 +102,23 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
             }
         }
 
+		public bool StoreBook(ComicBook comicBook)
+		{
+			bool flag = false;
+			using (LockSource(readOnly: false))
+			{
+				if (UpdateEnabled)
+				{
+					if (!OnStoreBook(comicBook))
+						return false;
+
+					flag = true;
+				}
+
+				return flag;
+            }
+		}
+
         protected virtual ComicInfo OnLoadInfo()
 		{
 			return null;
@@ -112,10 +129,15 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
             return null;
         }
 
-		protected virtual bool OnStoreInfo(ComicInfo comicInfo)
+        protected virtual bool OnStoreInfo(ComicInfo comicInfo)
 		{
 			return false;
 		}
+
+        protected virtual bool OnStoreBook(ComicBook comicBook)
+        {
+            return false;
+        }
 
         protected virtual bool IsSupportedImage(ProviderImageInfo file)
         {

--- a/ComicRack.Engine/IO/Provider/Readers/ComicProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/ComicProvider.cs
@@ -77,7 +77,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
         protected virtual T OnLoadInfo<T>() where T : ComicInfo
         {
             return default;
-            }
+        }
 
         public bool StoreInfo(ComicInfo comicInfo)
         {
@@ -98,32 +98,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
             }
         }
 
-        public bool StoreBook(ComicBook comicBook)
-        {
-            bool flag = false;
-            using (LockSource(readOnly: false))
-            {
-                if (UpdateEnabled)
-                {
-                    if (!OnStoreBook(comicBook))
-                        return false;
-
-                    flag = true;
-                }
-                if (!DisableNtfs)
-                    flag |= NtfsInfoStorage.StoreBook(base.Source, comicBook);
-
-                return flag;
-            }
-        }
-
-
         protected virtual bool OnStoreInfo(ComicInfo comicInfo)
-        {
-            return false;
-        }
-
-        protected virtual bool OnStoreBook(ComicBook comicBook)
         {
             return false;
         }

--- a/ComicRack.Engine/IO/Provider/Readers/ComicProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/ComicProvider.cs
@@ -55,38 +55,29 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
             set;
         }
 
-        public ComicInfo LoadInfo(InfoLoadingMethod method)
+        public T Load<T>(InfoLoadingMethod method, Func<Stream, T> deserializeDelegate) where T : ComicInfo
         {
             using (LockSource(readOnly: true))
             {
-				ComicInfo comicInfo = (DisableNtfs ? null : NtfsInfoStorage.LoadInfo(base.Source)); 
+                T comicInfo = (DisableNtfs ? null : NtfsInfoStorage.LoadInfo<T>(base.Source));
                 if (comicInfo == null && !DisableSidecar)
-                    comicInfo = ComicInfo.LoadFromSidecar(base.Source, ComicInfo.Deserialize);
+                    comicInfo = ComicInfo.LoadFromSidecar(base.Source, deserializeDelegate);
 
                 if (comicInfo != null && method == InfoLoadingMethod.Fast)
                     return comicInfo;
 
-                ComicInfo comicInfo2 = OnLoadInfo();
+                T comicInfo2 = OnLoadInfo<T>();
                 return comicInfo2 ?? comicInfo;
             }
         }
 
-        public ComicBook LoadBook(InfoLoadingMethod method)
+        public ComicInfo LoadInfo(InfoLoadingMethod method) => Load(method, ComicInfo.Deserialize);
+        public ComicBook LoadBook(InfoLoadingMethod method) => Load(method, ComicBook.DeserializeFull);
+
+        protected virtual T OnLoadInfo<T>() where T : ComicInfo
         {
-            using (LockSource(readOnly: true))
-            {
-                ComicBook comicBook = (DisableNtfs ? null : NtfsInfoStorage.LoadBook(base.Source));
-                if (comicBook == null && !DisableSidecar)
-                    comicBook = ComicInfo.LoadFromSidecar(base.Source, ComicBook.DeserializeFull);
-
-                if (comicBook != null && method == InfoLoadingMethod.Fast)
-                    return comicBook;
-
-                ComicBook comicBook2 = OnLoadBook();
-                return comicBook2 ?? comicBook;
+            return default;
             }
-        }
-
 
         public bool StoreInfo(ComicInfo comicInfo)
         {
@@ -126,15 +117,6 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
             }
         }
 
-        protected virtual ComicInfo OnLoadInfo()
-        {
-            return null;
-        }
-
-        protected virtual ComicBook OnLoadBook()
-        {
-            return null;
-        }
 
         protected virtual bool OnStoreInfo(ComicInfo comicInfo)
         {

--- a/ComicRack.Engine/IO/Provider/Readers/ComicProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/ComicProvider.cs
@@ -73,6 +73,16 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 			}
 		}
 
+        public ComicBook LoadBook(InfoLoadingMethod method)
+		{
+			using (LockSource(readOnly: true))
+			{
+                // TODO: see adding support for ComicBook in NTFS & sidecar
+                return OnLoadBook();
+            }
+        }
+
+
 		public bool StoreInfo(ComicInfo comicInfo)
 		{
 			bool flag = false;
@@ -96,6 +106,11 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 		{
 			return null;
 		}
+
+        protected virtual ComicBook OnLoadBook()
+        {
+            return null;
+        }
 
 		protected virtual bool OnStoreInfo(ComicInfo comicInfo)
 		{

--- a/ComicRack.Engine/IO/Provider/Readers/IComicAccessor.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/IComicAccessor.cs
@@ -11,7 +11,9 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 		byte[] ReadByteImage(string source, ProviderImageInfo info);
 
 		ComicInfo ReadInfo(string source);
+        ComicBook ReadBook(string source);
 
-		bool WriteInfo(string source, ComicInfo info);
+        bool WriteInfo(string source, ComicInfo info);
+        bool WriteBook(string source, ComicBook info);
 	}
 }

--- a/ComicRack.Engine/IO/Provider/Readers/IComicAccessor.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/IComicAccessor.cs
@@ -12,7 +12,6 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 
 		T ReadInfo<T>(string source) where T : ComicInfo;
 
-        bool WriteInfo(string source, ComicInfo info);
-        bool WriteBook(string source, ComicBook info);
+		bool WriteInfo(string source, ComicInfo info);
 	}
 }

--- a/ComicRack.Engine/IO/Provider/Readers/IComicAccessor.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/IComicAccessor.cs
@@ -10,8 +10,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 
 		byte[] ReadByteImage(string source, ProviderImageInfo info);
 
-		ComicInfo ReadInfo(string source);
-        ComicBook ReadBook(string source);
+		T ReadInfo<T>(string source) where T : ComicInfo;
 
         bool WriteInfo(string source, ComicInfo info);
         bool WriteBook(string source, ComicBook info);

--- a/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfGhostScript.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfGhostScript.cs
@@ -60,6 +60,5 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Pdf
         public T ReadInfo<T>(string source) where T: ComicInfo => null;
 
         public bool WriteInfo(string source, ComicInfo info) => false;
-        public bool WriteBook(string source, ComicBook info) => false;
     }
 }

--- a/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfGhostScript.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfGhostScript.cs
@@ -57,14 +57,10 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Pdf
 			return pdfImages.GetPageData(index, currentDpi);
 		}
 
-		public ComicInfo ReadInfo(string source)
-		{
-			return null;
-		}
+        public ComicInfo ReadInfo(string source) => null;
+        public ComicBook ReadBook(string source) => null;
 
-		public bool WriteInfo(string source, ComicInfo info)
-		{
-			return false;
-		}
-	}
+        public bool WriteInfo(string source, ComicInfo info) => false;
+        public bool WriteBook(string source, ComicBook info) => false;
+    }
 }

--- a/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfGhostScript.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfGhostScript.cs
@@ -57,8 +57,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Pdf
 			return pdfImages.GetPageData(index, currentDpi);
 		}
 
-        public ComicInfo ReadInfo(string source) => null;
-        public ComicBook ReadBook(string source) => null;
+        public T ReadInfo<T>(string source) where T: ComicInfo => null;
 
         public bool WriteInfo(string source, ComicInfo info) => false;
         public bool WriteBook(string source, ComicBook info) => false;

--- a/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfNative.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfNative.cs
@@ -139,17 +139,13 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Pdf
 			return LoadBitmapData(source, (ImageStreamInfo)info);
 		}
 
-		public ComicInfo ReadInfo(string source)
-		{
-			return null;
-		}
+        public ComicInfo ReadInfo(string source) => null;
+        public ComicBook ReadBook(string source) => null;
 
-		public bool WriteInfo(string source, ComicInfo info)
-		{
-			return false;
-		}
+        public bool WriteInfo(string source, ComicInfo info) => false;
+        public bool WriteBook(string source, ComicBook info) => false;
 
-		private static byte[] LoadBitmapData(string file, ImageStreamInfo si)
+        private static byte[] LoadBitmapData(string file, ImageStreamInfo si)
 		{
 			try
 			{

--- a/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfNative.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfNative.cs
@@ -142,7 +142,6 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Pdf
         public T ReadInfo<T>(string source) where T : ComicInfo => null;
 
         public bool WriteInfo(string source, ComicInfo info) => false;
-        public bool WriteBook(string source, ComicBook info) => false;
 
         private static byte[] LoadBitmapData(string file, ImageStreamInfo si)
 		{

--- a/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfNative.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfNative.cs
@@ -139,8 +139,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Pdf
 			return LoadBitmapData(source, (ImageStreamInfo)info);
 		}
 
-        public ComicInfo ReadInfo(string source) => null;
-        public ComicBook ReadBook(string source) => null;
+        public T ReadInfo<T>(string source) where T : ComicInfo => null;
 
         public bool WriteInfo(string source, ComicInfo info) => false;
         public bool WriteBook(string source, ComicBook info) => false;

--- a/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfiumReaderEngine.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfiumReaderEngine.cs
@@ -77,8 +77,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Pdf
             return outSize;
         }
 
-        public ComicInfo ReadInfo(string source) => null;
-        public ComicBook ReadBook(string source) => null;
+        public T ReadInfo<T>(string source) where T : ComicInfo => null;
 
         public bool WriteInfo(string source, ComicInfo info) => false;
         public bool WriteBook(string source, ComicBook info) => false;

--- a/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfiumReaderEngine.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfiumReaderEngine.cs
@@ -77,14 +77,10 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Pdf
             return outSize;
         }
 
-        public ComicInfo ReadInfo(string source)
-        {
-            return null;
-        }
+        public ComicInfo ReadInfo(string source) => null;
+        public ComicBook ReadBook(string source) => null;
 
-        public bool WriteInfo(string source, ComicInfo info)
-        {
-            return false;
-        }
+        public bool WriteInfo(string source, ComicInfo info) => false;
+        public bool WriteBook(string source, ComicBook info) => false;
     }
 }

--- a/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfiumReaderEngine.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/Pdf/PdfiumReaderEngine.cs
@@ -80,6 +80,5 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers.Pdf
         public T ReadInfo<T>(string source) where T : ComicInfo => null;
 
         public bool WriteInfo(string source, ComicInfo info) => false;
-        public bool WriteBook(string source, ComicBook info) => false;
     }
 }

--- a/ComicRack.Engine/IO/Provider/Readers/WebComicProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/WebComicProvider.cs
@@ -204,7 +204,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 			try
 			{
 				WebComic webComic = Load(base.Source);
-				webComic.Info = comicInfo;
+				webComic.Info = comicInfo.GetInfo(); // For now just force to be ComicInfo, it would create an error when it's a ComicBook
 				using (FileStream s = File.Create(base.Source))
 				{
 					XmlUtility.Store(s, webComic, compressed: false);

--- a/ComicRack.Engine/IO/Provider/Readers/WebComicProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/WebComicProvider.cs
@@ -198,6 +198,12 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 			}
 		}
 
+		// TODO: Add implementation for WebComics of OnLoadBook
+		protected override ComicBook OnLoadBook()
+		{
+			return null;
+        }
+
 		protected override bool OnStoreInfo(ComicInfo comicInfo)
 		{
 			try

--- a/ComicRack.Engine/IO/Provider/Readers/WebComicProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Readers/WebComicProvider.cs
@@ -186,11 +186,11 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 			}
 		}
 
-		protected override ComicInfo OnLoadInfo()
+		protected override T OnLoadInfo<T>()
 		{
 			try
 			{
-				return Load(base.Source).Info;
+				return Load(base.Source).Info as T;
 			}
 			catch
 			{
@@ -198,11 +198,6 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Readers
 			}
 		}
 
-		// TODO: Add implementation for WebComics of OnLoadBook
-		protected override ComicBook OnLoadBook()
-		{
-			return null;
-        }
 
 		protected override bool OnStoreInfo(ComicInfo comicInfo)
 		{

--- a/ComicRack.Engine/IO/Provider/Writers/PackedStorageProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Writers/PackedStorageProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using cYo.Common;
 using cYo.Common.Drawing;
 using cYo.Common.IO;
 using cYo.Common.Mathematics;
@@ -9,189 +10,198 @@ using cYo.Common.Text;
 
 namespace cYo.Projects.ComicRack.Engine.IO.Provider.Writers
 {
-	public abstract class PackedStorageProvider : StorageProvider
-	{
-		private class IndexedPageResult : IComparable<IndexedPageResult>
-		{
-			public int Index
-			{
-				get;
-				set;
-			}
+    public abstract class PackedStorageProvider : StorageProvider
+    {
+        private class IndexedPageResult : IComparable<IndexedPageResult>
+        {
+            public int Index
+            {
+                get;
+                set;
+            }
 
-			public int Offset
-			{
-				get;
-				set;
-			}
+            public int Offset
+            {
+                get;
+                set;
+            }
 
-			public PageResult Page
-			{
-				get;
-				set;
-			}
+            public PageResult Page
+            {
+                get;
+                set;
+            }
 
-			public string OriginalName
-			{
-				get;
-				set;
-			}
+            public string OriginalName
+            {
+                get;
+                set;
+            }
 
-			public int CompareTo(IndexedPageResult other)
-			{
-				int num = Index.CompareTo(other.Index);
-				if (num != 0)
-				{
-					return num;
-				}
-				return Offset.CompareTo(other.Offset);
-			}
-		}
+            public int CompareTo(IndexedPageResult other)
+            {
+                int num = Index.CompareTo(other.Index);
+                if (num != 0)
+                {
+                    return num;
+                }
+                return Offset.CompareTo(other.Offset);
+            }
+        }
 
-		protected abstract void OnCreateFile(string target, StorageSetting setting);
+        protected abstract void OnCreateFile(string target, StorageSetting setting);
 
-		protected abstract void OnCloseFile();
+        protected abstract void OnCloseFile();
 
-		protected abstract void AddEntry(string name, byte[] data);
+        protected abstract void AddEntry(string name, byte[] data);
 
 		protected override ComicInfo OnStore(IImageProvider provider, ComicInfo info, string target, StorageSetting setting)
-		{
-			OnCreateFile(target, setting);
-			List<IndexedPageResult> pages = new List<IndexedPageResult>();
-			try
-			{
-				int loopCount = 0;
-				long totalPageMemory = 0L;
-				Exception ce = null;
-				ParallelOptions parallelOptions = new ParallelOptions();
-				parallelOptions.MaxDegreeOfParallelism = EngineConfiguration.Default.ParallelConversions.Clamp(1, Environment.ProcessorCount);
-				Parallel.For(0, provider.Count, parallelOptions, delegate(int n, ParallelLoopState ls)
-				{
-					try
-					{
-						if (setting.IsValidPage(n))
-						{
+        {
+            OnCreateFile(target, setting);
+            List<IndexedPageResult> pages = new List<IndexedPageResult>();
+            try
+            {
+                int loopCount = 0;
+                long totalPageMemory = 0L;
+                Exception ce = null;
+                ParallelOptions parallelOptions = new ParallelOptions();
+                parallelOptions.MaxDegreeOfParallelism = EngineConfiguration.Default.ParallelConversions.Clamp(1, Environment.ProcessorCount);
+                Parallel.For(0, provider.Count, parallelOptions, (int n, ParallelLoopState ls) =>
+                {
+                    try
+                    {
+                        if (setting.IsValidPage(n))
+                        {
 							ComicPageInfo page = info.GetPage(n);
-							ProviderImageInfo imageInfo = provider.GetImageInfo(page.ImageIndex);
-							string ext = ((imageInfo != null && !string.IsNullOrEmpty(imageInfo.Name)) ? Path.GetExtension(imageInfo.Name) : ".jpg");
-							int num2 = 0;
+                            ProviderImageInfo imageInfo = provider.GetImageInfo(page.ImageIndex);
+                            string ext = ((imageInfo != null && !string.IsNullOrEmpty(imageInfo.Name)) ? Path.GetExtension(imageInfo.Name) : ".jpg");
+                            int num2 = 0;
 							PageResult[] images = StorageProvider.GetImages(provider, page, ext, setting, info.Manga == MangaYesNo.YesAndRightToLeft, setting.CreateThumbnails, true);
-							foreach (PageResult pageResult in images)
-							{
-								bool flag;
-								lock (this)
-								{
-									totalPageMemory += pageResult.Data.Length;
-									flag = totalPageMemory > 52428800;
-								}
-								if (flag)
-								{
-									pageResult.Store();
-								}
-								lock (pages)
-								{
-									pages.Add(new IndexedPageResult
-									{
-										Page = pageResult,
-										Index = n,
-										Offset = num2++,
-										OriginalName = imageInfo.Name
-									});
-								}
-							}
-							if (FireProgressEvent(++loopCount * 100 / provider.Count))
-							{
-								ls.Break();
-								throw new OperationCanceledException("Export operation was cancelled by the user.");
-							}
-						}
-					}
-					catch (Exception ex)
-					{
-						ce = ex;
-						ls.Break();
-					}
-				});
-				if (ce != null)
-				{
-					throw ce;
-				}
-				int num = 0;
-				ComicInfo comicInfo = new ComicInfo(info);
-				comicInfo.Pages.Clear();
-				pages.Sort();
-				HashSet<string> nameTable = new HashSet<string>();
-				foreach (IndexedPageResult item in pages)
-				{
-					item.Page.Restore();
-					try
-					{
+                            foreach (PageResult pageResult in images)
+                            {
+                                bool flag;
+                                lock (this)
+                                {
+                                    totalPageMemory += pageResult.Data.Length;
+                                    flag = totalPageMemory > 52428800;
+                                }
+                                if (flag)
+                                    pageResult.Store();
+
+                                lock (pages)
+                                {
+                                    pages.Add(new IndexedPageResult
+                                    {
+                                        Page = pageResult,
+                                        Index = n,
+                                        Offset = num2++,
+                                        OriginalName = imageInfo.Name
+                                    });
+                                }
+                            }
+                            if (FireProgressEvent(++loopCount * 100 / provider.Count))
+                            {
+                                ls.Break();
+                                throw new OperationCanceledException("Export operation was cancelled by the user.");
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        ce = ex;
+                        ls.Break();
+                    }
+                });
+                if (ce != null)
+                    throw ce;
+
+                int num = 0;
+
+                // If the original info is a ComicBook we need to keep it's type for AddBook, otherwise we will lose the properties that are only in ComicBook
+                ComicInfo comicInfo = info is ComicBook cb ? cb.Clone<ComicBook>() : new ComicInfo(info);
+                comicInfo.Pages.Clear();
+                pages.Sort();
+                HashSet<string> nameTable = new HashSet<string>();
+                foreach (IndexedPageResult item in pages)
+                {
+                    item.Page.Restore();
+                    try
+                    {
 						WritePage(item, num++, comicInfo, setting, nameTable);
-					}
-					finally
-					{
-						item.Page.Clear();
-					}
-				}
+                    }
+                    finally
+                    {
+                        item.Page.Clear();
+                    }
+                }
 				comicInfo.PageCount = comicInfo.Pages.Count;
-				if (setting.EmbedComicInfo)
-				{
-					AddInfo(comicInfo);
-				}
-				return comicInfo;
-			}
-			finally
-			{
-				foreach (IndexedPageResult item2 in pages)
-				{
-					item2.Page.Clear();
-				}
-				OnCloseFile();
-			}
-		}
+                if (setting.EmbedComicInfo)
+                    AddInfo(comicInfo.GetInfo()); // Force the type to ComicInfo otherwise so it doesn't output a ComicBook
+
+                if (setting.EmbedComicInfo && setting.EmbedComicBook && comicInfo is ComicBook comicBook)
+                    AddBook(comicBook);
+
+                return comicInfo;
+            }
+            finally
+            {
+                foreach (IndexedPageResult item2 in pages)
+                {
+                    item2.Page.Clear();
+                }
+                OnCloseFile();
+            }
+        }
 
 		private void WritePage(IndexedPageResult ipr, int k, ComicInfo myInfo, StorageSetting setting, ISet<string> nameTable)
-		{
-			PageResult page = ipr.Page;
-			ComicPageInfo info = page.Info;
-			string text = null;
-			if (setting.KeepOriginalImageNames && !string.IsNullOrEmpty(ipr.OriginalName))
-			{
-				text = Path.GetFileNameWithoutExtension(ipr.OriginalName);
-			}
-			if (string.IsNullOrEmpty(text))
-			{
-				text = $"P{k + 1:00000}";
-			}
-			if (!setting.KeepOriginalImageNames && info.IsBookmark)
-			{
-				text = text + " - " + FileUtility.MakeValidFilename(info.Bookmark.Left(25));
-			}
-			string arg = text;
-			int num = 2;
-			while (nameTable.Contains(text))
-			{
-				text = $"{arg}_{num++}";
-			}
-			nameTable.Add(text);
-			string text2 = text + page.Extension;
-			AddEntry(text2, page.Data);
-			if (setting.CreateThumbnails)
-			{
-				AddEntry($"Thumbnails\\{text}.tb", page.GetThumbnailData(setting));
-			}
-			info.ImageIndex = k++;
-			info.Rotation = ImageRotation.None;
-			if (setting.AddKeyToPageInfo)
-			{
-				info.Key = text2;
-			}
-			myInfo.Pages.Add(info);
-		}
+        {
+            PageResult page = ipr.Page;
+            ComicPageInfo info = page.Info;
+            string text = null;
+            if (setting.KeepOriginalImageNames && !string.IsNullOrEmpty(ipr.OriginalName))
+            {
+                text = Path.GetFileNameWithoutExtension(ipr.OriginalName);
+            }
+            if (string.IsNullOrEmpty(text))
+            {
+                text = $"P{k + 1:00000}";
+            }
+            if (!setting.KeepOriginalImageNames && info.IsBookmark)
+            {
+                text = text + " - " + FileUtility.MakeValidFilename(info.Bookmark.Left(25));
+            }
+            string arg = text;
+            int num = 2;
+            while (nameTable.Contains(text))
+            {
+                text = $"{arg}_{num++}";
+            }
+            nameTable.Add(text);
+            string text2 = text + page.Extension;
+            AddEntry(text2, page.Data);
+            if (setting.CreateThumbnails)
+            {
+                AddEntry($"Thumbnails\\{text}.tb", page.GetThumbnailData(setting));
+            }
+            info.ImageIndex = k++;
+            info.Rotation = ImageRotation.None;
+            if (setting.AddKeyToPageInfo)
+            {
+                info.Key = text2;
+            }
+            myInfo.Pages.Add(info);
+        }
 
-		protected virtual void AddInfo(ComicInfo comicInfo)
-		{
-			AddEntry("ComicInfo.xml", comicInfo.ToArray());
-		}
-	}
+        protected virtual void AddInfo(ComicInfo comicInfo)
+        {
+            AddEntry("ComicInfo.xml", comicInfo.ToArray());
+        }
+
+        protected virtual void AddBook(ComicBook comicBook)
+        {
+            byte[] data = comicBook.ToArrayFull();
+            if (data != null && data.Length > 0)
+                AddEntry("ComicBook.xml", data);
+        }
+    }
 }

--- a/ComicRack.Engine/IO/Provider/Writers/PackedStorageProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Writers/PackedStorageProvider.cs
@@ -202,7 +202,7 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Writers
             if (comicBook == null)
                 return;
 
-            byte[] data = comicBook.ToArrayFull(onlyPortable: true);
+            byte[] data = comicBook.ToArray();
             if (data != null && data.Length > 0)
                 AddEntry("ComicBook.xml", data);
         }

--- a/ComicRack.Engine/IO/Provider/Writers/PackedStorageProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Writers/PackedStorageProvider.cs
@@ -199,7 +199,10 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Writers
 
         protected virtual void AddBook(ComicBook comicBook)
         {
-            byte[] data = comicBook.ToArrayFull();
+            if (comicBook == null)
+                return;
+
+            byte[] data = comicBook.ToArrayFull(onlyPortable: true);
             if (data != null && data.Length > 0)
                 AddEntry("ComicBook.xml", data);
         }

--- a/ComicRack.Engine/IO/Provider/Writers/XmlInfoStorageProvider.cs
+++ b/ComicRack.Engine/IO/Provider/Writers/XmlInfoStorageProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using cYo.Common;
 
 namespace cYo.Projects.ComicRack.Engine.IO.Provider.Writers
 {
@@ -9,16 +10,16 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.Writers
 		protected override ComicInfo OnStore(IImageProvider provider, ComicInfo info, string target, StorageSetting setting)
 		{
 			if (info == null)
-			{
 				return info;
-			}
+
 			try
 			{
-				using (StreamWriter streamWriter = File.CreateText(target))
+				ComicInfo comicInfo = setting.EmbedComicInfo && setting.EmbedComicBook && info is ComicBook cb ? cb.Clone<ComicBook>() : info.GetInfo(); // Force the type depending on the settings
+                using (StreamWriter streamWriter = File.CreateText(target))
 				{
-					info.Serialize(streamWriter.BaseStream);
-				}
-				return info;
+                    comicInfo.Serialize(streamWriter.BaseStream);
+                }
+				return comicInfo;
 			}
 			catch (Exception)
 			{

--- a/ComicRack.Engine/IO/Provider/XmlInfo/ComicBookProvider.cs
+++ b/ComicRack.Engine/IO/Provider/XmlInfo/ComicBookProvider.cs
@@ -1,0 +1,8 @@
+﻿namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
+{
+    [XmlInfoFile("ComicBook.xml", 0)]
+    public class ComicBookProvider : XmlInfoProvider<ComicBook, ComicBook>
+    {
+        public override ComicBook ToXml(ComicBook xmlInfo) => xmlInfo;
+    }
+}

--- a/ComicRack.Engine/IO/Provider/XmlInfo/ComicInfoProvider.cs
+++ b/ComicRack.Engine/IO/Provider/XmlInfo/ComicInfoProvider.cs
@@ -8,9 +8,9 @@ using cYo.Common.Xml;
 
 namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
 {
-	[XmlInfoFile("ComicInfo.xml", 0)]
-	public class ComicInfoProvider : XmlInfoProvider<ComicInfo>
+	[XmlInfoFile("ComicInfo.xml", 0, XmlInfoType.ComicInfo)]
+	public class ComicInfoProvider : XmlInfoProvider<ComicInfo, ComicInfo>
 	{
-		public override ComicInfo ToComicInfo(ComicInfo xmlInfo) => xmlInfo;
+		public override ComicInfo ToXml(ComicInfo xmlInfo) => xmlInfo;
 	}
 }

--- a/ComicRack.Engine/IO/Provider/XmlInfo/ComicInfoProvider.cs
+++ b/ComicRack.Engine/IO/Provider/XmlInfo/ComicInfoProvider.cs
@@ -8,7 +8,7 @@ using cYo.Common.Xml;
 
 namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
 {
-	[XmlInfoFile("ComicInfo.xml", 0, XmlInfoType.ComicInfo)]
+	[XmlInfoFile("ComicInfo.xml", 0)]
 	public class ComicInfoProvider : XmlInfoProvider<ComicInfo, ComicInfo>
 	{
 		public override ComicInfo ToXml(ComicInfo xmlInfo) => xmlInfo;

--- a/ComicRack.Engine/IO/Provider/XmlInfo/MetronInfoProvider.cs
+++ b/ComicRack.Engine/IO/Provider/XmlInfo/MetronInfoProvider.cs
@@ -13,10 +13,10 @@ using cYo.Projects.ComicRack.Engine.Drawing;
 
 namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
 {
-	[XmlInfoFile("MetronInfo.xml", 1)]
-	public class MetronInfoProvider : XmlInfoProvider<MetronInfo>
+	[XmlInfoFile("MetronInfo.xml", 1, XmlInfoType.ComicInfo)]
+	public class MetronInfoProvider : XmlInfoProvider<MetronInfo, ComicInfo>
 	{
-		public override ComicInfo ToComicInfo(MetronInfo metronInfo)
+		public override ComicInfo ToXml(MetronInfo metronInfo)
 		{
 			if (metronInfo == null)
 				return null;

--- a/ComicRack.Engine/IO/Provider/XmlInfo/MetronInfoProvider.cs
+++ b/ComicRack.Engine/IO/Provider/XmlInfo/MetronInfoProvider.cs
@@ -13,7 +13,7 @@ using cYo.Projects.ComicRack.Engine.Drawing;
 
 namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
 {
-	[XmlInfoFile("MetronInfo.xml", 1, XmlInfoType.ComicInfo)]
+	[XmlInfoFile("MetronInfo.xml", 1)]
 	public class MetronInfoProvider : XmlInfoProvider<MetronInfo, ComicInfo>
 	{
 		public override ComicInfo ToXml(MetronInfo metronInfo)

--- a/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoFileAttribute.cs
+++ b/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoFileAttribute.cs
@@ -13,10 +13,13 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
 
 		public int Order { get; set; }
 
-		public XmlInfoFileAttribute(string xmlInfoFile, int order)
+        public XmlInfoType XmlInfoType { get; set; }
+
+        public XmlInfoFileAttribute(string xmlInfoFile, int order, XmlInfoType xmlInfoType = XmlInfoType.ComicInfo)
 		{
 			XmlInfoFile = xmlInfoFile;
 			Order = order;
-		}
+            XmlInfoType = xmlInfoType;
+        }
 	}
 }

--- a/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoFileAttribute.cs
+++ b/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoFileAttribute.cs
@@ -13,13 +13,10 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
 
 		public int Order { get; set; }
 
-        public XmlInfoType XmlInfoType { get; set; }
-
-        public XmlInfoFileAttribute(string xmlInfoFile, int order, XmlInfoType xmlInfoType = XmlInfoType.ComicInfo)
+        public XmlInfoFileAttribute(string xmlInfoFile, int order)
 		{
 			XmlInfoFile = xmlInfoFile;
 			Order = order;
-            XmlInfoType = xmlInfoType;
         }
 	}
 }

--- a/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoProvider.cs
+++ b/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoProvider.cs
@@ -4,27 +4,33 @@ using cYo.Common.Xml;
 
 namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
 {
-	public abstract class XmlInfoProvider
-	{
-		public abstract ComicInfo Deserialize(Func<string, Stream> getDataDelegate, string filename);
+    public abstract class XmlInfoProvider
+    {
+    }
+
+    public abstract class XmlInfoProvider<TXmlInfoResult>: XmlInfoProvider where TXmlInfoResult : class
+    {
+		public abstract TXmlInfoResult Deserialize(Func<string, Stream> getDataDelegate, string filename);
 	}
 
-	public abstract class XmlInfoProvider<T> : XmlInfoProvider where T : class
+    public abstract class XmlInfoProvider<TSourceProvider, TXmlInfoResult> : XmlInfoProvider<TXmlInfoResult>
+		where TSourceProvider : class
+		where TXmlInfoResult : class
 	{
-		public abstract ComicInfo ToComicInfo(T xmlInfo);
+		public abstract TXmlInfoResult ToXml(TSourceProvider xmlInfo);
 
-		public override ComicInfo Deserialize(Func<string, Stream> getDataDelegate, string filename)
+		public override TXmlInfoResult Deserialize(Func<string, Stream> getDataDelegate, string filename)
 		{
 			try
 			{
 				using (Stream inStream = getDataDelegate(filename))
 				{
-					return ToComicInfo(XmlUtility.GetSerializer<T>().Deserialize(inStream) as T);
+					return ToXml(XmlUtility.GetSerializer<TSourceProvider>().Deserialize(inStream) as TSourceProvider);
 				}
 			}
 			catch
 			{
-				return null;
+				return default;
 			}
 		}
 	}

--- a/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoProviderFactory.cs
+++ b/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoProviderFactory.cs
@@ -41,11 +41,8 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
 
         public IEnumerable<XmlInfoProviderInfo> GetProviderInfos(Type type)
         {
-            //find the type via the attribute, if it exists, otherwise find it via the generic argument of the provider type
-            if (TryParse(type, out XmlInfoType xmlInfoType))
-                return GetProviderInfos<XmlInfoProviderInfo>().Where(x => x.XmlInfoFile.XmlInfoType == xmlInfoType).OrderBy(x => x.XmlInfoFile.Order);
-
-            return Enumerable.Empty<XmlInfoProviderInfo>();
+            // Get the provider info based on the generic argument of the provider type
+            return GetProviderInfos<XmlInfoProviderInfo>().Where(x => x.ProviderType.BaseType.GetGenericArguments().LastOrDefault(t => t == type) != null).OrderBy(x => x.XmlInfoFile.Order);
         }
 
         public IEnumerable<XmlInfoProviderInfo> GetProviderInfos()
@@ -75,11 +72,6 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
                     return comicInfo;
             }
             return null;
-        }
-
-        private bool TryParse(Type type, out XmlInfoType xmlInfoType)
-        {
-            return Enum.TryParse(type.Name, out xmlInfoType);
         }
     }
 }

--- a/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoProviderFactory.cs
+++ b/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoProviderFactory.cs
@@ -13,59 +13,73 @@ using cYo.Common.Threading;
 
 namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
 {
-	public class XmlInfoProviderFactory : ProviderFactoryBase<XmlInfoProvider>
-	{
-		public void RegisterProvider(Type pt, IEnumerable<XmlInfoFile> xmlInfoFile, bool withLocking = true)
-		{
-			using (withLocking ? rwLock.UpgradeableReadLock() : null)
-			{
-				if (!providerDict.Any(pi => pi.ProviderType == pt))
-				{
-					using (withLocking ? rwLock.WriteLock() : null)
-					{
-						xmlInfoFile.ForEach(x => providerDict.Add(new XmlInfoProviderInfo(pt, x)));
-					}
-				}
-			}
-		}
+    public class XmlInfoProviderFactory : ProviderFactoryBase<XmlInfoProvider>
+    {
+        public void RegisterProvider(Type pt, IEnumerable<XmlInfoFile> xmlInfoFile, bool withLocking = true)
+        {
+            using (withLocking ? rwLock.UpgradeableReadLock() : null)
+            {
+                if (!providerDict.Any(pi => pi.ProviderType == pt))
+                {
+                    using (withLocking ? rwLock.WriteLock() : null)
+                    {
+                        xmlInfoFile.ForEach(x => providerDict.Add(new XmlInfoProviderInfo(pt, x)));
+                    }
+                }
+            }
+        }
 
-		public override void RegisterProvider(Type pt, bool withLocking = true)
-		{
-			IValidateProvider validateProvider = Activator.CreateInstance(pt) as IValidateProvider;
-			if (validateProvider == null || validateProvider.IsValid)
-			{
-				IEnumerable<XmlInfoFile> xmlInfos = pt.GetAttributes<XmlInfoFileAttribute>().Select(ffa => new XmlInfoFile(ffa.XmlInfoFile, ffa.Order));
-				RegisterProvider(pt, xmlInfos, withLocking);
-			}
-		}
+        public override void RegisterProvider(Type pt, bool withLocking = true)
+        {
+            IValidateProvider validateProvider = Activator.CreateInstance(pt) as IValidateProvider;
+            if (validateProvider == null || validateProvider.IsValid)
+            {
+                IEnumerable<XmlInfoFile> xmlInfos = pt.GetAttributes<XmlInfoFileAttribute>().Select(ffa => new XmlInfoFile(ffa.XmlInfoFile, ffa.Order));
+                RegisterProvider(pt, xmlInfos, withLocking);
+            }
+        }
 
-		public IEnumerable<XmlInfoProviderInfo> GetProviderInfos()
-		{
-			return GetProviderInfos<XmlInfoProviderInfo>().OrderBy(x => x.XmlInfoFile.Order);
-		}
+        public IEnumerable<XmlInfoProviderInfo> GetProviderInfos(Type type)
+        {
+            //find the type via the attribute, if it exists, otherwise find it via the generic argument of the provider type
+            if (TryParse(type, out XmlInfoType xmlInfoType))
+                return GetProviderInfos<XmlInfoProviderInfo>().Where(x => x.XmlInfoFile.XmlInfoType == xmlInfoType).OrderBy(x => x.XmlInfoFile.Order);
 
-		public IEnumerable<XmlInfoFile> GetXmlInfoFiles()
-		{
-			return GetProviderInfos().Select(p => p.XmlInfoFile);
-		}
+            return Enumerable.Empty<XmlInfoProviderInfo>();
+        }
 
-		public IEnumerable<XmlInfoProvider> CreateProviders()
-		{
-			return base.CreateProviders<XmlInfoProviderInfo>();
-		}
+        public IEnumerable<XmlInfoProviderInfo> GetProviderInfos()
+        {
+            return GetProviderInfos<XmlInfoProviderInfo>().OrderBy(x => x.XmlInfoFile.Order);
+        }
 
-		public ComicInfo DeserializeAll(Func<string, Stream> getDataDelegate)
-		{
-			foreach (var providerInfo in GetProviderInfos())
-			{
-				Type type = providerInfo.ProviderType;
-				XmlInfoProvider providerObject = Activator.CreateInstance(type) as XmlInfoProvider;
-				ComicInfo comicInfo = providerObject.Deserialize(getDataDelegate, providerInfo.XmlInfoFile.FileName);
+        public IEnumerable<XmlInfoFile> GetXmlInfoFiles()
+        {
+            return GetProviderInfos().Select(p => p.XmlInfoFile);
+        }
 
-				if (comicInfo is not null)
-					return comicInfo;
-			}
-			return null;
-		}
-	}
+        public IEnumerable<XmlInfoProvider> CreateProviders()
+        {
+            return base.CreateProviders<XmlInfoProviderInfo>();
+        }
+
+        public T DeserializeAll<T>(Func<string, Stream> getDataDelegate) where T : class
+        {
+            foreach (var providerInfo in GetProviderInfos(typeof(T)))
+            {
+                Type type = providerInfo.ProviderType;
+                XmlInfoProvider<T> providerObject = Activator.CreateInstance(type) as XmlInfoProvider<T>;
+                T comicInfo = providerObject.Deserialize(getDataDelegate, providerInfo.XmlInfoFile.FileName);
+
+                if (comicInfo is not null)
+                    return comicInfo;
+            }
+            return null;
+        }
+
+        private bool TryParse(Type type, out XmlInfoType xmlInfoType)
+        {
+            return Enum.TryParse(type.Name, out xmlInfoType);
+        }
+    }
 }

--- a/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoProviderInfo.cs
+++ b/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoProviderInfo.cs
@@ -24,5 +24,5 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
 		}
 	}
 
-	public record XmlInfoFile(string FileName, int Order, XmlInfoType XmlInfoType = XmlInfoType.ComicInfo);
+	public record XmlInfoFile(string FileName, int Order);
 }

--- a/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoProviderInfo.cs
+++ b/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoProviderInfo.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
 {
-	public class XmlInfoProviderInfo : IProviderInfo
+    public class XmlInfoProviderInfo : IProviderInfo
 	{
 		public Type ProviderType
 		{
@@ -24,5 +24,5 @@ namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
 		}
 	}
 
-	public record XmlInfoFile(string FileName, int Order);
+	public record XmlInfoFile(string FileName, int Order, XmlInfoType XmlInfoType = XmlInfoType.ComicInfo);
 }

--- a/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoType.cs
+++ b/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoType.cs
@@ -1,8 +1,0 @@
-﻿namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
-{
-    public enum XmlInfoType
-    {
-        ComicInfo,
-        ComicBook,
-    }
-}

--- a/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoType.cs
+++ b/ComicRack.Engine/IO/Provider/XmlInfo/XmlInfoType.cs
@@ -1,0 +1,8 @@
+﻿namespace cYo.Projects.ComicRack.Engine.IO.Provider.XmlInfo
+{
+    public enum XmlInfoType
+    {
+        ComicInfo,
+        ComicBook,
+    }
+}

--- a/ComicRack.Engine/IO/StorageSetting.cs
+++ b/ComicRack.Engine/IO/StorageSetting.cs
@@ -37,7 +37,7 @@ namespace cYo.Projects.ComicRack.Engine.IO
 			set;
 		}
 
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         public bool EmbedComicBook
         {
             get;
@@ -175,7 +175,7 @@ namespace cYo.Projects.ComicRack.Engine.IO
 			RemovePages = true;
 			RemovePageFilter = ComicPageType.Deleted;
 			EmbedComicInfo = true;
-			EmbedComicBook = false;
+			EmbedComicBook = true;
             ComicCompression = ExportCompression.None;
 			ThumbnailSize = new Size(0, 256);
 			DoublePages = DoublePageHandling.Keep;

--- a/ComicRack.Engine/IO/StorageSetting.cs
+++ b/ComicRack.Engine/IO/StorageSetting.cs
@@ -37,7 +37,14 @@ namespace cYo.Projects.ComicRack.Engine.IO
 			set;
 		}
 
-		[DefaultValue(true)]
+        [DefaultValue(false)]
+        public bool EmbedComicBook
+        {
+            get;
+            set;
+        }
+
+        [DefaultValue(true)]
 		public bool RemovePages
 		{
 			get;
@@ -168,7 +175,8 @@ namespace cYo.Projects.ComicRack.Engine.IO
 			RemovePages = true;
 			RemovePageFilter = ComicPageType.Deleted;
 			EmbedComicInfo = true;
-			ComicCompression = ExportCompression.None;
+			EmbedComicBook = false;
+            ComicCompression = ExportCompression.None;
 			ThumbnailSize = new Size(0, 256);
 			DoublePages = DoublePageHandling.Keep;
 			Resampling = EngineConfiguration.Default.ExportResampling;

--- a/ComicRack.Engine/IO/StorageSetting.cs
+++ b/ComicRack.Engine/IO/StorageSetting.cs
@@ -37,7 +37,7 @@ namespace cYo.Projects.ComicRack.Engine.IO
 			set;
 		}
 
-        [DefaultValue(true)]
+        [DefaultValue(false)]
         public bool EmbedComicBook
         {
             get;
@@ -175,7 +175,7 @@ namespace cYo.Projects.ComicRack.Engine.IO
 			RemovePages = true;
 			RemovePageFilter = ComicPageType.Deleted;
 			EmbedComicInfo = true;
-			EmbedComicBook = true;
+			EmbedComicBook = false;
             ComicCompression = ExportCompression.None;
 			ThumbnailSize = new Size(0, 256);
 			DoublePages = DoublePageHandling.Keep;

--- a/ComicRack.Engine/Metadata/ComicBook/Matcher/ComicBookModifiedLibraryInfoMatcher.cs
+++ b/ComicRack.Engine/Metadata/ComicBook/Matcher/ComicBookModifiedLibraryInfoMatcher.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ComponentModel;
+
+namespace cYo.Projects.ComicRack.Engine
+{
+	[Serializable]
+	[Description("Modified Library Info")]
+	[ComicBookMatcherHint("ComicBookIsDirty")]
+	public class ComicBookModifiedLibraryInfoMatcher : ComicBookYesNoMatcher
+	{
+		protected override YesNo GetValue(ComicBook comicBook)
+		{
+			if (!comicBook.ComicBookIsDirty)
+			{
+				return YesNo.No;
+			}
+			return YesNo.Yes;
+		}
+	}
+}

--- a/ComicRack.Engine/QueueManager.cs
+++ b/ComicRack.Engine/QueueManager.cs
@@ -567,7 +567,7 @@ namespace cYo.Projects.ComicRack.Engine
 				long oldSize = cb.FileSize;
 				DateTime oldWrite = cb.FileModifiedTime;
 				cb.WriteError += writeErrorHandler; // Write error to the list of update errors to be shown in the UI.
-				if (cb.WriteInfoToFile(withRefreshFileProperties: false))
+				if (cb.WriteInfoToFile(Settings, withRefreshFileProperties: false))
 				{
 					CacheManager.ImagePool.Pages.UpdateKeys((ImageKey key) => key.IsSameFile(cb.FilePath, oldSize, oldWrite), (ImageKey key) => key.UpdateFileInfo());
 					CacheManager.ImagePool.Thumbs.UpdateKeys((ImageKey key) => key.IsSameFile(cb.FilePath, oldSize, oldWrite), (ImageKey key) => key.UpdateFileInfo());

--- a/ComicRack.Engine/QueueManager.cs
+++ b/ComicRack.Engine/QueueManager.cs
@@ -407,11 +407,14 @@ namespace cYo.Projects.ComicRack.Engine
 			string outPath = default(string);
 			ExportComicsQueue.AddItem(kcb, (IAsyncResult ar) =>
 			{
-				bool clearDirtyFlag = setting.EmbedComicInfo && kcb.ComicInfoIsDirty; // clear the dirty flag after export if we embedded the comic info
-				EventHandler<BookChangedEventArgs> keepDirtyOnComicInfoUpdate = (s, e) =>
+				bool clearDirtyInfoFlag = setting.EmbedComicInfo && kcb.ComicInfoIsDirty; // clear the dirty flag after export if we embedded the comic info
+				bool clearDirtyBookFlag = setting.EmbedComicBook && kcb.ComicBookIsDirty; // clear the dirty flag after export if we embedded the library info
+                EventHandler<BookChangedEventArgs> keepDirtyOnInfoUpdate = (s, e) =>
 				{
-					if (e.IsComicInfo) // only clear the dirty flag when only the comic info has changed and not ComicBook properties
-						clearDirtyFlag = false;
+					if (e.IsComicInfo) // only clear the dirty flag when info that can be dirty have changed
+						clearDirtyInfoFlag = false;
+					else if (e.IsComicBook)
+						clearDirtyBookFlag = false;
 				};
 
 				foreach (ComicBook cb in cbs)
@@ -453,12 +456,12 @@ namespace cYo.Projects.ComicRack.Engine
 					// if the book data changes (manually) during export, we want to keep the dirty flag
 					// But only for cases when not using replaceSource, since that path will revert any changes made during export anyway. 
 					if (!isLocalAndReplaceSource)
-						kcb.BookChanged += keepDirtyOnComicInfoUpdate;
+						kcb.BookChanged += keepDirtyOnInfoUpdate;
 
 					outPath = comicExporter.Export(CacheManager.ImagePool);
 					if (outPath != null)
 					{
-						kcb.BookChanged -= keepDirtyOnComicInfoUpdate; // Unsubscribe from the event before changing values to avoid clearing the clearDirtyFlag when we change the book after export
+						kcb.BookChanged -= keepDirtyOnInfoUpdate; // Unsubscribe from the event before changing values to avoid clearing the clearDirtyFlag when we change the book after export
 						source = source.Where((string p) => !string.Equals(p, outPath, StringComparison.OrdinalIgnoreCase)); // source file names that differ from the new outPath
 						bool wasReplaced = isLocalAndReplaceSource || kcb.FilePath.Equals(outPath, StringComparison.OrdinalIgnoreCase); // files can be replaced by simply exporting to the same location and overwriting
 						if (isLocalAndReplaceSource)
@@ -495,9 +498,12 @@ namespace cYo.Projects.ComicRack.Engine
 						}
 
 						// We only want to clear the dirty flag if we replaced a file, otherwise it's a new file so clearing the flag would remove it from the original anyway
-						if (clearDirtyFlag && wasReplaced)
-							kcb.ComicInfoIsDirty = false; // clear the dirty flag since it was embeded during export
-					}
+						if (clearDirtyInfoFlag && wasReplaced)
+							kcb.ComicInfoIsDirty = false; // clear the dirty info flag since it was embeded during export
+
+                        if (clearDirtyBookFlag && wasReplaced)
+                            kcb.ComicBookIsDirty = false; // clear the dirty book flag since it was embeded during export
+                    }
 				}
 				catch (OperationCanceledException) { } //Since we cancelled don't add it as an error, just ignore it.
 				catch
@@ -529,25 +535,29 @@ namespace cYo.Projects.ComicRack.Engine
 		private readonly ConcurrentDictionary<ComicBook, Timer> debounceTimers = new();
 		public void AddBookToFileUpdate(ComicBook cb, bool alwaysWrite)
 		{
-			if (cb == null || !cb.IsLinked || !cb.ComicInfoIsDirty || !cb.FileInfoRetrieved || !Settings.UpdateComicFiles || !(Settings.AutoUpdateComicsFiles || alwaysWrite))
+			if (cb == null || !cb.IsLinked || !cb.FileInfoRetrieved || !Settings.UpdateComicFiles || !(Settings.AutoUpdateComicsFiles || alwaysWrite))
 				return;
 
-			// Cancel existing timer if one is running
-			if (debounceTimers.TryRemove(cb, out var t))
-				t?.Dispose();
-
-			debounceTimers[cb] = new Timer(_ =>
+            // Only continue when cb.ComicInfoIsDirty is true OR cb.ComicBookIsDirty and UpdateComicBookFiles are both true
+            if (cb.ComicInfoIsDirty || (Settings.UpdateComicBookFiles && cb.ComicBookIsDirty))
 			{
-				// Removes timer since it just executed
+				// Cancel existing timer if one is running
 				if (debounceTimers.TryRemove(cb, out var t))
 					t?.Dispose();
 
-				WriteComicBookInfoFileQueue.AddItem(cb, delegate
+				debounceTimers[cb] = new Timer(_ =>
 				{
-					if (cb.ComicInfoIsDirty && Settings.UpdateComicFiles && (Settings.AutoUpdateComicsFiles || alwaysWrite))
-						WriteInfoToFileWithCacheUpdate(cb);
-				});
-			}, null, 100, Timeout.Infinite);
+					// Removes timer since it just executed
+					if (debounceTimers.TryRemove(cb, out var t))
+						t?.Dispose();
+
+					WriteComicBookInfoFileQueue.AddItem(cb, delegate
+					{
+						if (((cb.ComicInfoIsDirty && Settings.UpdateComicFiles) || (cb.ComicBookIsDirty && Settings.UpdateComicBookFiles)) && (Settings.AutoUpdateComicsFiles || alwaysWrite))
+							WriteInfoToFileWithCacheUpdate(cb);
+					});
+				}, null, 100, Timeout.Infinite); 
+			}
 		}
 
 		public void AddBookToFileUpdate(ComicBook cb)
@@ -574,6 +584,9 @@ namespace cYo.Projects.ComicRack.Engine
 
 					cb.RefreshFileProperties();
 					cb.ComicInfoIsDirty = false;
+
+					if (Settings.UpdateComicBookFiles) // This might be ran even when only the info is dirty, so we don't want 
+						cb.ComicBookIsDirty = false;
 				}
 			}
 			catch (Exception)

--- a/ComicRack/Config/Settings.cs
+++ b/ComicRack/Config/Settings.cs
@@ -201,7 +201,9 @@ namespace cYo.Projects.ComicRack.Viewer.Config
 
 		private bool updateComicFiles;
 
-		private bool autoUpdateComicsFiles;
+		private bool updateComicBookFiles;
+
+        private bool autoUpdateComicsFiles;
 
 		private string helpSystem = DefaultHelpSystem;
 
@@ -996,7 +998,27 @@ namespace cYo.Projects.ComicRack.Viewer.Config
 			}
 		}
 
-		[Category("Behavior")]
+        [Category("Behavior")]
+        [Description("Update Book Files with extra information")]
+        [DefaultValue(false)]
+        [Browsable(false)]
+        public bool UpdateComicBookFiles
+        {
+            get
+            {
+                return updateComicBookFiles;
+            }
+            set
+            {
+                if (updateComicBookFiles != value)
+                {
+                    updateComicBookFiles = value;
+                    FireEvent(this.UpdateComicBookFilesChanged);
+                }
+            }
+        }
+
+        [Category("Behavior")]
 		[Description("Auto update of Book files")]
 		[DefaultValue(false)]
 		[Browsable(false)]
@@ -2517,7 +2539,10 @@ namespace cYo.Projects.ComicRack.Viewer.Config
 		[field: NonSerialized]
 		public event EventHandler UpdateComicFilesChanged;
 
-		[field: NonSerialized]
+        [field: NonSerialized]
+        public event EventHandler UpdateComicBookFilesChanged;
+
+        [field: NonSerialized]
 		public event EventHandler BlendWhilePagingChanged;
 
 		[field: NonSerialized]

--- a/ComicRack/Controls/CoverViewItem.cs
+++ b/ComicRack/Controls/CoverViewItem.cs
@@ -484,11 +484,10 @@ namespace cYo.Projects.ComicRack.Viewer.Controls
 			Rectangle rectangle = drawInfo.Bounds;
 			Font font = base.View.Font;
 			List<Image> list = null;
-			if (Comic.ComicInfoIsDirty && Comic.IsLinked && Program.Settings.UpdateComicFiles)
-			{
-				list = list.SafeAdd(IsDirtyImage);
-			}
-			switch (marker)
+            if (Comic.IsLinked && ((Comic.ComicInfoIsDirty && Program.Settings.UpdateComicFiles) || (Comic.ComicBookIsDirty && Program.Settings.UpdateComicBookFiles)))
+                list = list.SafeAdd(IsDirtyImage);
+
+            switch (marker)
 			{
 			case MarkerType.IsOpen:
 				list = list.SafeAdd(MarkerIsOpenImage);

--- a/ComicRack/Dialogs/ComicBookDialog.cs
+++ b/ComicRack/Dialogs/ComicBookDialog.cs
@@ -291,11 +291,11 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             bool canEditProperties = comic.EditMode.CanEditProperties();
             tabDetails.Enabled = tabPlot.Enabled = tabColors.Enabled = canEdit && canEditProperties;
             txCommunityRating.Enabled = tabPages.Enabled = canEdit && comic.EditMode.CanEditPages();
-            tabCatalog.Enabled = tabCustom.Enabled = isFilelessOrInContainer && canEditProperties;
+            tabCatalog.Enabled = tabCustom.Enabled = (isFilelessOrInContainer || Program.Settings.UpdateComicBookFiles) && canEditProperties;
             EnableTabPage(tabPages, comic.IsLinked);
             EnableTabPage(tabColors, comic.IsLinked);
-            EnableTabPage(tabCatalog, (!comic.IsLinked || !Program.Settings.CatalogOnlyForFileless) && isFilelessOrInContainer);
-            EnableTabPage(tabCustom, Program.Settings.ShowCustomBookFields && isFilelessOrInContainer);
+            EnableTabPage(tabCatalog, (!comic.IsLinked || !Program.Settings.CatalogOnlyForFileless) && (isFilelessOrInContainer || Program.Settings.UpdateComicBookFiles));
+            EnableTabPage(tabCustom, Program.Settings.ShowCustomBookFields && (isFilelessOrInContainer || Program.Settings.UpdateComicBookFiles));
             labelEnableProposed.Visible = cbEnableProposed.Visible = labelScanInformation.Visible = txScanInformation.Visible = comic.IsLinked;
             labelOpenedTime.Visible = dtpOpenedTime.Visible = labelPagesAsTextSimple.Visible = txPagesAsTextSimple.Visible = !comic.IsLinked;
             txRating.Enabled = cbEnableProposed.Enabled = cbSeriesComplete.Enabled = isFilelessOrInContainer;

--- a/ComicRack/Dialogs/ComicBookDialog.cs
+++ b/ComicRack/Dialogs/ComicBookDialog.cs
@@ -298,7 +298,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             EnableTabPage(tabCustom, Program.Settings.ShowCustomBookFields && (isFilelessOrInContainer || Program.Settings.UpdateComicBookFiles));
             labelEnableProposed.Visible = cbEnableProposed.Visible = labelScanInformation.Visible = txScanInformation.Visible = comic.IsLinked;
             labelOpenedTime.Visible = dtpOpenedTime.Visible = labelPagesAsTextSimple.Visible = txPagesAsTextSimple.Visible = !comic.IsLinked;
-            txRating.Enabled = cbEnableProposed.Enabled = cbSeriesComplete.Enabled = isFilelessOrInContainer;
+            txRating.Enabled = cbEnableProposed.Enabled = cbSeriesComplete.Enabled = (isFilelessOrInContainer || Program.Settings.UpdateComicBookFiles);
             if (!canEditProperties)
             {
                 txCommunityRating.Enabled = txRating.Enabled = false;

--- a/ComicRack/Dialogs/ComicDataPasteDialog.cs
+++ b/ComicRack/Dialogs/ComicDataPasteDialog.cs
@@ -162,8 +162,8 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
                     openedTime.Visible = pageCount.Visible = openedTime.Enabled = pageCount.Enabled = false;
                 }
 
-                // If books aren't in the library, disable the "Rating", "Color" and "Series Complete" checkboxes.
-                if (!books.Any((ComicBook cb) => cb.IsInContainer))
+                // If books aren't in the library, disable the "Rating", "Color" and "Series Complete" checkboxes. Unless the UpdateComicBookFiles is enabled
+                if (!Program.Settings.UpdateComicBookFiles && !books.Any((ComicBook cb) => cb.IsInContainer))
                 {
                     CheckBox rating = comicDataPasteDialog.chkRating;
                     CheckBox color = comicDataPasteDialog.chkColor;

--- a/ComicRack/Dialogs/ExportComicsDialog.Designer.cs
+++ b/ComicRack/Dialogs/ExportComicsDialog.Designer.cs
@@ -98,6 +98,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             this.labelExportTo = new System.Windows.Forms.Label();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.chkLossless = new System.Windows.Forms.CheckBox();
+            this.chkEmbedComicBook = new System.Windows.Forms.CheckBox();
             this.exportSettings.SuspendLayout();
             this.grpImageProcessing.SuspendLayout();
             this.grpCustomProcessing.SuspendLayout();
@@ -592,6 +593,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             this.grpFileFormat.Controls.Add(this.cbCompression);
             this.grpFileFormat.Controls.Add(this.labelCompression);
             this.grpFileFormat.Controls.Add(this.chkEmbedComicInfo);
+            this.grpFileFormat.Controls.Add(this.chkEmbedComicBook);
             this.grpFileFormat.Controls.Add(this.cbComicFormat);
             this.grpFileFormat.Controls.Add(this.labelComicFormat);
             this.grpFileFormat.Controls.Add(this.txRemovedPages);
@@ -946,6 +948,17 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             this.chkLossless.TabIndex = 14;
             this.chkLossless.Text = "Lossless compression";
             this.chkLossless.UseVisualStyleBackColor = true;
+            //
+            // chkEmbedComicBook
+            // 
+            this.chkEmbedComicBook.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.chkEmbedComicBook.AutoSize = true;
+            this.chkEmbedComicBook.Location = new System.Drawing.Point(295, 89);
+            this.chkEmbedComicBook.Name = "chkEmbedComicBook";
+            this.chkEmbedComicBook.Size = new System.Drawing.Size(114, 17);
+            this.chkEmbedComicBook.TabIndex = 12;
+            this.chkEmbedComicBook.Text = "Embed Library Info";
+            this.chkEmbedComicBook.UseVisualStyleBackColor = true;
             // 
             // ExportComicsDialog
             // 
@@ -1059,5 +1072,6 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 		private TextBoxEx txTagsToAppend;
 		private Label labelTagToAppend;
         private CheckBox chkLossless;
+        private CheckBox chkEmbedComicBook;
     }
 }

--- a/ComicRack/Dialogs/ExportComicsDialog.cs
+++ b/ComicRack/Dialogs/ExportComicsDialog.cs
@@ -106,7 +106,8 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 					FormatId = FormatId,
 					ComicCompression = (ExportCompression)cbCompression.SelectedIndex,
 					EmbedComicInfo = chkEmbedComicInfo.Checked,
-					RemovePageFilter = (ComicPageType)enumUtil.Value,
+					EmbedComicBook = chkEmbedComicBook.Checked,
+                    RemovePageFilter = (ComicPageType)enumUtil.Value,
 					IncludePages = txIncludePages.Text,
 					PageType = (StoragePageType)cbPageFormat.SelectedIndex,
 					PageCompression = tbQuality.Value,
@@ -138,7 +139,8 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 				FormatId = value.FormatId;
 				cbCompression.SelectedIndex = (int)value.ComicCompression;
 				chkEmbedComicInfo.Checked = value.EmbedComicInfo;
-				enumUtil.Value = (int)value.RemovePageFilter;
+				chkEmbedComicBook.Checked = value.EmbedComicBook;
+                enumUtil.Value = (int)value.RemovePageFilter;
 				txIncludePages.Text = value.IncludePages;
 				cbPageFormat.SelectedIndex = (int)value.PageType < cbPageFormat.Items.Count ? (int)value.PageType : 0;
 				tbQuality.Value = value.PageCompression;
@@ -212,7 +214,8 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 			chkDontEnlarge.Enabled = setting.PageResize != StoragePageResize.Original;
 			btRemovePreset.Enabled = tvPresets.SelectedNode != null && tvPresets.SelectedNode.Parent != null && (bool)tvPresets.SelectedNode.Parent.Tag;
 			grpCustomProcessing.Enabled = setting.ImageProcessingSource == ExportImageProcessingSource.Custom;
-		}
+			chkEmbedComicBook.Enabled = setting.EmbedComicInfo; // Only enable Embed Comic Book option if Embed Comic Info is checked, since it depends on it
+        }
 
 		private void tbQuality_ValueChanged(object sender, EventArgs e)
 		{

--- a/ComicRack/Dialogs/PreferencesDialog.Designer.cs
+++ b/ComicRack/Dialogs/PreferencesDialog.Designer.cs
@@ -16,2707 +16,2719 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 
         private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PreferencesDialog));
-			System.Windows.Forms.ListViewGroup listViewGroup1 = new System.Windows.Forms.ListViewGroup("Installed", System.Windows.Forms.HorizontalAlignment.Left);
-			System.Windows.Forms.ListViewGroup listViewGroup2 = new System.Windows.Forms.ListViewGroup("To be removed (requires restart)", System.Windows.Forms.HorizontalAlignment.Left);
-			System.Windows.Forms.ListViewGroup listViewGroup3 = new System.Windows.Forms.ListViewGroup("To be installed (requires restart)", System.Windows.Forms.HorizontalAlignment.Left);
-			this.btOK = new System.Windows.Forms.Button();
-			this.btCancel = new System.Windows.Forms.Button();
-			this.imageList = new System.Windows.Forms.ImageList(this.components);
-			this.btApply = new System.Windows.Forms.Button();
-			this.toolTip = new System.Windows.Forms.ToolTip(this.components);
-			this.pageBehavior = new System.Windows.Forms.Panel();
-			this.pageReader = new System.Windows.Forms.Panel();
-			this.groupHardwareAcceleration = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.chkEnableHardwareFiltering = new System.Windows.Forms.CheckBox();
-			this.chkEnableSoftwareFiltering = new System.Windows.Forms.CheckBox();
-			this.chkEnableHardware = new System.Windows.Forms.CheckBox();
-			this.chkEnableDisplayChangeAnimation = new System.Windows.Forms.CheckBox();
-			this.grpMouse = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.chkSmoothAutoScrolling = new System.Windows.Forms.CheckBox();
-			this.lblFast = new System.Windows.Forms.Label();
-			this.lblMouseWheel = new System.Windows.Forms.Label();
-			this.chkEnableInertialMouseScrolling = new System.Windows.Forms.CheckBox();
-			this.lblSlow = new System.Windows.Forms.Label();
-			this.tbMouseWheel = new cYo.Common.Windows.Forms.TrackBarLite();
-			this.groupOverlays = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.panelReaderOverlays = new System.Windows.Forms.Panel();
-			this.labelVisiblePartOverlay = new System.Windows.Forms.Label();
-			this.labelNavigationOverlay = new System.Windows.Forms.Label();
-			this.labelStatusOverlay = new System.Windows.Forms.Label();
-			this.labelPageOverlay = new System.Windows.Forms.Label();
-			this.cbNavigationOverlayPosition = new System.Windows.Forms.ComboBox();
-			this.labelNavigationOverlayPosition = new System.Windows.Forms.Label();
-			this.chkShowPageNames = new System.Windows.Forms.CheckBox();
-			this.tbOverlayScaling = new cYo.Common.Windows.Forms.TrackBarLite();
-			this.chkShowCurrentPageOverlay = new System.Windows.Forms.CheckBox();
-			this.chkShowStatusOverlay = new System.Windows.Forms.CheckBox();
-			this.chkShowVisiblePartOverlay = new System.Windows.Forms.CheckBox();
-			this.chkShowNavigationOverlay = new System.Windows.Forms.CheckBox();
-			this.labelOverlaySize = new System.Windows.Forms.Label();
-			this.grpKeyboard = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.btExportKeyboard = new System.Windows.Forms.Button();
-			this.btImportKeyboard = new cYo.Common.Windows.Forms.SplitButton();
-			this.cmKeyboardLayout = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.miDefaultKeyboardLayout = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
-			this.keyboardShortcutEditor = new cYo.Common.Windows.Forms.KeyboardShortcutEditor();
-			this.grpDisplay = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.tbGamma = new cYo.Common.Windows.Forms.TrackBarLite();
-			this.labelGamma = new System.Windows.Forms.Label();
-			this.chkAnamorphicScaling = new System.Windows.Forms.CheckBox();
-			this.chkHighQualityDisplay = new System.Windows.Forms.CheckBox();
-			this.labelSharpening = new System.Windows.Forms.Label();
-			this.tbSharpening = new cYo.Common.Windows.Forms.TrackBarLite();
-			this.btResetColor = new System.Windows.Forms.Button();
-			this.chkAutoContrast = new System.Windows.Forms.CheckBox();
-			this.labelSaturation = new System.Windows.Forms.Label();
-			this.tbSaturation = new cYo.Common.Windows.Forms.TrackBarLite();
-			this.labelBrightness = new System.Windows.Forms.Label();
-			this.tbBrightness = new cYo.Common.Windows.Forms.TrackBarLite();
-			this.tbContrast = new cYo.Common.Windows.Forms.TrackBarLite();
-			this.labelContrast = new System.Windows.Forms.Label();
-			this.pageAdvanced = new System.Windows.Forms.Panel();
-			this.grpWirelessSetup = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.btTestWifi = new System.Windows.Forms.Button();
-			this.lblWifiStatus = new System.Windows.Forms.Label();
-			this.lblWifiAddresses = new System.Windows.Forms.Label();
-			this.txWifiAddresses = new System.Windows.Forms.TextBox();
-			this.grpIntegration = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.btAssociateExtensions = new System.Windows.Forms.Button();
-			this.labelCheckedFormats = new System.Windows.Forms.Label();
-			this.chkOverwriteAssociations = new System.Windows.Forms.CheckBox();
-			this.lbFormats = new System.Windows.Forms.CheckedListBox();
-			this.groupMessagesAndSocial = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.btResetMessages = new System.Windows.Forms.Button();
-			this.labelReshowHidden = new System.Windows.Forms.Label();
-			this.groupMemory = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.grpMaximumMemoryUsage = new System.Windows.Forms.GroupBox();
-			this.lblMaximumMemoryUsageValue = new System.Windows.Forms.Label();
-			this.tbMaximumMemoryUsage = new cYo.Common.Windows.Forms.TrackBarLite();
-			this.lblMaximumMemoryUsage = new System.Windows.Forms.Label();
-			this.grpMemoryCache = new System.Windows.Forms.GroupBox();
-			this.lblPageMemCacheUsage = new System.Windows.Forms.Label();
-			this.labelMemThumbSize = new System.Windows.Forms.Label();
-			this.lblThumbMemCacheUsage = new System.Windows.Forms.Label();
-			this.numMemPageCount = new System.Windows.Forms.NumericUpDown();
-			this.labelMemPageCount = new System.Windows.Forms.Label();
-			this.chkMemPageOptimized = new System.Windows.Forms.CheckBox();
-			this.chkMemThumbOptimized = new System.Windows.Forms.CheckBox();
-			this.numMemThumbSize = new System.Windows.Forms.NumericUpDown();
-			this.grpDiskCache = new System.Windows.Forms.GroupBox();
-			this.chkEnableInternetCache = new System.Windows.Forms.CheckBox();
-			this.lblInternetCacheUsage = new System.Windows.Forms.Label();
-			this.btClearPageCache = new System.Windows.Forms.Button();
-			this.numPageCacheSize = new System.Windows.Forms.NumericUpDown();
-			this.numInternetCacheSize = new System.Windows.Forms.NumericUpDown();
-			this.btClearThumbnailCache = new System.Windows.Forms.Button();
-			this.btClearInternetCache = new System.Windows.Forms.Button();
-			this.chkEnablePageCache = new System.Windows.Forms.CheckBox();
-			this.lblPageCacheUsage = new System.Windows.Forms.Label();
-			this.numThumbnailCacheSize = new System.Windows.Forms.NumericUpDown();
-			this.chkEnableThumbnailCache = new System.Windows.Forms.CheckBox();
-			this.lblThumbCacheUsage = new System.Windows.Forms.Label();
-			this.grpBackupManager = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.chkIncludeAllAlternateConfigs = new System.Windows.Forms.CheckBox();
-			this.numBackupsToKeep = new System.Windows.Forms.NumericUpDown();
-			this.lblBackupsToKeep = new System.Windows.Forms.Label();
-			this.lbBackupOptions = new System.Windows.Forms.CheckedListBox();
-			this.btBackupLocation = new System.Windows.Forms.Button();
-			this.txtBackupLocation = new System.Windows.Forms.TextBox();
-			this.lblBackupLocation = new System.Windows.Forms.Label();
-			this.grpDatabaseBackup = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.btRestoreDatabase = new System.Windows.Forms.Button();
-			this.btBackupDatabase = new System.Windows.Forms.Button();
-			this.groupOtherComics = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.chkUpdateComicFiles = new System.Windows.Forms.CheckBox();
-			this.labelExcludeCover = new System.Windows.Forms.Label();
-			this.chkAutoUpdateComicFiles = new System.Windows.Forms.CheckBox();
-			this.txCoverFilter = new System.Windows.Forms.TextBox();
-			this.grpLanguages = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.btTranslate = new System.Windows.Forms.Button();
-			this.labelLanguage = new System.Windows.Forms.Label();
-			this.lbLanguages = new System.Windows.Forms.ListBox();
-			this.pageLibrary = new System.Windows.Forms.Panel();
-			this.grpVirtualTags = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.btnVTagsHelp = new System.Windows.Forms.Button();
-			this.grpVtagConfig = new System.Windows.Forms.GroupBox();
-			this.lblCaptionFormat = new System.Windows.Forms.Label();
-			this.txtCaptionFormat = new System.Windows.Forms.TextBox();
-			this.btInsertValue = new System.Windows.Forms.Button();
-			this.lblVirtualTagDescription = new System.Windows.Forms.Label();
-			this.lblVirtualTagName = new System.Windows.Forms.Label();
-			this.txtVirtualTagDescription = new System.Windows.Forms.TextBox();
-			this.txtVirtualTagName = new System.Windows.Forms.TextBox();
-			this.chkVirtualTagEnable = new System.Windows.Forms.CheckBox();
-			this.lblCaptionText = new System.Windows.Forms.Label();
-			this.lblCaptionSuffix = new System.Windows.Forms.Label();
-			this.rtfVirtualTagCaption = new System.Windows.Forms.RichTextBox();
-			this.lblFieldConfig = new System.Windows.Forms.Label();
-			this.txtCaptionPrefix = new System.Windows.Forms.TextBox();
-			this.lblCaptionPrefix = new System.Windows.Forms.Label();
-			this.btnCaptionInsert = new System.Windows.Forms.Button();
-			this.txtCaptionSuffix = new System.Windows.Forms.TextBox();
-			this.lblVirtualTags = new System.Windows.Forms.Label();
-			this.cbVirtualTags = new System.Windows.Forms.ComboBox();
-			this.grpServerSettings = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.txPrivateListingPassword = new cYo.Common.Windows.Forms.PasswordTextBox();
-			this.labelPrivateListPassword = new System.Windows.Forms.Label();
-			this.labelPublicServerAddress = new System.Windows.Forms.Label();
-			this.txPublicServerAddress = new System.Windows.Forms.TextBox();
-			this.grpSharing = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.chkAutoConnectShares = new System.Windows.Forms.CheckBox();
-			this.btRemoveShare = new System.Windows.Forms.Button();
-			this.btAddShare = new System.Windows.Forms.Button();
-			this.tabShares = new System.Windows.Forms.TabControl();
-			this.chkLookForShared = new System.Windows.Forms.CheckBox();
-			this.groupLibraryDisplay = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.chkLibraryGaugesTotal = new System.Windows.Forms.CheckBox();
-			this.chkLibraryGaugesUnread = new System.Windows.Forms.CheckBox();
-			this.chkLibraryGaugesNumeric = new System.Windows.Forms.CheckBox();
-			this.chkLibraryGaugesNew = new System.Windows.Forms.CheckBox();
-			this.chkLibraryGauges = new System.Windows.Forms.CheckBox();
-			this.grpScanning = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.chkDontAddRemovedFiles = new System.Windows.Forms.CheckBox();
-			this.chkAutoRemoveMissing = new System.Windows.Forms.CheckBox();
-			this.lblScan = new System.Windows.Forms.Label();
-			this.btScan = new System.Windows.Forms.Button();
-			this.groupComicFolders = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.btOpenFolder = new System.Windows.Forms.Button();
-			this.btChangeFolder = new System.Windows.Forms.Button();
-			this.lbPaths = new cYo.Common.Windows.Forms.CheckedListBoxEx();
-			this.labelWatchedFolders = new System.Windows.Forms.Label();
-			this.btRemoveFolder = new System.Windows.Forms.Button();
-			this.btAddFolder = new System.Windows.Forms.Button();
-			this.memCacheUpate = new System.Windows.Forms.Timer(this.components);
-			this.pageScripts = new System.Windows.Forms.Panel();
-			this.grpScriptSettings = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.btAddLibraryFolder = new System.Windows.Forms.Button();
-			this.chkDisableScripting = new System.Windows.Forms.CheckBox();
-			this.labelScriptPaths = new System.Windows.Forms.Label();
-			this.txLibraries = new System.Windows.Forms.TextBox();
-			this.grpScripts = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.chkHideSampleScripts = new System.Windows.Forms.CheckBox();
-			this.btConfigScript = new System.Windows.Forms.Button();
-			this.lvScripts = new System.Windows.Forms.ListView();
-			this.chScriptName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.chScriptPackage = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.grpPackages = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
-			this.btRemovePackage = new System.Windows.Forms.Button();
-			this.btInstallPackage = new System.Windows.Forms.Button();
-			this.lvPackages = new System.Windows.Forms.ListView();
-			this.chPackageName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.chPackageAuthor = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.chPackageDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.packageImageList = new System.Windows.Forms.ImageList(this.components);
-			this.tabReader = new System.Windows.Forms.CheckBox();
-			this.tabLibraries = new System.Windows.Forms.CheckBox();
-			this.tabBehavior = new System.Windows.Forms.CheckBox();
-			this.tabScripts = new System.Windows.Forms.CheckBox();
-			this.tabAdvanced = new System.Windows.Forms.CheckBox();
-			this.lblBackupOptions = new System.Windows.Forms.Label();
-			this.gbBackupOn = new System.Windows.Forms.GroupBox();
-			this.chkBackupOnStartup = new System.Windows.Forms.CheckBox();
-			this.chkBackupOnExit = new System.Windows.Forms.CheckBox();
-			this.pageReader.SuspendLayout();
-			this.groupHardwareAcceleration.SuspendLayout();
-			this.grpMouse.SuspendLayout();
-			this.groupOverlays.SuspendLayout();
-			this.panelReaderOverlays.SuspendLayout();
-			this.grpKeyboard.SuspendLayout();
-			this.cmKeyboardLayout.SuspendLayout();
-			this.grpDisplay.SuspendLayout();
-			this.pageAdvanced.SuspendLayout();
-			this.grpWirelessSetup.SuspendLayout();
-			this.grpIntegration.SuspendLayout();
-			this.groupMessagesAndSocial.SuspendLayout();
-			this.groupMemory.SuspendLayout();
-			this.grpMaximumMemoryUsage.SuspendLayout();
-			this.grpMemoryCache.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.numMemPageCount)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.numMemThumbSize)).BeginInit();
-			this.grpDiskCache.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.numPageCacheSize)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.numInternetCacheSize)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.numThumbnailCacheSize)).BeginInit();
-			this.grpBackupManager.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.numBackupsToKeep)).BeginInit();
-			this.grpDatabaseBackup.SuspendLayout();
-			this.groupOtherComics.SuspendLayout();
-			this.grpLanguages.SuspendLayout();
-			this.pageLibrary.SuspendLayout();
-			this.grpVirtualTags.SuspendLayout();
-			this.grpVtagConfig.SuspendLayout();
-			this.grpServerSettings.SuspendLayout();
-			this.grpSharing.SuspendLayout();
-			this.groupLibraryDisplay.SuspendLayout();
-			this.grpScanning.SuspendLayout();
-			this.groupComicFolders.SuspendLayout();
-			this.pageScripts.SuspendLayout();
-			this.grpScriptSettings.SuspendLayout();
-			this.grpScripts.SuspendLayout();
-			this.grpPackages.SuspendLayout();
-			this.gbBackupOn.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// btOK
-			// 
-			this.btOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.btOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-			this.btOK.FlatStyle = System.Windows.Forms.FlatStyle.System;
-			this.btOK.Location = new System.Drawing.Point(351, 422);
-			this.btOK.Name = "btOK";
-			this.btOK.Size = new System.Drawing.Size(80, 24);
-			this.btOK.TabIndex = 1;
-			this.btOK.Text = "&OK";
-			// 
-			// btCancel
-			// 
-			this.btCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.btCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.btCancel.FlatStyle = System.Windows.Forms.FlatStyle.System;
-			this.btCancel.Location = new System.Drawing.Point(437, 422);
-			this.btCancel.Name = "btCancel";
-			this.btCancel.Size = new System.Drawing.Size(80, 24);
-			this.btCancel.TabIndex = 2;
-			this.btCancel.Text = "&Cancel";
-			// 
-			// imageList
-			// 
-			this.imageList.ColorDepth = System.Windows.Forms.ColorDepth.Depth32Bit;
-			this.imageList.ImageSize = new System.Drawing.Size(16, 16);
-			this.imageList.TransparentColor = System.Drawing.Color.Transparent;
-			// 
-			// btApply
-			// 
-			this.btApply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.btApply.FlatStyle = System.Windows.Forms.FlatStyle.System;
-			this.btApply.Location = new System.Drawing.Point(523, 422);
-			this.btApply.Name = "btApply";
-			this.btApply.Size = new System.Drawing.Size(80, 24);
-			this.btApply.TabIndex = 3;
-			this.btApply.Text = "&Apply";
-			this.btApply.Click += new System.EventHandler(this.btApply_Click);
-			// 
-			// pageBehavior
-			// 
-			this.pageBehavior.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PreferencesDialog));
+            System.Windows.Forms.ListViewGroup listViewGroup4 = new System.Windows.Forms.ListViewGroup("Installed", System.Windows.Forms.HorizontalAlignment.Left);
+            System.Windows.Forms.ListViewGroup listViewGroup5 = new System.Windows.Forms.ListViewGroup("To be removed (requires restart)", System.Windows.Forms.HorizontalAlignment.Left);
+            System.Windows.Forms.ListViewGroup listViewGroup6 = new System.Windows.Forms.ListViewGroup("To be installed (requires restart)", System.Windows.Forms.HorizontalAlignment.Left);
+            this.btOK = new System.Windows.Forms.Button();
+            this.btCancel = new System.Windows.Forms.Button();
+            this.imageList = new System.Windows.Forms.ImageList(this.components);
+            this.btApply = new System.Windows.Forms.Button();
+            this.toolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.numBackupsToKeep = new System.Windows.Forms.NumericUpDown();
+            this.txtCaptionFormat = new System.Windows.Forms.TextBox();
+            this.pageBehavior = new System.Windows.Forms.Panel();
+            this.pageReader = new System.Windows.Forms.Panel();
+            this.groupHardwareAcceleration = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.chkEnableHardwareFiltering = new System.Windows.Forms.CheckBox();
+            this.chkEnableSoftwareFiltering = new System.Windows.Forms.CheckBox();
+            this.chkEnableHardware = new System.Windows.Forms.CheckBox();
+            this.chkEnableDisplayChangeAnimation = new System.Windows.Forms.CheckBox();
+            this.grpMouse = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.chkSmoothAutoScrolling = new System.Windows.Forms.CheckBox();
+            this.lblFast = new System.Windows.Forms.Label();
+            this.lblMouseWheel = new System.Windows.Forms.Label();
+            this.chkEnableInertialMouseScrolling = new System.Windows.Forms.CheckBox();
+            this.lblSlow = new System.Windows.Forms.Label();
+            this.tbMouseWheel = new cYo.Common.Windows.Forms.TrackBarLite();
+            this.groupOverlays = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.panelReaderOverlays = new System.Windows.Forms.Panel();
+            this.labelVisiblePartOverlay = new System.Windows.Forms.Label();
+            this.labelNavigationOverlay = new System.Windows.Forms.Label();
+            this.labelStatusOverlay = new System.Windows.Forms.Label();
+            this.labelPageOverlay = new System.Windows.Forms.Label();
+            this.cbNavigationOverlayPosition = new System.Windows.Forms.ComboBox();
+            this.labelNavigationOverlayPosition = new System.Windows.Forms.Label();
+            this.chkShowPageNames = new System.Windows.Forms.CheckBox();
+            this.tbOverlayScaling = new cYo.Common.Windows.Forms.TrackBarLite();
+            this.chkShowCurrentPageOverlay = new System.Windows.Forms.CheckBox();
+            this.chkShowStatusOverlay = new System.Windows.Forms.CheckBox();
+            this.chkShowVisiblePartOverlay = new System.Windows.Forms.CheckBox();
+            this.chkShowNavigationOverlay = new System.Windows.Forms.CheckBox();
+            this.labelOverlaySize = new System.Windows.Forms.Label();
+            this.grpKeyboard = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.btExportKeyboard = new System.Windows.Forms.Button();
+            this.btImportKeyboard = new cYo.Common.Windows.Forms.SplitButton();
+            this.cmKeyboardLayout = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.miDefaultKeyboardLayout = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.keyboardShortcutEditor = new cYo.Common.Windows.Forms.KeyboardShortcutEditor();
+            this.grpDisplay = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.tbGamma = new cYo.Common.Windows.Forms.TrackBarLite();
+            this.labelGamma = new System.Windows.Forms.Label();
+            this.chkAnamorphicScaling = new System.Windows.Forms.CheckBox();
+            this.chkHighQualityDisplay = new System.Windows.Forms.CheckBox();
+            this.labelSharpening = new System.Windows.Forms.Label();
+            this.tbSharpening = new cYo.Common.Windows.Forms.TrackBarLite();
+            this.btResetColor = new System.Windows.Forms.Button();
+            this.chkAutoContrast = new System.Windows.Forms.CheckBox();
+            this.labelSaturation = new System.Windows.Forms.Label();
+            this.tbSaturation = new cYo.Common.Windows.Forms.TrackBarLite();
+            this.labelBrightness = new System.Windows.Forms.Label();
+            this.tbBrightness = new cYo.Common.Windows.Forms.TrackBarLite();
+            this.tbContrast = new cYo.Common.Windows.Forms.TrackBarLite();
+            this.labelContrast = new System.Windows.Forms.Label();
+            this.pageAdvanced = new System.Windows.Forms.Panel();
+            this.grpWirelessSetup = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.btTestWifi = new System.Windows.Forms.Button();
+            this.lblWifiStatus = new System.Windows.Forms.Label();
+            this.lblWifiAddresses = new System.Windows.Forms.Label();
+            this.txWifiAddresses = new System.Windows.Forms.TextBox();
+            this.grpIntegration = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.btAssociateExtensions = new System.Windows.Forms.Button();
+            this.labelCheckedFormats = new System.Windows.Forms.Label();
+            this.chkOverwriteAssociations = new System.Windows.Forms.CheckBox();
+            this.lbFormats = new System.Windows.Forms.CheckedListBox();
+            this.groupMessagesAndSocial = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.btResetMessages = new System.Windows.Forms.Button();
+            this.labelReshowHidden = new System.Windows.Forms.Label();
+            this.groupMemory = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.grpMaximumMemoryUsage = new System.Windows.Forms.GroupBox();
+            this.lblMaximumMemoryUsageValue = new System.Windows.Forms.Label();
+            this.tbMaximumMemoryUsage = new cYo.Common.Windows.Forms.TrackBarLite();
+            this.lblMaximumMemoryUsage = new System.Windows.Forms.Label();
+            this.grpMemoryCache = new System.Windows.Forms.GroupBox();
+            this.lblPageMemCacheUsage = new System.Windows.Forms.Label();
+            this.labelMemThumbSize = new System.Windows.Forms.Label();
+            this.lblThumbMemCacheUsage = new System.Windows.Forms.Label();
+            this.numMemPageCount = new System.Windows.Forms.NumericUpDown();
+            this.labelMemPageCount = new System.Windows.Forms.Label();
+            this.chkMemPageOptimized = new System.Windows.Forms.CheckBox();
+            this.chkMemThumbOptimized = new System.Windows.Forms.CheckBox();
+            this.numMemThumbSize = new System.Windows.Forms.NumericUpDown();
+            this.grpDiskCache = new System.Windows.Forms.GroupBox();
+            this.chkEnableInternetCache = new System.Windows.Forms.CheckBox();
+            this.lblInternetCacheUsage = new System.Windows.Forms.Label();
+            this.btClearPageCache = new System.Windows.Forms.Button();
+            this.numPageCacheSize = new System.Windows.Forms.NumericUpDown();
+            this.numInternetCacheSize = new System.Windows.Forms.NumericUpDown();
+            this.btClearThumbnailCache = new System.Windows.Forms.Button();
+            this.btClearInternetCache = new System.Windows.Forms.Button();
+            this.chkEnablePageCache = new System.Windows.Forms.CheckBox();
+            this.lblPageCacheUsage = new System.Windows.Forms.Label();
+            this.numThumbnailCacheSize = new System.Windows.Forms.NumericUpDown();
+            this.chkEnableThumbnailCache = new System.Windows.Forms.CheckBox();
+            this.lblThumbCacheUsage = new System.Windows.Forms.Label();
+            this.grpBackupManager = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.gbBackupOn = new System.Windows.Forms.GroupBox();
+            this.chkBackupOnExit = new System.Windows.Forms.CheckBox();
+            this.chkBackupOnStartup = new System.Windows.Forms.CheckBox();
+            this.lblBackupOptions = new System.Windows.Forms.Label();
+            this.chkIncludeAllAlternateConfigs = new System.Windows.Forms.CheckBox();
+            this.lblBackupsToKeep = new System.Windows.Forms.Label();
+            this.lbBackupOptions = new System.Windows.Forms.CheckedListBox();
+            this.btBackupLocation = new System.Windows.Forms.Button();
+            this.txtBackupLocation = new System.Windows.Forms.TextBox();
+            this.lblBackupLocation = new System.Windows.Forms.Label();
+            this.grpDatabaseBackup = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.btRestoreDatabase = new System.Windows.Forms.Button();
+            this.btBackupDatabase = new System.Windows.Forms.Button();
+            this.groupOtherComics = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.chkUpdateComicFiles = new System.Windows.Forms.CheckBox();
+            this.labelExcludeCover = new System.Windows.Forms.Label();
+            this.chkAutoUpdateComicFiles = new System.Windows.Forms.CheckBox();
+            this.txCoverFilter = new System.Windows.Forms.TextBox();
+            this.grpLanguages = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.btTranslate = new System.Windows.Forms.Button();
+            this.labelLanguage = new System.Windows.Forms.Label();
+            this.lbLanguages = new System.Windows.Forms.ListBox();
+            this.pageLibrary = new System.Windows.Forms.Panel();
+            this.grpVirtualTags = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.btnVTagsHelp = new System.Windows.Forms.Button();
+            this.grpVtagConfig = new System.Windows.Forms.GroupBox();
+            this.lblCaptionFormat = new System.Windows.Forms.Label();
+            this.btInsertValue = new System.Windows.Forms.Button();
+            this.lblVirtualTagDescription = new System.Windows.Forms.Label();
+            this.lblVirtualTagName = new System.Windows.Forms.Label();
+            this.txtVirtualTagDescription = new System.Windows.Forms.TextBox();
+            this.txtVirtualTagName = new System.Windows.Forms.TextBox();
+            this.chkVirtualTagEnable = new System.Windows.Forms.CheckBox();
+            this.lblCaptionText = new System.Windows.Forms.Label();
+            this.lblCaptionSuffix = new System.Windows.Forms.Label();
+            this.rtfVirtualTagCaption = new System.Windows.Forms.RichTextBox();
+            this.lblFieldConfig = new System.Windows.Forms.Label();
+            this.txtCaptionPrefix = new System.Windows.Forms.TextBox();
+            this.lblCaptionPrefix = new System.Windows.Forms.Label();
+            this.btnCaptionInsert = new System.Windows.Forms.Button();
+            this.txtCaptionSuffix = new System.Windows.Forms.TextBox();
+            this.lblVirtualTags = new System.Windows.Forms.Label();
+            this.cbVirtualTags = new System.Windows.Forms.ComboBox();
+            this.grpServerSettings = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.txPrivateListingPassword = new cYo.Common.Windows.Forms.PasswordTextBox();
+            this.labelPrivateListPassword = new System.Windows.Forms.Label();
+            this.labelPublicServerAddress = new System.Windows.Forms.Label();
+            this.txPublicServerAddress = new System.Windows.Forms.TextBox();
+            this.grpSharing = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.chkAutoConnectShares = new System.Windows.Forms.CheckBox();
+            this.btRemoveShare = new System.Windows.Forms.Button();
+            this.btAddShare = new System.Windows.Forms.Button();
+            this.tabShares = new System.Windows.Forms.TabControl();
+            this.chkLookForShared = new System.Windows.Forms.CheckBox();
+            this.groupLibraryDisplay = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.chkLibraryGaugesTotal = new System.Windows.Forms.CheckBox();
+            this.chkLibraryGaugesUnread = new System.Windows.Forms.CheckBox();
+            this.chkLibraryGaugesNumeric = new System.Windows.Forms.CheckBox();
+            this.chkLibraryGaugesNew = new System.Windows.Forms.CheckBox();
+            this.chkLibraryGauges = new System.Windows.Forms.CheckBox();
+            this.grpScanning = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.chkDontAddRemovedFiles = new System.Windows.Forms.CheckBox();
+            this.chkAutoRemoveMissing = new System.Windows.Forms.CheckBox();
+            this.lblScan = new System.Windows.Forms.Label();
+            this.btScan = new System.Windows.Forms.Button();
+            this.groupComicFolders = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.btOpenFolder = new System.Windows.Forms.Button();
+            this.btChangeFolder = new System.Windows.Forms.Button();
+            this.lbPaths = new cYo.Common.Windows.Forms.CheckedListBoxEx();
+            this.labelWatchedFolders = new System.Windows.Forms.Label();
+            this.btRemoveFolder = new System.Windows.Forms.Button();
+            this.btAddFolder = new System.Windows.Forms.Button();
+            this.memCacheUpate = new System.Windows.Forms.Timer(this.components);
+            this.pageScripts = new System.Windows.Forms.Panel();
+            this.grpScriptSettings = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.btAddLibraryFolder = new System.Windows.Forms.Button();
+            this.chkDisableScripting = new System.Windows.Forms.CheckBox();
+            this.labelScriptPaths = new System.Windows.Forms.Label();
+            this.txLibraries = new System.Windows.Forms.TextBox();
+            this.grpScripts = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.chkHideSampleScripts = new System.Windows.Forms.CheckBox();
+            this.btConfigScript = new System.Windows.Forms.Button();
+            this.lvScripts = new System.Windows.Forms.ListView();
+            this.chScriptName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chScriptPackage = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.grpPackages = new cYo.Common.Windows.Forms.CollapsibleGroupBox();
+            this.btRemovePackage = new System.Windows.Forms.Button();
+            this.btInstallPackage = new System.Windows.Forms.Button();
+            this.lvPackages = new System.Windows.Forms.ListView();
+            this.chPackageName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chPackageAuthor = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chPackageDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.packageImageList = new System.Windows.Forms.ImageList(this.components);
+            this.tabReader = new System.Windows.Forms.CheckBox();
+            this.tabLibraries = new System.Windows.Forms.CheckBox();
+            this.tabBehavior = new System.Windows.Forms.CheckBox();
+            this.tabScripts = new System.Windows.Forms.CheckBox();
+            this.tabAdvanced = new System.Windows.Forms.CheckBox();
+            this.chkUpdateComicBookFiles = new System.Windows.Forms.CheckBox();
+            ((System.ComponentModel.ISupportInitialize)(this.numBackupsToKeep)).BeginInit();
+            this.pageReader.SuspendLayout();
+            this.groupHardwareAcceleration.SuspendLayout();
+            this.grpMouse.SuspendLayout();
+            this.groupOverlays.SuspendLayout();
+            this.panelReaderOverlays.SuspendLayout();
+            this.grpKeyboard.SuspendLayout();
+            this.cmKeyboardLayout.SuspendLayout();
+            this.grpDisplay.SuspendLayout();
+            this.pageAdvanced.SuspendLayout();
+            this.grpWirelessSetup.SuspendLayout();
+            this.grpIntegration.SuspendLayout();
+            this.groupMessagesAndSocial.SuspendLayout();
+            this.groupMemory.SuspendLayout();
+            this.grpMaximumMemoryUsage.SuspendLayout();
+            this.grpMemoryCache.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numMemPageCount)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numMemThumbSize)).BeginInit();
+            this.grpDiskCache.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numPageCacheSize)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numInternetCacheSize)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numThumbnailCacheSize)).BeginInit();
+            this.grpBackupManager.SuspendLayout();
+            this.gbBackupOn.SuspendLayout();
+            this.grpDatabaseBackup.SuspendLayout();
+            this.groupOtherComics.SuspendLayout();
+            this.grpLanguages.SuspendLayout();
+            this.pageLibrary.SuspendLayout();
+            this.grpVirtualTags.SuspendLayout();
+            this.grpVtagConfig.SuspendLayout();
+            this.grpServerSettings.SuspendLayout();
+            this.grpSharing.SuspendLayout();
+            this.groupLibraryDisplay.SuspendLayout();
+            this.grpScanning.SuspendLayout();
+            this.groupComicFolders.SuspendLayout();
+            this.pageScripts.SuspendLayout();
+            this.grpScriptSettings.SuspendLayout();
+            this.grpScripts.SuspendLayout();
+            this.grpPackages.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // btOK
+            // 
+            this.btOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btOK.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.btOK.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.btOK.Location = new System.Drawing.Point(351, 422);
+            this.btOK.Name = "btOK";
+            this.btOK.Size = new System.Drawing.Size(80, 24);
+            this.btOK.TabIndex = 1;
+            this.btOK.Text = "&OK";
+            // 
+            // btCancel
+            // 
+            this.btCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btCancel.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.btCancel.Location = new System.Drawing.Point(437, 422);
+            this.btCancel.Name = "btCancel";
+            this.btCancel.Size = new System.Drawing.Size(80, 24);
+            this.btCancel.TabIndex = 2;
+            this.btCancel.Text = "&Cancel";
+            // 
+            // imageList
+            // 
+            this.imageList.ColorDepth = System.Windows.Forms.ColorDepth.Depth32Bit;
+            this.imageList.ImageSize = new System.Drawing.Size(16, 16);
+            this.imageList.TransparentColor = System.Drawing.Color.Transparent;
+            // 
+            // btApply
+            // 
+            this.btApply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btApply.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.btApply.Location = new System.Drawing.Point(523, 422);
+            this.btApply.Name = "btApply";
+            this.btApply.Size = new System.Drawing.Size(80, 24);
+            this.btApply.TabIndex = 3;
+            this.btApply.Text = "&Apply";
+            this.btApply.Click += new System.EventHandler(this.btApply_Click);
+            // 
+            // numBackupsToKeep
+            // 
+            this.numBackupsToKeep.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.numBackupsToKeep.Location = new System.Drawing.Point(414, 154);
+            this.numBackupsToKeep.Name = "numBackupsToKeep";
+            this.numBackupsToKeep.Size = new System.Drawing.Size(69, 20);
+            this.numBackupsToKeep.TabIndex = 5;
+            this.numBackupsToKeep.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this.toolTip.SetToolTip(this.numBackupsToKeep, "Setting this to 0 will keep all backups");
+            // 
+            // txtCaptionFormat
+            // 
+            this.txtCaptionFormat.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtCaptionFormat.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtCaptionFormat.Location = new System.Drawing.Point(269, 167);
+            this.txtCaptionFormat.Name = "txtCaptionFormat";
+            this.txtCaptionFormat.Size = new System.Drawing.Size(50, 20);
+            this.txtCaptionFormat.TabIndex = 27;
+            this.toolTip.SetToolTip(this.txtCaptionFormat, resources.GetString("txtCaptionFormat.ToolTip"));
+            this.txtCaptionFormat.WordWrap = false;
+            // 
+            // pageBehavior
+            // 
+            this.pageBehavior.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.pageBehavior.AutoScroll = true;
-			this.pageBehavior.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.pageBehavior.Location = new System.Drawing.Point(84, 8);
-			this.pageBehavior.Name = "pageBehavior";
-			this.pageBehavior.Size = new System.Drawing.Size(517, 408);
-			this.pageBehavior.TabIndex = 6;
-			// 
-			// pageReader
-			// 
-			this.pageReader.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.pageBehavior.AutoScroll = true;
+            this.pageBehavior.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.pageBehavior.Location = new System.Drawing.Point(84, 8);
+            this.pageBehavior.Name = "pageBehavior";
+            this.pageBehavior.Size = new System.Drawing.Size(517, 408);
+            this.pageBehavior.TabIndex = 6;
+            // 
+            // pageReader
+            // 
+            this.pageReader.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.pageReader.AutoScroll = true;
-			this.pageReader.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.pageReader.Controls.Add(this.groupHardwareAcceleration);
-			this.pageReader.Controls.Add(this.grpMouse);
-			this.pageReader.Controls.Add(this.groupOverlays);
-			this.pageReader.Controls.Add(this.grpKeyboard);
-			this.pageReader.Controls.Add(this.grpDisplay);
-			this.pageReader.Location = new System.Drawing.Point(84, 8);
-			this.pageReader.Name = "pageReader";
-			this.pageReader.Size = new System.Drawing.Size(517, 408);
-			this.pageReader.TabIndex = 8;
-			// 
-			// groupHardwareAcceleration
-			// 
-			this.groupHardwareAcceleration.Controls.Add(this.chkEnableHardwareFiltering);
-			this.groupHardwareAcceleration.Controls.Add(this.chkEnableSoftwareFiltering);
-			this.groupHardwareAcceleration.Controls.Add(this.chkEnableHardware);
-			this.groupHardwareAcceleration.Controls.Add(this.chkEnableDisplayChangeAnimation);
-			this.groupHardwareAcceleration.Dock = System.Windows.Forms.DockStyle.Top;
-			this.groupHardwareAcceleration.Location = new System.Drawing.Point(0, 1180);
-			this.groupHardwareAcceleration.Name = "groupHardwareAcceleration";
-			this.groupHardwareAcceleration.Size = new System.Drawing.Size(498, 137);
-			this.groupHardwareAcceleration.TabIndex = 3;
-			this.groupHardwareAcceleration.Text = "Hardware Acceleration";
-			// 
-			// chkEnableHardwareFiltering
-			// 
-			this.chkEnableHardwareFiltering.AutoSize = true;
-			this.chkEnableHardwareFiltering.Location = new System.Drawing.Point(33, 70);
-			this.chkEnableHardwareFiltering.Name = "chkEnableHardwareFiltering";
-			this.chkEnableHardwareFiltering.Size = new System.Drawing.Size(138, 17);
-			this.chkEnableHardwareFiltering.TabIndex = 1;
-			this.chkEnableHardwareFiltering.Text = "Enable Hardware Filters";
-			this.chkEnableHardwareFiltering.UseVisualStyleBackColor = true;
-			// 
-			// chkEnableSoftwareFiltering
-			// 
-			this.chkEnableSoftwareFiltering.AutoSize = true;
-			this.chkEnableSoftwareFiltering.Location = new System.Drawing.Point(33, 88);
-			this.chkEnableSoftwareFiltering.Name = "chkEnableSoftwareFiltering";
-			this.chkEnableSoftwareFiltering.Size = new System.Drawing.Size(134, 17);
-			this.chkEnableSoftwareFiltering.TabIndex = 2;
-			this.chkEnableSoftwareFiltering.Text = "Enable Software Filters";
-			this.chkEnableSoftwareFiltering.UseVisualStyleBackColor = true;
-			// 
-			// chkEnableHardware
-			// 
-			this.chkEnableHardware.AutoSize = true;
-			this.chkEnableHardware.Location = new System.Drawing.Point(12, 38);
-			this.chkEnableHardware.Name = "chkEnableHardware";
-			this.chkEnableHardware.Size = new System.Drawing.Size(170, 17);
-			this.chkEnableHardware.TabIndex = 0;
-			this.chkEnableHardware.Text = "Enable Hardware Acceleration";
-			this.chkEnableHardware.UseVisualStyleBackColor = true;
-			// 
-			// chkEnableDisplayChangeAnimation
-			// 
-			this.chkEnableDisplayChangeAnimation.AutoSize = true;
-			this.chkEnableDisplayChangeAnimation.Location = new System.Drawing.Point(33, 108);
-			this.chkEnableDisplayChangeAnimation.Name = "chkEnableDisplayChangeAnimation";
-			this.chkEnableDisplayChangeAnimation.Size = new System.Drawing.Size(229, 17);
-			this.chkEnableDisplayChangeAnimation.TabIndex = 3;
-			this.chkEnableDisplayChangeAnimation.Text = "Enable Animation of Page Display changes";
-			this.chkEnableDisplayChangeAnimation.UseVisualStyleBackColor = true;
-			// 
-			// grpMouse
-			// 
-			this.grpMouse.Controls.Add(this.chkSmoothAutoScrolling);
-			this.grpMouse.Controls.Add(this.lblFast);
-			this.grpMouse.Controls.Add(this.lblMouseWheel);
-			this.grpMouse.Controls.Add(this.chkEnableInertialMouseScrolling);
-			this.grpMouse.Controls.Add(this.lblSlow);
-			this.grpMouse.Controls.Add(this.tbMouseWheel);
-			this.grpMouse.Dock = System.Windows.Forms.DockStyle.Top;
-			this.grpMouse.Location = new System.Drawing.Point(0, 1046);
-			this.grpMouse.Name = "grpMouse";
-			this.grpMouse.Size = new System.Drawing.Size(498, 134);
-			this.grpMouse.TabIndex = 5;
-			this.grpMouse.Text = "Mouse & Scrolling";
-			// 
-			// chkSmoothAutoScrolling
-			// 
-			this.chkSmoothAutoScrolling.AutoSize = true;
-			this.chkSmoothAutoScrolling.Location = new System.Drawing.Point(9, 39);
-			this.chkSmoothAutoScrolling.Name = "chkSmoothAutoScrolling";
-			this.chkSmoothAutoScrolling.Size = new System.Drawing.Size(130, 17);
-			this.chkSmoothAutoScrolling.TabIndex = 0;
-			this.chkSmoothAutoScrolling.Text = "Smooth Auto Scrolling";
-			this.chkSmoothAutoScrolling.UseVisualStyleBackColor = true;
-			// 
-			// lblFast
-			// 
-			this.lblFast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.lblFast.Location = new System.Drawing.Point(426, 96);
-			this.lblFast.Name = "lblFast";
-			this.lblFast.Size = new System.Drawing.Size(56, 19);
-			this.lblFast.TabIndex = 4;
-			this.lblFast.Text = "fast";
-			// 
-			// lblMouseWheel
-			// 
-			this.lblMouseWheel.AutoSize = true;
-			this.lblMouseWheel.Location = new System.Drawing.Point(9, 97);
-			this.lblMouseWheel.Name = "lblMouseWheel";
-			this.lblMouseWheel.Size = new System.Drawing.Size(117, 13);
-			this.lblMouseWheel.TabIndex = 0;
-			this.lblMouseWheel.Text = "Mouse Wheel scrolling:";
-			// 
-			// chkEnableInertialMouseScrolling
-			// 
-			this.chkEnableInertialMouseScrolling.AutoSize = true;
-			this.chkEnableInertialMouseScrolling.Location = new System.Drawing.Point(9, 62);
-			this.chkEnableInertialMouseScrolling.Name = "chkEnableInertialMouseScrolling";
-			this.chkEnableInertialMouseScrolling.Size = new System.Drawing.Size(169, 17);
-			this.chkEnableInertialMouseScrolling.TabIndex = 1;
-			this.chkEnableInertialMouseScrolling.Text = "Enable Inertial Mouse scrolling";
-			this.chkEnableInertialMouseScrolling.UseVisualStyleBackColor = true;
-			// 
-			// lblSlow
-			// 
-			this.lblSlow.Location = new System.Drawing.Point(186, 97);
-			this.lblSlow.Name = "lblSlow";
-			this.lblSlow.Size = new System.Drawing.Size(55, 19);
-			this.lblSlow.TabIndex = 2;
-			this.lblSlow.Text = "slow";
-			this.lblSlow.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			// 
-			// tbMouseWheel
-			// 
-			this.tbMouseWheel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.pageReader.AutoScroll = true;
+            this.pageReader.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.pageReader.Controls.Add(this.groupHardwareAcceleration);
+            this.pageReader.Controls.Add(this.grpMouse);
+            this.pageReader.Controls.Add(this.groupOverlays);
+            this.pageReader.Controls.Add(this.grpKeyboard);
+            this.pageReader.Controls.Add(this.grpDisplay);
+            this.pageReader.Location = new System.Drawing.Point(84, 8);
+            this.pageReader.Name = "pageReader";
+            this.pageReader.Size = new System.Drawing.Size(517, 408);
+            this.pageReader.TabIndex = 8;
+            // 
+            // groupHardwareAcceleration
+            // 
+            this.groupHardwareAcceleration.Controls.Add(this.chkEnableHardwareFiltering);
+            this.groupHardwareAcceleration.Controls.Add(this.chkEnableSoftwareFiltering);
+            this.groupHardwareAcceleration.Controls.Add(this.chkEnableHardware);
+            this.groupHardwareAcceleration.Controls.Add(this.chkEnableDisplayChangeAnimation);
+            this.groupHardwareAcceleration.Dock = System.Windows.Forms.DockStyle.Top;
+            this.groupHardwareAcceleration.Location = new System.Drawing.Point(0, 1180);
+            this.groupHardwareAcceleration.Name = "groupHardwareAcceleration";
+            this.groupHardwareAcceleration.Size = new System.Drawing.Size(498, 137);
+            this.groupHardwareAcceleration.TabIndex = 3;
+            this.groupHardwareAcceleration.Text = "Hardware Acceleration";
+            // 
+            // chkEnableHardwareFiltering
+            // 
+            this.chkEnableHardwareFiltering.AutoSize = true;
+            this.chkEnableHardwareFiltering.Location = new System.Drawing.Point(33, 70);
+            this.chkEnableHardwareFiltering.Name = "chkEnableHardwareFiltering";
+            this.chkEnableHardwareFiltering.Size = new System.Drawing.Size(138, 17);
+            this.chkEnableHardwareFiltering.TabIndex = 1;
+            this.chkEnableHardwareFiltering.Text = "Enable Hardware Filters";
+            this.chkEnableHardwareFiltering.UseVisualStyleBackColor = true;
+            // 
+            // chkEnableSoftwareFiltering
+            // 
+            this.chkEnableSoftwareFiltering.AutoSize = true;
+            this.chkEnableSoftwareFiltering.Location = new System.Drawing.Point(33, 88);
+            this.chkEnableSoftwareFiltering.Name = "chkEnableSoftwareFiltering";
+            this.chkEnableSoftwareFiltering.Size = new System.Drawing.Size(134, 17);
+            this.chkEnableSoftwareFiltering.TabIndex = 2;
+            this.chkEnableSoftwareFiltering.Text = "Enable Software Filters";
+            this.chkEnableSoftwareFiltering.UseVisualStyleBackColor = true;
+            // 
+            // chkEnableHardware
+            // 
+            this.chkEnableHardware.AutoSize = true;
+            this.chkEnableHardware.Location = new System.Drawing.Point(12, 38);
+            this.chkEnableHardware.Name = "chkEnableHardware";
+            this.chkEnableHardware.Size = new System.Drawing.Size(170, 17);
+            this.chkEnableHardware.TabIndex = 0;
+            this.chkEnableHardware.Text = "Enable Hardware Acceleration";
+            this.chkEnableHardware.UseVisualStyleBackColor = true;
+            // 
+            // chkEnableDisplayChangeAnimation
+            // 
+            this.chkEnableDisplayChangeAnimation.AutoSize = true;
+            this.chkEnableDisplayChangeAnimation.Location = new System.Drawing.Point(33, 108);
+            this.chkEnableDisplayChangeAnimation.Name = "chkEnableDisplayChangeAnimation";
+            this.chkEnableDisplayChangeAnimation.Size = new System.Drawing.Size(229, 17);
+            this.chkEnableDisplayChangeAnimation.TabIndex = 3;
+            this.chkEnableDisplayChangeAnimation.Text = "Enable Animation of Page Display changes";
+            this.chkEnableDisplayChangeAnimation.UseVisualStyleBackColor = true;
+            // 
+            // grpMouse
+            // 
+            this.grpMouse.Controls.Add(this.chkSmoothAutoScrolling);
+            this.grpMouse.Controls.Add(this.lblFast);
+            this.grpMouse.Controls.Add(this.lblMouseWheel);
+            this.grpMouse.Controls.Add(this.chkEnableInertialMouseScrolling);
+            this.grpMouse.Controls.Add(this.lblSlow);
+            this.grpMouse.Controls.Add(this.tbMouseWheel);
+            this.grpMouse.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpMouse.Location = new System.Drawing.Point(0, 1046);
+            this.grpMouse.Name = "grpMouse";
+            this.grpMouse.Size = new System.Drawing.Size(498, 134);
+            this.grpMouse.TabIndex = 5;
+            this.grpMouse.Text = "Mouse & Scrolling";
+            // 
+            // chkSmoothAutoScrolling
+            // 
+            this.chkSmoothAutoScrolling.AutoSize = true;
+            this.chkSmoothAutoScrolling.Location = new System.Drawing.Point(9, 39);
+            this.chkSmoothAutoScrolling.Name = "chkSmoothAutoScrolling";
+            this.chkSmoothAutoScrolling.Size = new System.Drawing.Size(130, 17);
+            this.chkSmoothAutoScrolling.TabIndex = 0;
+            this.chkSmoothAutoScrolling.Text = "Smooth Auto Scrolling";
+            this.chkSmoothAutoScrolling.UseVisualStyleBackColor = true;
+            // 
+            // lblFast
+            // 
+            this.lblFast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblFast.Location = new System.Drawing.Point(426, 96);
+            this.lblFast.Name = "lblFast";
+            this.lblFast.Size = new System.Drawing.Size(56, 19);
+            this.lblFast.TabIndex = 4;
+            this.lblFast.Text = "fast";
+            // 
+            // lblMouseWheel
+            // 
+            this.lblMouseWheel.AutoSize = true;
+            this.lblMouseWheel.Location = new System.Drawing.Point(9, 97);
+            this.lblMouseWheel.Name = "lblMouseWheel";
+            this.lblMouseWheel.Size = new System.Drawing.Size(117, 13);
+            this.lblMouseWheel.TabIndex = 0;
+            this.lblMouseWheel.Text = "Mouse Wheel scrolling:";
+            // 
+            // chkEnableInertialMouseScrolling
+            // 
+            this.chkEnableInertialMouseScrolling.AutoSize = true;
+            this.chkEnableInertialMouseScrolling.Location = new System.Drawing.Point(9, 62);
+            this.chkEnableInertialMouseScrolling.Name = "chkEnableInertialMouseScrolling";
+            this.chkEnableInertialMouseScrolling.Size = new System.Drawing.Size(169, 17);
+            this.chkEnableInertialMouseScrolling.TabIndex = 1;
+            this.chkEnableInertialMouseScrolling.Text = "Enable Inertial Mouse scrolling";
+            this.chkEnableInertialMouseScrolling.UseVisualStyleBackColor = true;
+            // 
+            // lblSlow
+            // 
+            this.lblSlow.Location = new System.Drawing.Point(186, 97);
+            this.lblSlow.Name = "lblSlow";
+            this.lblSlow.Size = new System.Drawing.Size(55, 19);
+            this.lblSlow.TabIndex = 2;
+            this.lblSlow.Text = "slow";
+            this.lblSlow.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // tbMouseWheel
+            // 
+            this.tbMouseWheel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.tbMouseWheel.Location = new System.Drawing.Point(247, 97);
-			this.tbMouseWheel.Maximum = 50;
-			this.tbMouseWheel.Minimum = 5;
-			this.tbMouseWheel.Name = "tbMouseWheel";
-			this.tbMouseWheel.Size = new System.Drawing.Size(173, 16);
-			this.tbMouseWheel.TabIndex = 3;
-			this.tbMouseWheel.ThumbSize = new System.Drawing.Size(8, 16);
-			this.tbMouseWheel.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
-			this.tbMouseWheel.Value = 5;
-			// 
-			// groupOverlays
-			// 
-			this.groupOverlays.Controls.Add(this.panelReaderOverlays);
-			this.groupOverlays.Controls.Add(this.cbNavigationOverlayPosition);
-			this.groupOverlays.Controls.Add(this.labelNavigationOverlayPosition);
-			this.groupOverlays.Controls.Add(this.chkShowPageNames);
-			this.groupOverlays.Controls.Add(this.tbOverlayScaling);
-			this.groupOverlays.Controls.Add(this.chkShowCurrentPageOverlay);
-			this.groupOverlays.Controls.Add(this.chkShowStatusOverlay);
-			this.groupOverlays.Controls.Add(this.chkShowVisiblePartOverlay);
-			this.groupOverlays.Controls.Add(this.chkShowNavigationOverlay);
-			this.groupOverlays.Controls.Add(this.labelOverlaySize);
-			this.groupOverlays.Dock = System.Windows.Forms.DockStyle.Top;
-			this.groupOverlays.Location = new System.Drawing.Point(0, 690);
-			this.groupOverlays.Name = "groupOverlays";
-			this.groupOverlays.Size = new System.Drawing.Size(498, 356);
-			this.groupOverlays.TabIndex = 2;
-			this.groupOverlays.Text = "Overlays";
-			// 
-			// panelReaderOverlays
-			// 
-			this.panelReaderOverlays.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.panelReaderOverlays.BackColor = ThemeColors.Preferences.PanelReader;
-			this.panelReaderOverlays.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.panelReaderOverlays.Controls.Add(this.labelVisiblePartOverlay);
-			this.panelReaderOverlays.Controls.Add(this.labelNavigationOverlay);
-			this.panelReaderOverlays.Controls.Add(this.labelStatusOverlay);
-			this.panelReaderOverlays.Controls.Add(this.labelPageOverlay);
-			this.panelReaderOverlays.Location = new System.Drawing.Point(118, 39);
-			this.panelReaderOverlays.Name = "panelReaderOverlays";
-			this.panelReaderOverlays.Size = new System.Drawing.Size(258, 134);
-			this.panelReaderOverlays.TabIndex = 8;
-			// 
-			// labelVisiblePartOverlay
-			// 
-			this.labelVisiblePartOverlay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.labelVisiblePartOverlay.BackColor = ThemeColors.Preferences.LabelOverlays;
-			this.labelVisiblePartOverlay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.labelVisiblePartOverlay.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-			this.labelVisiblePartOverlay.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.labelVisiblePartOverlay.Location = new System.Drawing.Point(204, 75);
-			this.labelVisiblePartOverlay.Name = "labelVisiblePartOverlay";
-			this.labelVisiblePartOverlay.Size = new System.Drawing.Size(49, 51);
-			this.labelVisiblePartOverlay.TabIndex = 3;
-			this.labelVisiblePartOverlay.Text = "Visible Part";
-			this.labelVisiblePartOverlay.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.labelVisiblePartOverlay.UseMnemonic = false;
-			// 
-			// labelNavigationOverlay
-			// 
-			this.labelNavigationOverlay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.labelNavigationOverlay.BackColor = ThemeColors.Preferences.LabelOverlays;
-			this.labelNavigationOverlay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.labelNavigationOverlay.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.labelNavigationOverlay.Location = new System.Drawing.Point(55, 100);
-			this.labelNavigationOverlay.Name = "labelNavigationOverlay";
-			this.labelNavigationOverlay.Size = new System.Drawing.Size(143, 26);
-			this.labelNavigationOverlay.TabIndex = 2;
-			this.labelNavigationOverlay.Text = "Navigation";
-			this.labelNavigationOverlay.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.labelNavigationOverlay.UseMnemonic = false;
-			// 
-			// labelStatusOverlay
-			// 
-			this.labelStatusOverlay.BackColor = ThemeColors.Preferences.LabelOverlays;
-			this.labelStatusOverlay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.labelStatusOverlay.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-			this.labelStatusOverlay.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.labelStatusOverlay.Location = new System.Drawing.Point(60, 49);
-			this.labelStatusOverlay.Name = "labelStatusOverlay";
-			this.labelStatusOverlay.Size = new System.Drawing.Size(134, 26);
-			this.labelStatusOverlay.TabIndex = 1;
-			this.labelStatusOverlay.Text = "Messages and Status";
-			this.labelStatusOverlay.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.labelStatusOverlay.UseMnemonic = false;
-			// 
-			// labelPageOverlay
-			// 
-			this.labelPageOverlay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.labelPageOverlay.BackColor = ThemeColors.Preferences.LabelOverlays;
-			this.labelPageOverlay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.labelPageOverlay.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-			this.labelPageOverlay.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.labelPageOverlay.Location = new System.Drawing.Point(204, 3);
-			this.labelPageOverlay.Name = "labelPageOverlay";
-			this.labelPageOverlay.Size = new System.Drawing.Size(49, 36);
-			this.labelPageOverlay.TabIndex = 0;
-			this.labelPageOverlay.Text = "Page";
-			this.labelPageOverlay.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.labelPageOverlay.UseMnemonic = false;
-			// 
-			// cbNavigationOverlayPosition
-			// 
-			this.cbNavigationOverlayPosition.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.cbNavigationOverlayPosition.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cbNavigationOverlayPosition.FormattingEnabled = true;
-			this.cbNavigationOverlayPosition.Items.AddRange(new object[] {
+            this.tbMouseWheel.Location = new System.Drawing.Point(247, 97);
+            this.tbMouseWheel.Maximum = 50;
+            this.tbMouseWheel.Minimum = 5;
+            this.tbMouseWheel.Name = "tbMouseWheel";
+            this.tbMouseWheel.Size = new System.Drawing.Size(173, 16);
+            this.tbMouseWheel.TabIndex = 3;
+            this.tbMouseWheel.ThumbSize = new System.Drawing.Size(8, 16);
+            this.tbMouseWheel.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
+            this.tbMouseWheel.Value = 5;
+            // 
+            // groupOverlays
+            // 
+            this.groupOverlays.Controls.Add(this.panelReaderOverlays);
+            this.groupOverlays.Controls.Add(this.cbNavigationOverlayPosition);
+            this.groupOverlays.Controls.Add(this.labelNavigationOverlayPosition);
+            this.groupOverlays.Controls.Add(this.chkShowPageNames);
+            this.groupOverlays.Controls.Add(this.tbOverlayScaling);
+            this.groupOverlays.Controls.Add(this.chkShowCurrentPageOverlay);
+            this.groupOverlays.Controls.Add(this.chkShowStatusOverlay);
+            this.groupOverlays.Controls.Add(this.chkShowVisiblePartOverlay);
+            this.groupOverlays.Controls.Add(this.chkShowNavigationOverlay);
+            this.groupOverlays.Controls.Add(this.labelOverlaySize);
+            this.groupOverlays.Dock = System.Windows.Forms.DockStyle.Top;
+            this.groupOverlays.Location = new System.Drawing.Point(0, 690);
+            this.groupOverlays.Name = "groupOverlays";
+            this.groupOverlays.Size = new System.Drawing.Size(498, 356);
+            this.groupOverlays.TabIndex = 2;
+            this.groupOverlays.Text = "Overlays";
+            // 
+            // panelReaderOverlays
+            // 
+            this.panelReaderOverlays.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.panelReaderOverlays.BackColor = System.Drawing.Color.WhiteSmoke;
+            this.panelReaderOverlays.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panelReaderOverlays.Controls.Add(this.labelVisiblePartOverlay);
+            this.panelReaderOverlays.Controls.Add(this.labelNavigationOverlay);
+            this.panelReaderOverlays.Controls.Add(this.labelStatusOverlay);
+            this.panelReaderOverlays.Controls.Add(this.labelPageOverlay);
+            this.panelReaderOverlays.Location = new System.Drawing.Point(118, 39);
+            this.panelReaderOverlays.Name = "panelReaderOverlays";
+            this.panelReaderOverlays.Size = new System.Drawing.Size(258, 134);
+            this.panelReaderOverlays.TabIndex = 8;
+            // 
+            // labelVisiblePartOverlay
+            // 
+            this.labelVisiblePartOverlay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelVisiblePartOverlay.BackColor = System.Drawing.Color.Gainsboro;
+            this.labelVisiblePartOverlay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.labelVisiblePartOverlay.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.labelVisiblePartOverlay.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelVisiblePartOverlay.Location = new System.Drawing.Point(204, 75);
+            this.labelVisiblePartOverlay.Name = "labelVisiblePartOverlay";
+            this.labelVisiblePartOverlay.Size = new System.Drawing.Size(49, 51);
+            this.labelVisiblePartOverlay.TabIndex = 3;
+            this.labelVisiblePartOverlay.Text = "Visible Part";
+            this.labelVisiblePartOverlay.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.labelVisiblePartOverlay.UseMnemonic = false;
+            // 
+            // labelNavigationOverlay
+            // 
+            this.labelNavigationOverlay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.labelNavigationOverlay.BackColor = System.Drawing.Color.Gainsboro;
+            this.labelNavigationOverlay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.labelNavigationOverlay.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelNavigationOverlay.Location = new System.Drawing.Point(55, 100);
+            this.labelNavigationOverlay.Name = "labelNavigationOverlay";
+            this.labelNavigationOverlay.Size = new System.Drawing.Size(143, 26);
+            this.labelNavigationOverlay.TabIndex = 2;
+            this.labelNavigationOverlay.Text = "Navigation";
+            this.labelNavigationOverlay.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.labelNavigationOverlay.UseMnemonic = false;
+            // 
+            // labelStatusOverlay
+            // 
+            this.labelStatusOverlay.BackColor = System.Drawing.Color.Gainsboro;
+            this.labelStatusOverlay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.labelStatusOverlay.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.labelStatusOverlay.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelStatusOverlay.Location = new System.Drawing.Point(60, 49);
+            this.labelStatusOverlay.Name = "labelStatusOverlay";
+            this.labelStatusOverlay.Size = new System.Drawing.Size(134, 26);
+            this.labelStatusOverlay.TabIndex = 1;
+            this.labelStatusOverlay.Text = "Messages and Status";
+            this.labelStatusOverlay.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.labelStatusOverlay.UseMnemonic = false;
+            // 
+            // labelPageOverlay
+            // 
+            this.labelPageOverlay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelPageOverlay.BackColor = System.Drawing.Color.Gainsboro;
+            this.labelPageOverlay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.labelPageOverlay.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.labelPageOverlay.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelPageOverlay.Location = new System.Drawing.Point(204, 3);
+            this.labelPageOverlay.Name = "labelPageOverlay";
+            this.labelPageOverlay.Size = new System.Drawing.Size(49, 36);
+            this.labelPageOverlay.TabIndex = 0;
+            this.labelPageOverlay.Text = "Page";
+            this.labelPageOverlay.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.labelPageOverlay.UseMnemonic = false;
+            // 
+            // cbNavigationOverlayPosition
+            // 
+            this.cbNavigationOverlayPosition.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.cbNavigationOverlayPosition.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbNavigationOverlayPosition.FormattingEnabled = true;
+            this.cbNavigationOverlayPosition.Items.AddRange(new object[] {
             "at Bottom",
             "on Top"});
-			this.cbNavigationOverlayPosition.Location = new System.Drawing.Point(84, 313);
-			this.cbNavigationOverlayPosition.Name = "cbNavigationOverlayPosition";
-			this.cbNavigationOverlayPosition.Size = new System.Drawing.Size(121, 21);
-			this.cbNavigationOverlayPosition.TabIndex = 6;
-			// 
-			// labelNavigationOverlayPosition
-			// 
-			this.labelNavigationOverlayPosition.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.labelNavigationOverlayPosition.AutoSize = true;
-			this.labelNavigationOverlayPosition.Location = new System.Drawing.Point(18, 316);
-			this.labelNavigationOverlayPosition.Name = "labelNavigationOverlayPosition";
-			this.labelNavigationOverlayPosition.Size = new System.Drawing.Size(61, 13);
-			this.labelNavigationOverlayPosition.TabIndex = 5;
-			this.labelNavigationOverlayPosition.Text = "Navigation:";
-			// 
-			// chkShowPageNames
-			// 
-			this.chkShowPageNames.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.chkShowPageNames.AutoSize = true;
-			this.chkShowPageNames.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.chkShowPageNames.Location = new System.Drawing.Point(283, 193);
-			this.chkShowPageNames.Name = "chkShowPageNames";
-			this.chkShowPageNames.Size = new System.Drawing.Size(181, 17);
-			this.chkShowPageNames.TabIndex = 4;
-			this.chkShowPageNames.Text = "Current Page also displays Name";
-			this.chkShowPageNames.UseVisualStyleBackColor = true;
-			// 
-			// tbOverlayScaling
-			// 
-			this.tbOverlayScaling.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.tbOverlayScaling.Location = new System.Drawing.Point(288, 316);
-			this.tbOverlayScaling.Maximum = 150;
-			this.tbOverlayScaling.Minimum = 40;
-			this.tbOverlayScaling.Name = "tbOverlayScaling";
-			this.tbOverlayScaling.Size = new System.Drawing.Size(184, 16);
-			this.tbOverlayScaling.TabIndex = 8;
-			this.tbOverlayScaling.ThumbSize = new System.Drawing.Size(8, 16);
-			this.tbOverlayScaling.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
-			this.tbOverlayScaling.Value = 50;
-			this.tbOverlayScaling.ValueChanged += new System.EventHandler(this.tbOverlayScalingChanged);
-			// 
-			// chkShowCurrentPageOverlay
-			// 
-			this.chkShowCurrentPageOverlay.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.chkShowCurrentPageOverlay.AutoSize = true;
-			this.chkShowCurrentPageOverlay.Location = new System.Drawing.Point(58, 193);
-			this.chkShowCurrentPageOverlay.Name = "chkShowCurrentPageOverlay";
-			this.chkShowCurrentPageOverlay.Size = new System.Drawing.Size(117, 17);
-			this.chkShowCurrentPageOverlay.TabIndex = 0;
-			this.chkShowCurrentPageOverlay.Text = "Show current Page";
-			this.chkShowCurrentPageOverlay.UseVisualStyleBackColor = true;
-			// 
-			// chkShowStatusOverlay
-			// 
-			this.chkShowStatusOverlay.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.chkShowStatusOverlay.AutoSize = true;
-			this.chkShowStatusOverlay.Location = new System.Drawing.Point(58, 217);
-			this.chkShowStatusOverlay.Name = "chkShowStatusOverlay";
-			this.chkShowStatusOverlay.Size = new System.Drawing.Size(158, 17);
-			this.chkShowStatusOverlay.TabIndex = 1;
-			this.chkShowStatusOverlay.Text = "Show Messages and Status";
-			this.chkShowStatusOverlay.UseVisualStyleBackColor = true;
-			// 
-			// chkShowVisiblePartOverlay
-			// 
-			this.chkShowVisiblePartOverlay.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.chkShowVisiblePartOverlay.AutoSize = true;
-			this.chkShowVisiblePartOverlay.Location = new System.Drawing.Point(58, 241);
-			this.chkShowVisiblePartOverlay.Name = "chkShowVisiblePartOverlay";
-			this.chkShowVisiblePartOverlay.Size = new System.Drawing.Size(135, 17);
-			this.chkShowVisiblePartOverlay.TabIndex = 2;
-			this.chkShowVisiblePartOverlay.Text = "Show visible Page Part";
-			this.chkShowVisiblePartOverlay.UseVisualStyleBackColor = true;
-			// 
-			// chkShowNavigationOverlay
-			// 
-			this.chkShowNavigationOverlay.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.chkShowNavigationOverlay.AutoSize = true;
-			this.chkShowNavigationOverlay.Location = new System.Drawing.Point(58, 264);
-			this.chkShowNavigationOverlay.Name = "chkShowNavigationOverlay";
-			this.chkShowNavigationOverlay.Size = new System.Drawing.Size(171, 17);
-			this.chkShowNavigationOverlay.TabIndex = 3;
-			this.chkShowNavigationOverlay.Text = "Show Navigation automatically";
-			this.chkShowNavigationOverlay.UseVisualStyleBackColor = true;
-			// 
-			// labelOverlaySize
-			// 
-			this.labelOverlaySize.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.labelOverlaySize.AutoSize = true;
-			this.labelOverlaySize.Location = new System.Drawing.Point(244, 316);
-			this.labelOverlaySize.Name = "labelOverlaySize";
-			this.labelOverlaySize.Size = new System.Drawing.Size(38, 13);
-			this.labelOverlaySize.TabIndex = 7;
-			this.labelOverlaySize.Text = "Sizing:";
-			// 
-			// grpKeyboard
-			// 
-			this.grpKeyboard.Controls.Add(this.btExportKeyboard);
-			this.grpKeyboard.Controls.Add(this.btImportKeyboard);
-			this.grpKeyboard.Controls.Add(this.keyboardShortcutEditor);
-			this.grpKeyboard.Dock = System.Windows.Forms.DockStyle.Top;
-			this.grpKeyboard.Location = new System.Drawing.Point(0, 300);
-			this.grpKeyboard.Name = "grpKeyboard";
-			this.grpKeyboard.Size = new System.Drawing.Size(498, 390);
-			this.grpKeyboard.TabIndex = 4;
-			this.grpKeyboard.Text = "Keyboard";
-			// 
-			// btExportKeyboard
-			// 
-			this.btExportKeyboard.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btExportKeyboard.Location = new System.Drawing.Point(274, 357);
-			this.btExportKeyboard.Name = "btExportKeyboard";
-			this.btExportKeyboard.Size = new System.Drawing.Size(102, 23);
-			this.btExportKeyboard.TabIndex = 1;
-			this.btExportKeyboard.Text = "Export...";
-			this.btExportKeyboard.UseVisualStyleBackColor = true;
-			this.btExportKeyboard.Click += new System.EventHandler(this.btExportKeyboard_Click);
-			// 
-			// btImportKeyboard
-			// 
-			this.btImportKeyboard.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btImportKeyboard.ContextMenuStrip = this.cmKeyboardLayout;
-			this.btImportKeyboard.Location = new System.Drawing.Point(382, 357);
-			this.btImportKeyboard.Name = "btImportKeyboard";
-			this.btImportKeyboard.Size = new System.Drawing.Size(102, 23);
-			this.btImportKeyboard.TabIndex = 2;
-			this.btImportKeyboard.Text = "Import...";
-			this.btImportKeyboard.UseVisualStyleBackColor = true;
-			this.btImportKeyboard.ShowContextMenu += new System.EventHandler(this.btImportKeyboard_ShowContextMenu);
-			this.btImportKeyboard.Click += new System.EventHandler(this.btLoadKeyboard_Click);
-			// 
-			// cmKeyboardLayout
-			// 
-			this.cmKeyboardLayout.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.cbNavigationOverlayPosition.Location = new System.Drawing.Point(84, 313);
+            this.cbNavigationOverlayPosition.Name = "cbNavigationOverlayPosition";
+            this.cbNavigationOverlayPosition.Size = new System.Drawing.Size(121, 21);
+            this.cbNavigationOverlayPosition.TabIndex = 6;
+            // 
+            // labelNavigationOverlayPosition
+            // 
+            this.labelNavigationOverlayPosition.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.labelNavigationOverlayPosition.AutoSize = true;
+            this.labelNavigationOverlayPosition.Location = new System.Drawing.Point(18, 316);
+            this.labelNavigationOverlayPosition.Name = "labelNavigationOverlayPosition";
+            this.labelNavigationOverlayPosition.Size = new System.Drawing.Size(61, 13);
+            this.labelNavigationOverlayPosition.TabIndex = 5;
+            this.labelNavigationOverlayPosition.Text = "Navigation:";
+            // 
+            // chkShowPageNames
+            // 
+            this.chkShowPageNames.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.chkShowPageNames.AutoSize = true;
+            this.chkShowPageNames.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chkShowPageNames.Location = new System.Drawing.Point(283, 193);
+            this.chkShowPageNames.Name = "chkShowPageNames";
+            this.chkShowPageNames.Size = new System.Drawing.Size(181, 17);
+            this.chkShowPageNames.TabIndex = 4;
+            this.chkShowPageNames.Text = "Current Page also displays Name";
+            this.chkShowPageNames.UseVisualStyleBackColor = true;
+            // 
+            // tbOverlayScaling
+            // 
+            this.tbOverlayScaling.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.tbOverlayScaling.Location = new System.Drawing.Point(288, 316);
+            this.tbOverlayScaling.Maximum = 150;
+            this.tbOverlayScaling.Minimum = 40;
+            this.tbOverlayScaling.Name = "tbOverlayScaling";
+            this.tbOverlayScaling.Size = new System.Drawing.Size(184, 16);
+            this.tbOverlayScaling.TabIndex = 8;
+            this.tbOverlayScaling.ThumbSize = new System.Drawing.Size(8, 16);
+            this.tbOverlayScaling.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
+            this.tbOverlayScaling.Value = 50;
+            this.tbOverlayScaling.ValueChanged += new System.EventHandler(this.tbOverlayScalingChanged);
+            // 
+            // chkShowCurrentPageOverlay
+            // 
+            this.chkShowCurrentPageOverlay.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.chkShowCurrentPageOverlay.AutoSize = true;
+            this.chkShowCurrentPageOverlay.Location = new System.Drawing.Point(58, 193);
+            this.chkShowCurrentPageOverlay.Name = "chkShowCurrentPageOverlay";
+            this.chkShowCurrentPageOverlay.Size = new System.Drawing.Size(117, 17);
+            this.chkShowCurrentPageOverlay.TabIndex = 0;
+            this.chkShowCurrentPageOverlay.Text = "Show current Page";
+            this.chkShowCurrentPageOverlay.UseVisualStyleBackColor = true;
+            // 
+            // chkShowStatusOverlay
+            // 
+            this.chkShowStatusOverlay.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.chkShowStatusOverlay.AutoSize = true;
+            this.chkShowStatusOverlay.Location = new System.Drawing.Point(58, 217);
+            this.chkShowStatusOverlay.Name = "chkShowStatusOverlay";
+            this.chkShowStatusOverlay.Size = new System.Drawing.Size(158, 17);
+            this.chkShowStatusOverlay.TabIndex = 1;
+            this.chkShowStatusOverlay.Text = "Show Messages and Status";
+            this.chkShowStatusOverlay.UseVisualStyleBackColor = true;
+            // 
+            // chkShowVisiblePartOverlay
+            // 
+            this.chkShowVisiblePartOverlay.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.chkShowVisiblePartOverlay.AutoSize = true;
+            this.chkShowVisiblePartOverlay.Location = new System.Drawing.Point(58, 241);
+            this.chkShowVisiblePartOverlay.Name = "chkShowVisiblePartOverlay";
+            this.chkShowVisiblePartOverlay.Size = new System.Drawing.Size(135, 17);
+            this.chkShowVisiblePartOverlay.TabIndex = 2;
+            this.chkShowVisiblePartOverlay.Text = "Show visible Page Part";
+            this.chkShowVisiblePartOverlay.UseVisualStyleBackColor = true;
+            // 
+            // chkShowNavigationOverlay
+            // 
+            this.chkShowNavigationOverlay.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.chkShowNavigationOverlay.AutoSize = true;
+            this.chkShowNavigationOverlay.Location = new System.Drawing.Point(58, 264);
+            this.chkShowNavigationOverlay.Name = "chkShowNavigationOverlay";
+            this.chkShowNavigationOverlay.Size = new System.Drawing.Size(171, 17);
+            this.chkShowNavigationOverlay.TabIndex = 3;
+            this.chkShowNavigationOverlay.Text = "Show Navigation automatically";
+            this.chkShowNavigationOverlay.UseVisualStyleBackColor = true;
+            // 
+            // labelOverlaySize
+            // 
+            this.labelOverlaySize.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.labelOverlaySize.AutoSize = true;
+            this.labelOverlaySize.Location = new System.Drawing.Point(244, 316);
+            this.labelOverlaySize.Name = "labelOverlaySize";
+            this.labelOverlaySize.Size = new System.Drawing.Size(38, 13);
+            this.labelOverlaySize.TabIndex = 7;
+            this.labelOverlaySize.Text = "Sizing:";
+            // 
+            // grpKeyboard
+            // 
+            this.grpKeyboard.Controls.Add(this.btExportKeyboard);
+            this.grpKeyboard.Controls.Add(this.btImportKeyboard);
+            this.grpKeyboard.Controls.Add(this.keyboardShortcutEditor);
+            this.grpKeyboard.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpKeyboard.Location = new System.Drawing.Point(0, 300);
+            this.grpKeyboard.Name = "grpKeyboard";
+            this.grpKeyboard.Size = new System.Drawing.Size(498, 390);
+            this.grpKeyboard.TabIndex = 4;
+            this.grpKeyboard.Text = "Keyboard";
+            // 
+            // btExportKeyboard
+            // 
+            this.btExportKeyboard.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btExportKeyboard.Location = new System.Drawing.Point(274, 357);
+            this.btExportKeyboard.Name = "btExportKeyboard";
+            this.btExportKeyboard.Size = new System.Drawing.Size(102, 23);
+            this.btExportKeyboard.TabIndex = 1;
+            this.btExportKeyboard.Text = "Export...";
+            this.btExportKeyboard.UseVisualStyleBackColor = true;
+            this.btExportKeyboard.Click += new System.EventHandler(this.btExportKeyboard_Click);
+            // 
+            // btImportKeyboard
+            // 
+            this.btImportKeyboard.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btImportKeyboard.ContextMenuStrip = this.cmKeyboardLayout;
+            this.btImportKeyboard.Location = new System.Drawing.Point(382, 357);
+            this.btImportKeyboard.Name = "btImportKeyboard";
+            this.btImportKeyboard.Size = new System.Drawing.Size(102, 23);
+            this.btImportKeyboard.TabIndex = 2;
+            this.btImportKeyboard.Text = "Import...";
+            this.btImportKeyboard.UseVisualStyleBackColor = true;
+            this.btImportKeyboard.ShowContextMenu += new System.EventHandler(this.btImportKeyboard_ShowContextMenu);
+            this.btImportKeyboard.Click += new System.EventHandler(this.btLoadKeyboard_Click);
+            // 
+            // cmKeyboardLayout
+            // 
+            this.cmKeyboardLayout.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.miDefaultKeyboardLayout,
             this.toolStripMenuItem1});
-			this.cmKeyboardLayout.Name = "cmKeyboardLayout";
-			this.cmKeyboardLayout.Size = new System.Drawing.Size(113, 32);
-			// 
-			// miDefaultKeyboardLayout
-			// 
-			this.miDefaultKeyboardLayout.Name = "miDefaultKeyboardLayout";
-			this.miDefaultKeyboardLayout.Size = new System.Drawing.Size(112, 22);
-			this.miDefaultKeyboardLayout.Text = "&Default";
-			this.miDefaultKeyboardLayout.Click += new System.EventHandler(this.miDefaultKeyboardLayout_Click);
-			// 
-			// toolStripMenuItem1
-			// 
-			this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-			this.toolStripMenuItem1.Size = new System.Drawing.Size(109, 6);
-			// 
-			// keyboardShortcutEditor
-			// 
-			this.keyboardShortcutEditor.AllowDrop = true;
-			this.keyboardShortcutEditor.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.cmKeyboardLayout.Name = "cmKeyboardLayout";
+            this.cmKeyboardLayout.Size = new System.Drawing.Size(113, 32);
+            // 
+            // miDefaultKeyboardLayout
+            // 
+            this.miDefaultKeyboardLayout.Name = "miDefaultKeyboardLayout";
+            this.miDefaultKeyboardLayout.Size = new System.Drawing.Size(112, 22);
+            this.miDefaultKeyboardLayout.Text = "&Default";
+            this.miDefaultKeyboardLayout.Click += new System.EventHandler(this.miDefaultKeyboardLayout_Click);
+            // 
+            // toolStripMenuItem1
+            // 
+            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(109, 6);
+            // 
+            // keyboardShortcutEditor
+            // 
+            this.keyboardShortcutEditor.AllowDrop = true;
+            this.keyboardShortcutEditor.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.keyboardShortcutEditor.Location = new System.Drawing.Point(12, 37);
-			this.keyboardShortcutEditor.Name = "keyboardShortcutEditor";
-			this.keyboardShortcutEditor.Shortcuts = null;
-			this.keyboardShortcutEditor.Size = new System.Drawing.Size(472, 314);
-			this.keyboardShortcutEditor.TabIndex = 0;
-			this.keyboardShortcutEditor.DragDrop += new System.Windows.Forms.DragEventHandler(this.keyboardShortcutEditor_DragDrop);
-			this.keyboardShortcutEditor.DragOver += new System.Windows.Forms.DragEventHandler(this.keyboardShortcutEditor_DragOver);
-			// 
-			// grpDisplay
-			// 
-			this.grpDisplay.Controls.Add(this.tbGamma);
-			this.grpDisplay.Controls.Add(this.labelGamma);
-			this.grpDisplay.Controls.Add(this.chkAnamorphicScaling);
-			this.grpDisplay.Controls.Add(this.chkHighQualityDisplay);
-			this.grpDisplay.Controls.Add(this.labelSharpening);
-			this.grpDisplay.Controls.Add(this.tbSharpening);
-			this.grpDisplay.Controls.Add(this.btResetColor);
-			this.grpDisplay.Controls.Add(this.chkAutoContrast);
-			this.grpDisplay.Controls.Add(this.labelSaturation);
-			this.grpDisplay.Controls.Add(this.tbSaturation);
-			this.grpDisplay.Controls.Add(this.labelBrightness);
-			this.grpDisplay.Controls.Add(this.tbBrightness);
-			this.grpDisplay.Controls.Add(this.tbContrast);
-			this.grpDisplay.Controls.Add(this.labelContrast);
-			this.grpDisplay.Dock = System.Windows.Forms.DockStyle.Top;
-			this.grpDisplay.Location = new System.Drawing.Point(0, 0);
-			this.grpDisplay.Name = "grpDisplay";
-			this.grpDisplay.Size = new System.Drawing.Size(498, 300);
-			this.grpDisplay.TabIndex = 1;
-			this.grpDisplay.Text = "Display";
-			// 
-			// tbGamma
-			// 
-			this.tbGamma.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.keyboardShortcutEditor.Location = new System.Drawing.Point(12, 37);
+            this.keyboardShortcutEditor.Name = "keyboardShortcutEditor";
+            this.keyboardShortcutEditor.Shortcuts = null;
+            this.keyboardShortcutEditor.Size = new System.Drawing.Size(472, 314);
+            this.keyboardShortcutEditor.TabIndex = 0;
+            this.keyboardShortcutEditor.DragDrop += new System.Windows.Forms.DragEventHandler(this.keyboardShortcutEditor_DragDrop);
+            this.keyboardShortcutEditor.DragOver += new System.Windows.Forms.DragEventHandler(this.keyboardShortcutEditor_DragOver);
+            // 
+            // grpDisplay
+            // 
+            this.grpDisplay.Controls.Add(this.tbGamma);
+            this.grpDisplay.Controls.Add(this.labelGamma);
+            this.grpDisplay.Controls.Add(this.chkAnamorphicScaling);
+            this.grpDisplay.Controls.Add(this.chkHighQualityDisplay);
+            this.grpDisplay.Controls.Add(this.labelSharpening);
+            this.grpDisplay.Controls.Add(this.tbSharpening);
+            this.grpDisplay.Controls.Add(this.btResetColor);
+            this.grpDisplay.Controls.Add(this.chkAutoContrast);
+            this.grpDisplay.Controls.Add(this.labelSaturation);
+            this.grpDisplay.Controls.Add(this.tbSaturation);
+            this.grpDisplay.Controls.Add(this.labelBrightness);
+            this.grpDisplay.Controls.Add(this.tbBrightness);
+            this.grpDisplay.Controls.Add(this.tbContrast);
+            this.grpDisplay.Controls.Add(this.labelContrast);
+            this.grpDisplay.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpDisplay.Location = new System.Drawing.Point(0, 0);
+            this.grpDisplay.Name = "grpDisplay";
+            this.grpDisplay.Size = new System.Drawing.Size(498, 300);
+            this.grpDisplay.TabIndex = 1;
+            this.grpDisplay.Text = "Display";
+            // 
+            // tbGamma
+            // 
+            this.tbGamma.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.tbGamma.Location = new System.Drawing.Point(150, 193);
-			this.tbGamma.Minimum = -100;
-			this.tbGamma.Name = "tbGamma";
-			this.tbGamma.Size = new System.Drawing.Size(332, 16);
-			this.tbGamma.TabIndex = 12;
-			this.tbGamma.Text = "tbSaturation";
-			this.tbGamma.ThumbSize = new System.Drawing.Size(8, 16);
-			this.tbGamma.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
-			this.tbGamma.ValueChanged += new System.EventHandler(this.tbColorAdjustmentChanged);
-			this.tbGamma.DoubleClick += new System.EventHandler(this.tbGamma_DoubleClick);
-			// 
-			// labelGamma
-			// 
-			this.labelGamma.Location = new System.Drawing.Point(14, 193);
-			this.labelGamma.Name = "labelGamma";
-			this.labelGamma.Size = new System.Drawing.Size(133, 13);
-			this.labelGamma.TabIndex = 11;
-			this.labelGamma.Text = "Gamma Adjustment:";
-			this.labelGamma.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			// 
-			// chkAnamorphicScaling
-			// 
-			this.chkAnamorphicScaling.AutoSize = true;
-			this.chkAnamorphicScaling.Location = new System.Drawing.Point(12, 60);
-			this.chkAnamorphicScaling.Name = "chkAnamorphicScaling";
-			this.chkAnamorphicScaling.Size = new System.Drawing.Size(120, 17);
-			this.chkAnamorphicScaling.TabIndex = 0;
-			this.chkAnamorphicScaling.Text = "&Anamorphic Scaling";
-			this.chkAnamorphicScaling.UseVisualStyleBackColor = true;
-			// 
-			// chkHighQualityDisplay
-			// 
-			this.chkHighQualityDisplay.AutoSize = true;
-			this.chkHighQualityDisplay.Location = new System.Drawing.Point(12, 37);
-			this.chkHighQualityDisplay.Name = "chkHighQualityDisplay";
-			this.chkHighQualityDisplay.Size = new System.Drawing.Size(83, 17);
-			this.chkHighQualityDisplay.TabIndex = 0;
-			this.chkHighQualityDisplay.Text = "&High Quality";
-			this.chkHighQualityDisplay.UseVisualStyleBackColor = true;
-			// 
-			// labelSharpening
-			// 
-			this.labelSharpening.Location = new System.Drawing.Point(17, 225);
-			this.labelSharpening.Name = "labelSharpening";
-			this.labelSharpening.Size = new System.Drawing.Size(132, 13);
-			this.labelSharpening.TabIndex = 8;
-			this.labelSharpening.Text = "Sharpening:";
-			this.labelSharpening.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			// 
-			// tbSharpening
-			// 
-			this.tbSharpening.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.tbGamma.Location = new System.Drawing.Point(150, 193);
+            this.tbGamma.Minimum = -100;
+            this.tbGamma.Name = "tbGamma";
+            this.tbGamma.Size = new System.Drawing.Size(332, 16);
+            this.tbGamma.TabIndex = 12;
+            this.tbGamma.Text = "tbSaturation";
+            this.tbGamma.ThumbSize = new System.Drawing.Size(8, 16);
+            this.tbGamma.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
+            this.tbGamma.ValueChanged += new System.EventHandler(this.tbColorAdjustmentChanged);
+            this.tbGamma.DoubleClick += new System.EventHandler(this.tbGamma_DoubleClick);
+            // 
+            // labelGamma
+            // 
+            this.labelGamma.Location = new System.Drawing.Point(14, 193);
+            this.labelGamma.Name = "labelGamma";
+            this.labelGamma.Size = new System.Drawing.Size(133, 13);
+            this.labelGamma.TabIndex = 11;
+            this.labelGamma.Text = "Gamma Adjustment:";
+            this.labelGamma.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // chkAnamorphicScaling
+            // 
+            this.chkAnamorphicScaling.AutoSize = true;
+            this.chkAnamorphicScaling.Location = new System.Drawing.Point(12, 60);
+            this.chkAnamorphicScaling.Name = "chkAnamorphicScaling";
+            this.chkAnamorphicScaling.Size = new System.Drawing.Size(120, 17);
+            this.chkAnamorphicScaling.TabIndex = 0;
+            this.chkAnamorphicScaling.Text = "&Anamorphic Scaling";
+            this.chkAnamorphicScaling.UseVisualStyleBackColor = true;
+            // 
+            // chkHighQualityDisplay
+            // 
+            this.chkHighQualityDisplay.AutoSize = true;
+            this.chkHighQualityDisplay.Location = new System.Drawing.Point(12, 37);
+            this.chkHighQualityDisplay.Name = "chkHighQualityDisplay";
+            this.chkHighQualityDisplay.Size = new System.Drawing.Size(83, 17);
+            this.chkHighQualityDisplay.TabIndex = 0;
+            this.chkHighQualityDisplay.Text = "&High Quality";
+            this.chkHighQualityDisplay.UseVisualStyleBackColor = true;
+            // 
+            // labelSharpening
+            // 
+            this.labelSharpening.Location = new System.Drawing.Point(17, 225);
+            this.labelSharpening.Name = "labelSharpening";
+            this.labelSharpening.Size = new System.Drawing.Size(132, 13);
+            this.labelSharpening.TabIndex = 8;
+            this.labelSharpening.Text = "Sharpening:";
+            this.labelSharpening.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // tbSharpening
+            // 
+            this.tbSharpening.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.tbSharpening.LargeChange = 1;
-			this.tbSharpening.Location = new System.Drawing.Point(149, 225);
-			this.tbSharpening.Maximum = 3;
-			this.tbSharpening.Name = "tbSharpening";
-			this.tbSharpening.Size = new System.Drawing.Size(333, 18);
-			this.tbSharpening.TabIndex = 9;
-			this.tbSharpening.Text = "tbSaturation";
-			this.tbSharpening.ThumbSize = new System.Drawing.Size(8, 16);
-			this.tbSharpening.TickFrequency = 1;
-			this.tbSharpening.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
-			this.tbSharpening.DoubleClick += new System.EventHandler(this.tbSharpening_DoubleClick);
-			// 
-			// btResetColor
-			// 
-			this.btResetColor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btResetColor.Location = new System.Drawing.Point(394, 265);
-			this.btResetColor.Name = "btResetColor";
-			this.btResetColor.Size = new System.Drawing.Size(91, 23);
-			this.btResetColor.TabIndex = 10;
-			this.btResetColor.Text = "&Reset";
-			this.btResetColor.UseVisualStyleBackColor = true;
-			this.btResetColor.Click += new System.EventHandler(this.btReset_Click);
-			// 
-			// chkAutoContrast
-			// 
-			this.chkAutoContrast.AutoSize = true;
-			this.chkAutoContrast.Location = new System.Drawing.Point(12, 95);
-			this.chkAutoContrast.Name = "chkAutoContrast";
-			this.chkAutoContrast.Size = new System.Drawing.Size(184, 17);
-			this.chkAutoContrast.TabIndex = 1;
-			this.chkAutoContrast.Text = "Automatic &Contrast Enhancement";
-			this.chkAutoContrast.UseVisualStyleBackColor = true;
-			// 
-			// labelSaturation
-			// 
-			this.labelSaturation.Location = new System.Drawing.Point(11, 122);
-			this.labelSaturation.Name = "labelSaturation";
-			this.labelSaturation.Size = new System.Drawing.Size(136, 13);
-			this.labelSaturation.TabIndex = 2;
-			this.labelSaturation.Text = "Saturation Adjustment:";
-			this.labelSaturation.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			// 
-			// tbSaturation
-			// 
-			this.tbSaturation.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.tbSharpening.LargeChange = 1;
+            this.tbSharpening.Location = new System.Drawing.Point(149, 225);
+            this.tbSharpening.Maximum = 3;
+            this.tbSharpening.Name = "tbSharpening";
+            this.tbSharpening.Size = new System.Drawing.Size(333, 18);
+            this.tbSharpening.TabIndex = 9;
+            this.tbSharpening.Text = "tbSaturation";
+            this.tbSharpening.ThumbSize = new System.Drawing.Size(8, 16);
+            this.tbSharpening.TickFrequency = 1;
+            this.tbSharpening.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
+            this.tbSharpening.DoubleClick += new System.EventHandler(this.tbSharpening_DoubleClick);
+            // 
+            // btResetColor
+            // 
+            this.btResetColor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btResetColor.Location = new System.Drawing.Point(394, 265);
+            this.btResetColor.Name = "btResetColor";
+            this.btResetColor.Size = new System.Drawing.Size(91, 23);
+            this.btResetColor.TabIndex = 10;
+            this.btResetColor.Text = "&Reset";
+            this.btResetColor.UseVisualStyleBackColor = true;
+            this.btResetColor.Click += new System.EventHandler(this.btReset_Click);
+            // 
+            // chkAutoContrast
+            // 
+            this.chkAutoContrast.AutoSize = true;
+            this.chkAutoContrast.Location = new System.Drawing.Point(12, 95);
+            this.chkAutoContrast.Name = "chkAutoContrast";
+            this.chkAutoContrast.Size = new System.Drawing.Size(184, 17);
+            this.chkAutoContrast.TabIndex = 1;
+            this.chkAutoContrast.Text = "Automatic &Contrast Enhancement";
+            this.chkAutoContrast.UseVisualStyleBackColor = true;
+            // 
+            // labelSaturation
+            // 
+            this.labelSaturation.Location = new System.Drawing.Point(11, 122);
+            this.labelSaturation.Name = "labelSaturation";
+            this.labelSaturation.Size = new System.Drawing.Size(136, 13);
+            this.labelSaturation.TabIndex = 2;
+            this.labelSaturation.Text = "Saturation Adjustment:";
+            this.labelSaturation.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // tbSaturation
+            // 
+            this.tbSaturation.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.tbSaturation.Location = new System.Drawing.Point(148, 122);
-			this.tbSaturation.Minimum = -100;
-			this.tbSaturation.Name = "tbSaturation";
-			this.tbSaturation.Size = new System.Drawing.Size(334, 16);
-			this.tbSaturation.TabIndex = 3;
-			this.tbSaturation.ThumbSize = new System.Drawing.Size(8, 16);
-			this.tbSaturation.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
-			this.tbSaturation.ValueChanged += new System.EventHandler(this.tbColorAdjustmentChanged);
-			this.tbSaturation.DoubleClick += new System.EventHandler(this.tbSaturation_DoubleClick);
-			// 
-			// labelBrightness
-			// 
-			this.labelBrightness.Location = new System.Drawing.Point(14, 144);
-			this.labelBrightness.Name = "labelBrightness";
-			this.labelBrightness.Size = new System.Drawing.Size(133, 13);
-			this.labelBrightness.TabIndex = 4;
-			this.labelBrightness.Text = "Brightness Adjustment:";
-			this.labelBrightness.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			// 
-			// tbBrightness
-			// 
-			this.tbBrightness.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.tbSaturation.Location = new System.Drawing.Point(148, 122);
+            this.tbSaturation.Minimum = -100;
+            this.tbSaturation.Name = "tbSaturation";
+            this.tbSaturation.Size = new System.Drawing.Size(334, 16);
+            this.tbSaturation.TabIndex = 3;
+            this.tbSaturation.ThumbSize = new System.Drawing.Size(8, 16);
+            this.tbSaturation.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
+            this.tbSaturation.ValueChanged += new System.EventHandler(this.tbColorAdjustmentChanged);
+            this.tbSaturation.DoubleClick += new System.EventHandler(this.tbSaturation_DoubleClick);
+            // 
+            // labelBrightness
+            // 
+            this.labelBrightness.Location = new System.Drawing.Point(14, 144);
+            this.labelBrightness.Name = "labelBrightness";
+            this.labelBrightness.Size = new System.Drawing.Size(133, 13);
+            this.labelBrightness.TabIndex = 4;
+            this.labelBrightness.Text = "Brightness Adjustment:";
+            this.labelBrightness.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // tbBrightness
+            // 
+            this.tbBrightness.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.tbBrightness.Location = new System.Drawing.Point(148, 144);
-			this.tbBrightness.Minimum = -100;
-			this.tbBrightness.Name = "tbBrightness";
-			this.tbBrightness.Size = new System.Drawing.Size(334, 16);
-			this.tbBrightness.TabIndex = 5;
-			this.tbBrightness.Text = "tbBrightness";
-			this.tbBrightness.ThumbSize = new System.Drawing.Size(8, 16);
-			this.tbBrightness.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
-			this.tbBrightness.ValueChanged += new System.EventHandler(this.tbColorAdjustmentChanged);
-			this.tbBrightness.DoubleClick += new System.EventHandler(this.tbBrightness_DoubleClick);
-			// 
-			// tbContrast
-			// 
-			this.tbContrast.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.tbBrightness.Location = new System.Drawing.Point(148, 144);
+            this.tbBrightness.Minimum = -100;
+            this.tbBrightness.Name = "tbBrightness";
+            this.tbBrightness.Size = new System.Drawing.Size(334, 16);
+            this.tbBrightness.TabIndex = 5;
+            this.tbBrightness.Text = "tbBrightness";
+            this.tbBrightness.ThumbSize = new System.Drawing.Size(8, 16);
+            this.tbBrightness.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
+            this.tbBrightness.ValueChanged += new System.EventHandler(this.tbColorAdjustmentChanged);
+            this.tbBrightness.DoubleClick += new System.EventHandler(this.tbBrightness_DoubleClick);
+            // 
+            // tbContrast
+            // 
+            this.tbContrast.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.tbContrast.Location = new System.Drawing.Point(148, 168);
-			this.tbContrast.Minimum = -100;
-			this.tbContrast.Name = "tbContrast";
-			this.tbContrast.Size = new System.Drawing.Size(334, 16);
-			this.tbContrast.TabIndex = 7;
-			this.tbContrast.Text = "tbSaturation";
-			this.tbContrast.ThumbSize = new System.Drawing.Size(8, 16);
-			this.tbContrast.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
-			this.tbContrast.ValueChanged += new System.EventHandler(this.tbColorAdjustmentChanged);
-			this.tbContrast.DoubleClick += new System.EventHandler(this.tbContrast_DoubleClick);
-			// 
-			// labelContrast
-			// 
-			this.labelContrast.Location = new System.Drawing.Point(14, 168);
-			this.labelContrast.Name = "labelContrast";
-			this.labelContrast.Size = new System.Drawing.Size(133, 13);
-			this.labelContrast.TabIndex = 6;
-			this.labelContrast.Text = "Contrast Adjustment:";
-			this.labelContrast.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			// 
-			// pageAdvanced
-			// 
-			this.pageAdvanced.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.tbContrast.Location = new System.Drawing.Point(148, 168);
+            this.tbContrast.Minimum = -100;
+            this.tbContrast.Name = "tbContrast";
+            this.tbContrast.Size = new System.Drawing.Size(334, 16);
+            this.tbContrast.TabIndex = 7;
+            this.tbContrast.Text = "tbSaturation";
+            this.tbContrast.ThumbSize = new System.Drawing.Size(8, 16);
+            this.tbContrast.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
+            this.tbContrast.ValueChanged += new System.EventHandler(this.tbColorAdjustmentChanged);
+            this.tbContrast.DoubleClick += new System.EventHandler(this.tbContrast_DoubleClick);
+            // 
+            // labelContrast
+            // 
+            this.labelContrast.Location = new System.Drawing.Point(14, 168);
+            this.labelContrast.Name = "labelContrast";
+            this.labelContrast.Size = new System.Drawing.Size(133, 13);
+            this.labelContrast.TabIndex = 6;
+            this.labelContrast.Text = "Contrast Adjustment:";
+            this.labelContrast.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // pageAdvanced
+            // 
+            this.pageAdvanced.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.pageAdvanced.AutoScroll = true;
-			this.pageAdvanced.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.pageAdvanced.Controls.Add(this.grpWirelessSetup);
-			this.pageAdvanced.Controls.Add(this.grpIntegration);
-			this.pageAdvanced.Controls.Add(this.groupMessagesAndSocial);
-			this.pageAdvanced.Controls.Add(this.groupMemory);
-			this.pageAdvanced.Controls.Add(this.grpBackupManager);
-			this.pageAdvanced.Controls.Add(this.grpDatabaseBackup);
-			this.pageAdvanced.Controls.Add(this.groupOtherComics);
-			this.pageAdvanced.Controls.Add(this.grpLanguages);
-			this.pageAdvanced.Location = new System.Drawing.Point(84, 8);
-			this.pageAdvanced.Name = "pageAdvanced";
-			this.pageAdvanced.Size = new System.Drawing.Size(517, 408);
-			this.pageAdvanced.TabIndex = 9;
-			// 
-			// grpWirelessSetup
-			// 
-			this.grpWirelessSetup.Controls.Add(this.btTestWifi);
-			this.grpWirelessSetup.Controls.Add(this.lblWifiStatus);
-			this.grpWirelessSetup.Controls.Add(this.lblWifiAddresses);
-			this.grpWirelessSetup.Controls.Add(this.txWifiAddresses);
-			this.grpWirelessSetup.Dock = System.Windows.Forms.DockStyle.Top;
-			this.grpWirelessSetup.Location = new System.Drawing.Point(0, 1594);
-			this.grpWirelessSetup.Name = "grpWirelessSetup";
-			this.grpWirelessSetup.Size = new System.Drawing.Size(498, 136);
-			this.grpWirelessSetup.TabIndex = 8;
-			this.grpWirelessSetup.Text = "Wireless Setup";
-			// 
-			// btTestWifi
-			// 
-			this.btTestWifi.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btTestWifi.Location = new System.Drawing.Point(382, 63);
-			this.btTestWifi.Name = "btTestWifi";
-			this.btTestWifi.Size = new System.Drawing.Size(104, 23);
-			this.btTestWifi.TabIndex = 3;
-			this.btTestWifi.Text = "Test";
-			this.btTestWifi.UseVisualStyleBackColor = true;
-			this.btTestWifi.Click += new System.EventHandler(this.btTestWifi_Click);
-			// 
-			// lblWifiStatus
-			// 
-			this.lblWifiStatus.Location = new System.Drawing.Point(6, 93);
-			this.lblWifiStatus.Name = "lblWifiStatus";
-			this.lblWifiStatus.Size = new System.Drawing.Size(370, 21);
-			this.lblWifiStatus.TabIndex = 2;
-			this.lblWifiStatus.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// lblWifiAddresses
-			// 
-			this.lblWifiAddresses.AutoSize = true;
-			this.lblWifiAddresses.Location = new System.Drawing.Point(4, 41);
-			this.lblWifiAddresses.Name = "lblWifiAddresses";
-			this.lblWifiAddresses.Size = new System.Drawing.Size(490, 13);
-			this.lblWifiAddresses.TabIndex = 1;
-			this.lblWifiAddresses.Text = "Semicolon separated list of IP addresses for Wireless Devices which where not det" +
+            this.pageAdvanced.AutoScroll = true;
+            this.pageAdvanced.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.pageAdvanced.Controls.Add(this.grpWirelessSetup);
+            this.pageAdvanced.Controls.Add(this.grpIntegration);
+            this.pageAdvanced.Controls.Add(this.groupMessagesAndSocial);
+            this.pageAdvanced.Controls.Add(this.groupMemory);
+            this.pageAdvanced.Controls.Add(this.grpBackupManager);
+            this.pageAdvanced.Controls.Add(this.grpDatabaseBackup);
+            this.pageAdvanced.Controls.Add(this.groupOtherComics);
+            this.pageAdvanced.Controls.Add(this.grpLanguages);
+            this.pageAdvanced.Location = new System.Drawing.Point(84, 8);
+            this.pageAdvanced.Name = "pageAdvanced";
+            this.pageAdvanced.Size = new System.Drawing.Size(517, 408);
+            this.pageAdvanced.TabIndex = 9;
+            // 
+            // grpWirelessSetup
+            // 
+            this.grpWirelessSetup.Controls.Add(this.btTestWifi);
+            this.grpWirelessSetup.Controls.Add(this.lblWifiStatus);
+            this.grpWirelessSetup.Controls.Add(this.lblWifiAddresses);
+            this.grpWirelessSetup.Controls.Add(this.txWifiAddresses);
+            this.grpWirelessSetup.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpWirelessSetup.Location = new System.Drawing.Point(0, 1618);
+            this.grpWirelessSetup.Name = "grpWirelessSetup";
+            this.grpWirelessSetup.Size = new System.Drawing.Size(498, 136);
+            this.grpWirelessSetup.TabIndex = 8;
+            this.grpWirelessSetup.Text = "Wireless Setup";
+            // 
+            // btTestWifi
+            // 
+            this.btTestWifi.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btTestWifi.Location = new System.Drawing.Point(382, 63);
+            this.btTestWifi.Name = "btTestWifi";
+            this.btTestWifi.Size = new System.Drawing.Size(104, 23);
+            this.btTestWifi.TabIndex = 3;
+            this.btTestWifi.Text = "Test";
+            this.btTestWifi.UseVisualStyleBackColor = true;
+            this.btTestWifi.Click += new System.EventHandler(this.btTestWifi_Click);
+            // 
+            // lblWifiStatus
+            // 
+            this.lblWifiStatus.Location = new System.Drawing.Point(6, 93);
+            this.lblWifiStatus.Name = "lblWifiStatus";
+            this.lblWifiStatus.Size = new System.Drawing.Size(370, 21);
+            this.lblWifiStatus.TabIndex = 2;
+            this.lblWifiStatus.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // lblWifiAddresses
+            // 
+            this.lblWifiAddresses.AutoSize = true;
+            this.lblWifiAddresses.Location = new System.Drawing.Point(4, 41);
+            this.lblWifiAddresses.Name = "lblWifiAddresses";
+            this.lblWifiAddresses.Size = new System.Drawing.Size(490, 13);
+            this.lblWifiAddresses.TabIndex = 1;
+            this.lblWifiAddresses.Text = "Semicolon separated list of IP addresses for Wireless Devices which where not det" +
     "ected automatically:";
-			// 
-			// txWifiAddresses
-			// 
-			this.txWifiAddresses.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            // 
+            // txWifiAddresses
+            // 
+            this.txWifiAddresses.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txWifiAddresses.Location = new System.Drawing.Point(6, 65);
-			this.txWifiAddresses.Name = "txWifiAddresses";
-			this.txWifiAddresses.Size = new System.Drawing.Size(370, 20);
-			this.txWifiAddresses.TabIndex = 0;
-			// 
-			// grpIntegration
-			// 
-			this.grpIntegration.Controls.Add(this.btAssociateExtensions);
-			this.grpIntegration.Controls.Add(this.labelCheckedFormats);
-			this.grpIntegration.Controls.Add(this.chkOverwriteAssociations);
-			this.grpIntegration.Controls.Add(this.lbFormats);
-			this.grpIntegration.Dock = System.Windows.Forms.DockStyle.Top;
-			this.grpIntegration.Location = new System.Drawing.Point(0, 1254);
-			this.grpIntegration.Name = "grpIntegration";
-			this.grpIntegration.Size = new System.Drawing.Size(498, 340);
-			this.grpIntegration.TabIndex = 0;
-			this.grpIntegration.Text = "Explorer Integration";
-			// 
-			// btAssociateExtensions
-			// 
-			this.btAssociateExtensions.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btAssociateExtensions.Location = new System.Drawing.Point(382, 57);
-			this.btAssociateExtensions.Name = "btAssociateExtensions";
-			this.btAssociateExtensions.Size = new System.Drawing.Size(104, 23);
-			this.btAssociateExtensions.TabIndex = 4;
-			this.btAssociateExtensions.Text = "Change...";
-			this.btAssociateExtensions.UseVisualStyleBackColor = true;
-			this.btAssociateExtensions.Click += new System.EventHandler(this.btAssociateExtensions_Click);
-			// 
-			// labelCheckedFormats
-			// 
-			this.labelCheckedFormats.AutoSize = true;
-			this.labelCheckedFormats.Location = new System.Drawing.Point(3, 35);
-			this.labelCheckedFormats.Name = "labelCheckedFormats";
-			this.labelCheckedFormats.Size = new System.Drawing.Size(253, 13);
-			this.labelCheckedFormats.TabIndex = 0;
-			this.labelCheckedFormats.Text = "Checked formats will be associated with ComicRack";
-			// 
-			// chkOverwriteAssociations
-			// 
-			this.chkOverwriteAssociations.AutoSize = true;
-			this.chkOverwriteAssociations.CheckAlign = System.Drawing.ContentAlignment.TopLeft;
-			this.chkOverwriteAssociations.Location = new System.Drawing.Point(6, 307);
-			this.chkOverwriteAssociations.Name = "chkOverwriteAssociations";
-			this.chkOverwriteAssociations.Size = new System.Drawing.Size(289, 17);
-			this.chkOverwriteAssociations.TabIndex = 2;
-			this.chkOverwriteAssociations.Text = "Overwrite existing associations instead of \'Open With ...\'";
-			this.chkOverwriteAssociations.TextAlign = System.Drawing.ContentAlignment.TopLeft;
-			this.chkOverwriteAssociations.UseVisualStyleBackColor = true;
-			// 
-			// lbFormats
-			// 
-			this.lbFormats.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.txWifiAddresses.Location = new System.Drawing.Point(6, 65);
+            this.txWifiAddresses.Name = "txWifiAddresses";
+            this.txWifiAddresses.Size = new System.Drawing.Size(370, 20);
+            this.txWifiAddresses.TabIndex = 0;
+            // 
+            // grpIntegration
+            // 
+            this.grpIntegration.Controls.Add(this.btAssociateExtensions);
+            this.grpIntegration.Controls.Add(this.labelCheckedFormats);
+            this.grpIntegration.Controls.Add(this.chkOverwriteAssociations);
+            this.grpIntegration.Controls.Add(this.lbFormats);
+            this.grpIntegration.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpIntegration.Location = new System.Drawing.Point(0, 1278);
+            this.grpIntegration.Name = "grpIntegration";
+            this.grpIntegration.Size = new System.Drawing.Size(498, 340);
+            this.grpIntegration.TabIndex = 0;
+            this.grpIntegration.Text = "Explorer Integration";
+            // 
+            // btAssociateExtensions
+            // 
+            this.btAssociateExtensions.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btAssociateExtensions.Location = new System.Drawing.Point(382, 57);
+            this.btAssociateExtensions.Name = "btAssociateExtensions";
+            this.btAssociateExtensions.Size = new System.Drawing.Size(104, 23);
+            this.btAssociateExtensions.TabIndex = 4;
+            this.btAssociateExtensions.Text = "Change...";
+            this.btAssociateExtensions.UseVisualStyleBackColor = true;
+            this.btAssociateExtensions.Click += new System.EventHandler(this.btAssociateExtensions_Click);
+            // 
+            // labelCheckedFormats
+            // 
+            this.labelCheckedFormats.AutoSize = true;
+            this.labelCheckedFormats.Location = new System.Drawing.Point(3, 35);
+            this.labelCheckedFormats.Name = "labelCheckedFormats";
+            this.labelCheckedFormats.Size = new System.Drawing.Size(253, 13);
+            this.labelCheckedFormats.TabIndex = 0;
+            this.labelCheckedFormats.Text = "Checked formats will be associated with ComicRack";
+            // 
+            // chkOverwriteAssociations
+            // 
+            this.chkOverwriteAssociations.AutoSize = true;
+            this.chkOverwriteAssociations.CheckAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chkOverwriteAssociations.Location = new System.Drawing.Point(6, 307);
+            this.chkOverwriteAssociations.Name = "chkOverwriteAssociations";
+            this.chkOverwriteAssociations.Size = new System.Drawing.Size(289, 17);
+            this.chkOverwriteAssociations.TabIndex = 2;
+            this.chkOverwriteAssociations.Text = "Overwrite existing associations instead of \'Open With ...\'";
+            this.chkOverwriteAssociations.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chkOverwriteAssociations.UseVisualStyleBackColor = true;
+            // 
+            // lbFormats
+            // 
+            this.lbFormats.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.lbFormats.CheckOnClick = true;
-			this.lbFormats.FormattingEnabled = true;
-			this.lbFormats.Location = new System.Drawing.Point(6, 57);
-			this.lbFormats.Name = "lbFormats";
-			this.lbFormats.Size = new System.Drawing.Size(371, 244);
-			this.lbFormats.TabIndex = 1;
-			// 
-			// groupMessagesAndSocial
-			// 
-			this.groupMessagesAndSocial.Controls.Add(this.btResetMessages);
-			this.groupMessagesAndSocial.Controls.Add(this.labelReshowHidden);
-			this.groupMessagesAndSocial.Dock = System.Windows.Forms.DockStyle.Top;
-			this.groupMessagesAndSocial.Location = new System.Drawing.Point(0, 1179);
-			this.groupMessagesAndSocial.Name = "groupMessagesAndSocial";
-			this.groupMessagesAndSocial.Size = new System.Drawing.Size(498, 75);
-			this.groupMessagesAndSocial.TabIndex = 6;
-			this.groupMessagesAndSocial.Text = "Messages and Social";
-			// 
-			// btResetMessages
-			// 
-			this.btResetMessages.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btResetMessages.Location = new System.Drawing.Point(382, 41);
-			this.btResetMessages.Name = "btResetMessages";
-			this.btResetMessages.Size = new System.Drawing.Size(104, 23);
-			this.btResetMessages.TabIndex = 1;
-			this.btResetMessages.Text = "Reset";
-			this.btResetMessages.UseVisualStyleBackColor = true;
-			this.btResetMessages.Click += new System.EventHandler(this.btResetMessages_Click);
-			// 
-			// labelReshowHidden
-			// 
-			this.labelReshowHidden.Location = new System.Drawing.Point(6, 46);
-			this.labelReshowHidden.Name = "labelReshowHidden";
-			this.labelReshowHidden.Size = new System.Drawing.Size(370, 17);
-			this.labelReshowHidden.TabIndex = 0;
-			this.labelReshowHidden.Text = "To reshow hidden messages press";
-			// 
-			// groupMemory
-			// 
-			this.groupMemory.Controls.Add(this.grpMaximumMemoryUsage);
-			this.groupMemory.Controls.Add(this.grpMemoryCache);
-			this.groupMemory.Controls.Add(this.grpDiskCache);
-			this.groupMemory.Dock = System.Windows.Forms.DockStyle.Top;
-			this.groupMemory.Location = new System.Drawing.Point(0, 824);
-			this.groupMemory.Name = "groupMemory";
-			this.groupMemory.Size = new System.Drawing.Size(498, 355);
-			this.groupMemory.TabIndex = 1;
-			this.groupMemory.Text = "Caches & Memory Usage";
-			// 
-			// grpMaximumMemoryUsage
-			// 
-			this.grpMaximumMemoryUsage.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.lbFormats.CheckOnClick = true;
+            this.lbFormats.FormattingEnabled = true;
+            this.lbFormats.Location = new System.Drawing.Point(6, 57);
+            this.lbFormats.Name = "lbFormats";
+            this.lbFormats.Size = new System.Drawing.Size(371, 244);
+            this.lbFormats.TabIndex = 1;
+            // 
+            // groupMessagesAndSocial
+            // 
+            this.groupMessagesAndSocial.Controls.Add(this.btResetMessages);
+            this.groupMessagesAndSocial.Controls.Add(this.labelReshowHidden);
+            this.groupMessagesAndSocial.Dock = System.Windows.Forms.DockStyle.Top;
+            this.groupMessagesAndSocial.Location = new System.Drawing.Point(0, 1203);
+            this.groupMessagesAndSocial.Name = "groupMessagesAndSocial";
+            this.groupMessagesAndSocial.Size = new System.Drawing.Size(498, 75);
+            this.groupMessagesAndSocial.TabIndex = 6;
+            this.groupMessagesAndSocial.Text = "Messages and Social";
+            // 
+            // btResetMessages
+            // 
+            this.btResetMessages.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btResetMessages.Location = new System.Drawing.Point(382, 41);
+            this.btResetMessages.Name = "btResetMessages";
+            this.btResetMessages.Size = new System.Drawing.Size(104, 23);
+            this.btResetMessages.TabIndex = 1;
+            this.btResetMessages.Text = "Reset";
+            this.btResetMessages.UseVisualStyleBackColor = true;
+            this.btResetMessages.Click += new System.EventHandler(this.btResetMessages_Click);
+            // 
+            // labelReshowHidden
+            // 
+            this.labelReshowHidden.Location = new System.Drawing.Point(6, 46);
+            this.labelReshowHidden.Name = "labelReshowHidden";
+            this.labelReshowHidden.Size = new System.Drawing.Size(370, 17);
+            this.labelReshowHidden.TabIndex = 0;
+            this.labelReshowHidden.Text = "To reshow hidden messages press";
+            // 
+            // groupMemory
+            // 
+            this.groupMemory.Controls.Add(this.grpMaximumMemoryUsage);
+            this.groupMemory.Controls.Add(this.grpMemoryCache);
+            this.groupMemory.Controls.Add(this.grpDiskCache);
+            this.groupMemory.Dock = System.Windows.Forms.DockStyle.Top;
+            this.groupMemory.Location = new System.Drawing.Point(0, 848);
+            this.groupMemory.Name = "groupMemory";
+            this.groupMemory.Size = new System.Drawing.Size(498, 355);
+            this.groupMemory.TabIndex = 1;
+            this.groupMemory.Text = "Caches & Memory Usage";
+            // 
+            // grpMaximumMemoryUsage
+            // 
+            this.grpMaximumMemoryUsage.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.grpMaximumMemoryUsage.Controls.Add(this.lblMaximumMemoryUsageValue);
-			this.grpMaximumMemoryUsage.Controls.Add(this.tbMaximumMemoryUsage);
-			this.grpMaximumMemoryUsage.Controls.Add(this.lblMaximumMemoryUsage);
-			this.grpMaximumMemoryUsage.Location = new System.Drawing.Point(7, 255);
-			this.grpMaximumMemoryUsage.Name = "grpMaximumMemoryUsage";
-			this.grpMaximumMemoryUsage.Size = new System.Drawing.Size(476, 86);
-			this.grpMaximumMemoryUsage.TabIndex = 14;
-			this.grpMaximumMemoryUsage.TabStop = false;
-			this.grpMaximumMemoryUsage.Text = "Maximum Memory Usage";
-			// 
-			// lblMaximumMemoryUsageValue
-			// 
-			this.lblMaximumMemoryUsageValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.lblMaximumMemoryUsageValue.AutoSize = true;
-			this.lblMaximumMemoryUsageValue.Location = new System.Drawing.Point(397, 31);
-			this.lblMaximumMemoryUsageValue.Name = "lblMaximumMemoryUsageValue";
-			this.lblMaximumMemoryUsageValue.Size = new System.Drawing.Size(63, 13);
-			this.lblMaximumMemoryUsageValue.TabIndex = 2;
-			this.lblMaximumMemoryUsageValue.Text = "Slider Value";
-			// 
-			// tbMaximumMemoryUsage
-			// 
-			this.tbMaximumMemoryUsage.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.grpMaximumMemoryUsage.Controls.Add(this.lblMaximumMemoryUsageValue);
+            this.grpMaximumMemoryUsage.Controls.Add(this.tbMaximumMemoryUsage);
+            this.grpMaximumMemoryUsage.Controls.Add(this.lblMaximumMemoryUsage);
+            this.grpMaximumMemoryUsage.Location = new System.Drawing.Point(7, 255);
+            this.grpMaximumMemoryUsage.Name = "grpMaximumMemoryUsage";
+            this.grpMaximumMemoryUsage.Size = new System.Drawing.Size(476, 86);
+            this.grpMaximumMemoryUsage.TabIndex = 14;
+            this.grpMaximumMemoryUsage.TabStop = false;
+            this.grpMaximumMemoryUsage.Text = "Maximum Memory Usage";
+            // 
+            // lblMaximumMemoryUsageValue
+            // 
+            this.lblMaximumMemoryUsageValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblMaximumMemoryUsageValue.AutoSize = true;
+            this.lblMaximumMemoryUsageValue.Location = new System.Drawing.Point(397, 31);
+            this.lblMaximumMemoryUsageValue.Name = "lblMaximumMemoryUsageValue";
+            this.lblMaximumMemoryUsageValue.Size = new System.Drawing.Size(63, 13);
+            this.lblMaximumMemoryUsageValue.TabIndex = 2;
+            this.lblMaximumMemoryUsageValue.Text = "Slider Value";
+            // 
+            // tbMaximumMemoryUsage
+            // 
+            this.tbMaximumMemoryUsage.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.tbMaximumMemoryUsage.LargeChange = 4;
-			this.tbMaximumMemoryUsage.Location = new System.Drawing.Point(7, 24);
-			this.tbMaximumMemoryUsage.Maximum = 64;
-			this.tbMaximumMemoryUsage.Name = "tbMaximumMemoryUsage";
-			this.tbMaximumMemoryUsage.Size = new System.Drawing.Size(379, 29);
-			this.tbMaximumMemoryUsage.TabIndex = 1;
-			this.tbMaximumMemoryUsage.ThumbSize = new System.Drawing.Size(10, 20);
-			this.tbMaximumMemoryUsage.TickFrequency = 8;
-			this.tbMaximumMemoryUsage.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
-			this.tbMaximumMemoryUsage.TickThickness = 2;
-			this.tbMaximumMemoryUsage.ValueChanged += new System.EventHandler(this.tbSystemMemory_ValueChanged);
-			// 
-			// lblMaximumMemoryUsage
-			// 
-			this.lblMaximumMemoryUsage.Dock = System.Windows.Forms.DockStyle.Bottom;
-			this.lblMaximumMemoryUsage.Location = new System.Drawing.Point(3, 58);
-			this.lblMaximumMemoryUsage.Name = "lblMaximumMemoryUsage";
-			this.lblMaximumMemoryUsage.Size = new System.Drawing.Size(470, 25);
-			this.lblMaximumMemoryUsage.TabIndex = 0;
-			this.lblMaximumMemoryUsage.Text = "Limiting the memory can adversely affect the performance.";
-			this.lblMaximumMemoryUsage.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// grpMemoryCache
-			// 
-			this.grpMemoryCache.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.tbMaximumMemoryUsage.LargeChange = 4;
+            this.tbMaximumMemoryUsage.Location = new System.Drawing.Point(7, 24);
+            this.tbMaximumMemoryUsage.Maximum = 64;
+            this.tbMaximumMemoryUsage.Name = "tbMaximumMemoryUsage";
+            this.tbMaximumMemoryUsage.Size = new System.Drawing.Size(379, 29);
+            this.tbMaximumMemoryUsage.TabIndex = 1;
+            this.tbMaximumMemoryUsage.ThumbSize = new System.Drawing.Size(10, 20);
+            this.tbMaximumMemoryUsage.TickFrequency = 8;
+            this.tbMaximumMemoryUsage.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
+            this.tbMaximumMemoryUsage.TickThickness = 2;
+            this.tbMaximumMemoryUsage.ValueChanged += new System.EventHandler(this.tbSystemMemory_ValueChanged);
+            // 
+            // lblMaximumMemoryUsage
+            // 
+            this.lblMaximumMemoryUsage.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.lblMaximumMemoryUsage.Location = new System.Drawing.Point(3, 58);
+            this.lblMaximumMemoryUsage.Name = "lblMaximumMemoryUsage";
+            this.lblMaximumMemoryUsage.Size = new System.Drawing.Size(470, 25);
+            this.lblMaximumMemoryUsage.TabIndex = 0;
+            this.lblMaximumMemoryUsage.Text = "Limiting the memory can adversely affect the performance.";
+            this.lblMaximumMemoryUsage.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // grpMemoryCache
+            // 
+            this.grpMemoryCache.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.grpMemoryCache.Controls.Add(this.lblPageMemCacheUsage);
-			this.grpMemoryCache.Controls.Add(this.labelMemThumbSize);
-			this.grpMemoryCache.Controls.Add(this.lblThumbMemCacheUsage);
-			this.grpMemoryCache.Controls.Add(this.numMemPageCount);
-			this.grpMemoryCache.Controls.Add(this.labelMemPageCount);
-			this.grpMemoryCache.Controls.Add(this.chkMemPageOptimized);
-			this.grpMemoryCache.Controls.Add(this.chkMemThumbOptimized);
-			this.grpMemoryCache.Controls.Add(this.numMemThumbSize);
-			this.grpMemoryCache.Location = new System.Drawing.Point(6, 162);
-			this.grpMemoryCache.Name = "grpMemoryCache";
-			this.grpMemoryCache.Size = new System.Drawing.Size(476, 85);
-			this.grpMemoryCache.TabIndex = 13;
-			this.grpMemoryCache.TabStop = false;
-			this.grpMemoryCache.Text = "Memory Cache";
-			// 
-			// lblPageMemCacheUsage
-			// 
-			this.lblPageMemCacheUsage.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.lblPageMemCacheUsage.AutoSize = true;
-			this.lblPageMemCacheUsage.Location = new System.Drawing.Point(299, 52);
-			this.lblPageMemCacheUsage.Name = "lblPageMemCacheUsage";
-			this.lblPageMemCacheUsage.Size = new System.Drawing.Size(124, 13);
-			this.lblPageMemCacheUsage.TabIndex = 8;
-			this.lblPageMemCacheUsage.Text = "usage Page Mem Cache";
-			// 
-			// labelMemThumbSize
-			// 
-			this.labelMemThumbSize.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.labelMemThumbSize.AutoSize = true;
-			this.labelMemThumbSize.Location = new System.Drawing.Point(19, 29);
-			this.labelMemThumbSize.Name = "labelMemThumbSize";
-			this.labelMemThumbSize.Size = new System.Drawing.Size(86, 13);
-			this.labelMemThumbSize.TabIndex = 0;
-			this.labelMemThumbSize.Text = "Thumbnails [MB]";
-			// 
-			// lblThumbMemCacheUsage
-			// 
-			this.lblThumbMemCacheUsage.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.lblThumbMemCacheUsage.AutoSize = true;
-			this.lblThumbMemCacheUsage.Location = new System.Drawing.Point(299, 26);
-			this.lblThumbMemCacheUsage.Name = "lblThumbMemCacheUsage";
-			this.lblThumbMemCacheUsage.Size = new System.Drawing.Size(132, 13);
-			this.lblThumbMemCacheUsage.TabIndex = 7;
-			this.lblThumbMemCacheUsage.Text = "usage Thumb Mem Cache";
-			// 
-			// numMemPageCount
-			// 
-			this.numMemPageCount.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.numMemPageCount.Location = new System.Drawing.Point(145, 51);
-			this.numMemPageCount.Maximum = new decimal(new int[] {
+            this.grpMemoryCache.Controls.Add(this.lblPageMemCacheUsage);
+            this.grpMemoryCache.Controls.Add(this.labelMemThumbSize);
+            this.grpMemoryCache.Controls.Add(this.lblThumbMemCacheUsage);
+            this.grpMemoryCache.Controls.Add(this.numMemPageCount);
+            this.grpMemoryCache.Controls.Add(this.labelMemPageCount);
+            this.grpMemoryCache.Controls.Add(this.chkMemPageOptimized);
+            this.grpMemoryCache.Controls.Add(this.chkMemThumbOptimized);
+            this.grpMemoryCache.Controls.Add(this.numMemThumbSize);
+            this.grpMemoryCache.Location = new System.Drawing.Point(6, 162);
+            this.grpMemoryCache.Name = "grpMemoryCache";
+            this.grpMemoryCache.Size = new System.Drawing.Size(476, 85);
+            this.grpMemoryCache.TabIndex = 13;
+            this.grpMemoryCache.TabStop = false;
+            this.grpMemoryCache.Text = "Memory Cache";
+            // 
+            // lblPageMemCacheUsage
+            // 
+            this.lblPageMemCacheUsage.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.lblPageMemCacheUsage.AutoSize = true;
+            this.lblPageMemCacheUsage.Location = new System.Drawing.Point(299, 52);
+            this.lblPageMemCacheUsage.Name = "lblPageMemCacheUsage";
+            this.lblPageMemCacheUsage.Size = new System.Drawing.Size(124, 13);
+            this.lblPageMemCacheUsage.TabIndex = 8;
+            this.lblPageMemCacheUsage.Text = "usage Page Mem Cache";
+            // 
+            // labelMemThumbSize
+            // 
+            this.labelMemThumbSize.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.labelMemThumbSize.AutoSize = true;
+            this.labelMemThumbSize.Location = new System.Drawing.Point(19, 29);
+            this.labelMemThumbSize.Name = "labelMemThumbSize";
+            this.labelMemThumbSize.Size = new System.Drawing.Size(86, 13);
+            this.labelMemThumbSize.TabIndex = 0;
+            this.labelMemThumbSize.Text = "Thumbnails [MB]";
+            // 
+            // lblThumbMemCacheUsage
+            // 
+            this.lblThumbMemCacheUsage.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.lblThumbMemCacheUsage.AutoSize = true;
+            this.lblThumbMemCacheUsage.Location = new System.Drawing.Point(299, 26);
+            this.lblThumbMemCacheUsage.Name = "lblThumbMemCacheUsage";
+            this.lblThumbMemCacheUsage.Size = new System.Drawing.Size(132, 13);
+            this.lblThumbMemCacheUsage.TabIndex = 7;
+            this.lblThumbMemCacheUsage.Text = "usage Thumb Mem Cache";
+            // 
+            // numMemPageCount
+            // 
+            this.numMemPageCount.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.numMemPageCount.Location = new System.Drawing.Point(145, 51);
+            this.numMemPageCount.Maximum = new decimal(new int[] {
             25,
             0,
             0,
             0});
-			this.numMemPageCount.Minimum = new decimal(new int[] {
+            this.numMemPageCount.Minimum = new decimal(new int[] {
             5,
             0,
             0,
             0});
-			this.numMemPageCount.Name = "numMemPageCount";
-			this.numMemPageCount.Size = new System.Drawing.Size(67, 20);
-			this.numMemPageCount.TabIndex = 4;
-			this.numMemPageCount.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-			this.numMemPageCount.Value = new decimal(new int[] {
+            this.numMemPageCount.Name = "numMemPageCount";
+            this.numMemPageCount.Size = new System.Drawing.Size(67, 20);
+            this.numMemPageCount.TabIndex = 4;
+            this.numMemPageCount.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this.numMemPageCount.Value = new decimal(new int[] {
             5,
             0,
             0,
             0});
-			// 
-			// labelMemPageCount
-			// 
-			this.labelMemPageCount.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.labelMemPageCount.AutoSize = true;
-			this.labelMemPageCount.Location = new System.Drawing.Point(19, 52);
-			this.labelMemPageCount.Name = "labelMemPageCount";
-			this.labelMemPageCount.Size = new System.Drawing.Size(73, 13);
-			this.labelMemPageCount.TabIndex = 3;
-			this.labelMemPageCount.Text = "Pages [count]";
-			// 
-			// chkMemPageOptimized
-			// 
-			this.chkMemPageOptimized.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.chkMemPageOptimized.AutoSize = true;
-			this.chkMemPageOptimized.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-			this.chkMemPageOptimized.Location = new System.Drawing.Point(218, 51);
-			this.chkMemPageOptimized.Name = "chkMemPageOptimized";
-			this.chkMemPageOptimized.Size = new System.Drawing.Size(70, 17);
-			this.chkMemPageOptimized.TabIndex = 5;
-			this.chkMemPageOptimized.Text = "optimized";
-			this.chkMemPageOptimized.UseVisualStyleBackColor = true;
-			// 
-			// chkMemThumbOptimized
-			// 
-			this.chkMemThumbOptimized.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.chkMemThumbOptimized.AutoSize = true;
-			this.chkMemThumbOptimized.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-			this.chkMemThumbOptimized.Location = new System.Drawing.Point(218, 25);
-			this.chkMemThumbOptimized.Name = "chkMemThumbOptimized";
-			this.chkMemThumbOptimized.Size = new System.Drawing.Size(70, 17);
-			this.chkMemThumbOptimized.TabIndex = 2;
-			this.chkMemThumbOptimized.Text = "optimized";
-			this.chkMemThumbOptimized.UseVisualStyleBackColor = true;
-			// 
-			// numMemThumbSize
-			// 
-			this.numMemThumbSize.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.numMemThumbSize.Increment = new decimal(new int[] {
+            // 
+            // labelMemPageCount
+            // 
+            this.labelMemPageCount.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.labelMemPageCount.AutoSize = true;
+            this.labelMemPageCount.Location = new System.Drawing.Point(19, 52);
+            this.labelMemPageCount.Name = "labelMemPageCount";
+            this.labelMemPageCount.Size = new System.Drawing.Size(73, 13);
+            this.labelMemPageCount.TabIndex = 3;
+            this.labelMemPageCount.Text = "Pages [count]";
+            // 
+            // chkMemPageOptimized
+            // 
+            this.chkMemPageOptimized.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.chkMemPageOptimized.AutoSize = true;
+            this.chkMemPageOptimized.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.chkMemPageOptimized.Location = new System.Drawing.Point(218, 51);
+            this.chkMemPageOptimized.Name = "chkMemPageOptimized";
+            this.chkMemPageOptimized.Size = new System.Drawing.Size(70, 17);
+            this.chkMemPageOptimized.TabIndex = 5;
+            this.chkMemPageOptimized.Text = "optimized";
+            this.chkMemPageOptimized.UseVisualStyleBackColor = true;
+            // 
+            // chkMemThumbOptimized
+            // 
+            this.chkMemThumbOptimized.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.chkMemThumbOptimized.AutoSize = true;
+            this.chkMemThumbOptimized.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.chkMemThumbOptimized.Location = new System.Drawing.Point(218, 25);
+            this.chkMemThumbOptimized.Name = "chkMemThumbOptimized";
+            this.chkMemThumbOptimized.Size = new System.Drawing.Size(70, 17);
+            this.chkMemThumbOptimized.TabIndex = 2;
+            this.chkMemThumbOptimized.Text = "optimized";
+            this.chkMemThumbOptimized.UseVisualStyleBackColor = true;
+            // 
+            // numMemThumbSize
+            // 
+            this.numMemThumbSize.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.numMemThumbSize.Increment = new decimal(new int[] {
             5,
             0,
             0,
             0});
-			this.numMemThumbSize.Location = new System.Drawing.Point(145, 24);
-			this.numMemThumbSize.Minimum = new decimal(new int[] {
+            this.numMemThumbSize.Location = new System.Drawing.Point(145, 24);
+            this.numMemThumbSize.Minimum = new decimal(new int[] {
             20,
             0,
             0,
             0});
-			this.numMemThumbSize.Name = "numMemThumbSize";
-			this.numMemThumbSize.Size = new System.Drawing.Size(67, 20);
-			this.numMemThumbSize.TabIndex = 1;
-			this.numMemThumbSize.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-			this.numMemThumbSize.Value = new decimal(new int[] {
+            this.numMemThumbSize.Name = "numMemThumbSize";
+            this.numMemThumbSize.Size = new System.Drawing.Size(67, 20);
+            this.numMemThumbSize.TabIndex = 1;
+            this.numMemThumbSize.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this.numMemThumbSize.Value = new decimal(new int[] {
             25,
             0,
             0,
             0});
-			// 
-			// grpDiskCache
-			// 
-			this.grpDiskCache.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            // 
+            // grpDiskCache
+            // 
+            this.grpDiskCache.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.grpDiskCache.Controls.Add(this.chkEnableInternetCache);
-			this.grpDiskCache.Controls.Add(this.lblInternetCacheUsage);
-			this.grpDiskCache.Controls.Add(this.btClearPageCache);
-			this.grpDiskCache.Controls.Add(this.numPageCacheSize);
-			this.grpDiskCache.Controls.Add(this.numInternetCacheSize);
-			this.grpDiskCache.Controls.Add(this.btClearThumbnailCache);
-			this.grpDiskCache.Controls.Add(this.btClearInternetCache);
-			this.grpDiskCache.Controls.Add(this.chkEnablePageCache);
-			this.grpDiskCache.Controls.Add(this.lblPageCacheUsage);
-			this.grpDiskCache.Controls.Add(this.numThumbnailCacheSize);
-			this.grpDiskCache.Controls.Add(this.chkEnableThumbnailCache);
-			this.grpDiskCache.Controls.Add(this.lblThumbCacheUsage);
-			this.grpDiskCache.Location = new System.Drawing.Point(6, 35);
-			this.grpDiskCache.Name = "grpDiskCache";
-			this.grpDiskCache.Size = new System.Drawing.Size(476, 120);
-			this.grpDiskCache.TabIndex = 12;
-			this.grpDiskCache.TabStop = false;
-			this.grpDiskCache.Text = "Disk Cache";
-			// 
-			// chkEnableInternetCache
-			// 
-			this.chkEnableInternetCache.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.chkEnableInternetCache.AutoSize = true;
-			this.chkEnableInternetCache.Location = new System.Drawing.Point(22, 31);
-			this.chkEnableInternetCache.Name = "chkEnableInternetCache";
-			this.chkEnableInternetCache.Size = new System.Drawing.Size(87, 17);
-			this.chkEnableInternetCache.TabIndex = 0;
-			this.chkEnableInternetCache.Text = "Internet [MB]";
-			this.chkEnableInternetCache.UseVisualStyleBackColor = true;
-			// 
-			// lblInternetCacheUsage
-			// 
-			this.lblInternetCacheUsage.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.lblInternetCacheUsage.AutoSize = true;
-			this.lblInternetCacheUsage.Location = new System.Drawing.Point(298, 31);
-			this.lblInternetCacheUsage.Name = "lblInternetCacheUsage";
-			this.lblInternetCacheUsage.Size = new System.Drawing.Size(109, 13);
-			this.lblInternetCacheUsage.TabIndex = 3;
-			this.lblInternetCacheUsage.Text = "usage Internet Cache";
-			// 
-			// btClearPageCache
-			// 
-			this.btClearPageCache.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.btClearPageCache.Location = new System.Drawing.Point(218, 80);
-			this.btClearPageCache.Name = "btClearPageCache";
-			this.btClearPageCache.Size = new System.Drawing.Size(74, 21);
-			this.btClearPageCache.TabIndex = 10;
-			this.btClearPageCache.Text = "Clear";
-			this.btClearPageCache.UseVisualStyleBackColor = true;
-			this.btClearPageCache.Click += new System.EventHandler(this.btClearPageCache_Click);
-			// 
-			// numPageCacheSize
-			// 
-			this.numPageCacheSize.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.numPageCacheSize.Increment = new decimal(new int[] {
+            this.grpDiskCache.Controls.Add(this.chkEnableInternetCache);
+            this.grpDiskCache.Controls.Add(this.lblInternetCacheUsage);
+            this.grpDiskCache.Controls.Add(this.btClearPageCache);
+            this.grpDiskCache.Controls.Add(this.numPageCacheSize);
+            this.grpDiskCache.Controls.Add(this.numInternetCacheSize);
+            this.grpDiskCache.Controls.Add(this.btClearThumbnailCache);
+            this.grpDiskCache.Controls.Add(this.btClearInternetCache);
+            this.grpDiskCache.Controls.Add(this.chkEnablePageCache);
+            this.grpDiskCache.Controls.Add(this.lblPageCacheUsage);
+            this.grpDiskCache.Controls.Add(this.numThumbnailCacheSize);
+            this.grpDiskCache.Controls.Add(this.chkEnableThumbnailCache);
+            this.grpDiskCache.Controls.Add(this.lblThumbCacheUsage);
+            this.grpDiskCache.Location = new System.Drawing.Point(6, 35);
+            this.grpDiskCache.Name = "grpDiskCache";
+            this.grpDiskCache.Size = new System.Drawing.Size(476, 120);
+            this.grpDiskCache.TabIndex = 12;
+            this.grpDiskCache.TabStop = false;
+            this.grpDiskCache.Text = "Disk Cache";
+            // 
+            // chkEnableInternetCache
+            // 
+            this.chkEnableInternetCache.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.chkEnableInternetCache.AutoSize = true;
+            this.chkEnableInternetCache.Location = new System.Drawing.Point(22, 31);
+            this.chkEnableInternetCache.Name = "chkEnableInternetCache";
+            this.chkEnableInternetCache.Size = new System.Drawing.Size(87, 17);
+            this.chkEnableInternetCache.TabIndex = 0;
+            this.chkEnableInternetCache.Text = "Internet [MB]";
+            this.chkEnableInternetCache.UseVisualStyleBackColor = true;
+            // 
+            // lblInternetCacheUsage
+            // 
+            this.lblInternetCacheUsage.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.lblInternetCacheUsage.AutoSize = true;
+            this.lblInternetCacheUsage.Location = new System.Drawing.Point(298, 31);
+            this.lblInternetCacheUsage.Name = "lblInternetCacheUsage";
+            this.lblInternetCacheUsage.Size = new System.Drawing.Size(109, 13);
+            this.lblInternetCacheUsage.TabIndex = 3;
+            this.lblInternetCacheUsage.Text = "usage Internet Cache";
+            // 
+            // btClearPageCache
+            // 
+            this.btClearPageCache.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.btClearPageCache.Location = new System.Drawing.Point(218, 80);
+            this.btClearPageCache.Name = "btClearPageCache";
+            this.btClearPageCache.Size = new System.Drawing.Size(74, 21);
+            this.btClearPageCache.TabIndex = 10;
+            this.btClearPageCache.Text = "Clear";
+            this.btClearPageCache.UseVisualStyleBackColor = true;
+            this.btClearPageCache.Click += new System.EventHandler(this.btClearPageCache_Click);
+            // 
+            // numPageCacheSize
+            // 
+            this.numPageCacheSize.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.numPageCacheSize.Increment = new decimal(new int[] {
             10,
             0,
             0,
             0});
-			this.numPageCacheSize.Location = new System.Drawing.Point(145, 82);
-			this.numPageCacheSize.Maximum = new decimal(new int[] {
+            this.numPageCacheSize.Location = new System.Drawing.Point(145, 82);
+            this.numPageCacheSize.Maximum = new decimal(new int[] {
             1000000,
             0,
             0,
             0});
-			this.numPageCacheSize.Minimum = new decimal(new int[] {
+            this.numPageCacheSize.Minimum = new decimal(new int[] {
             10,
             0,
             0,
             0});
-			this.numPageCacheSize.Name = "numPageCacheSize";
-			this.numPageCacheSize.Size = new System.Drawing.Size(67, 20);
-			this.numPageCacheSize.TabIndex = 9;
-			this.numPageCacheSize.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-			this.numPageCacheSize.Value = new decimal(new int[] {
+            this.numPageCacheSize.Name = "numPageCacheSize";
+            this.numPageCacheSize.Size = new System.Drawing.Size(67, 20);
+            this.numPageCacheSize.TabIndex = 9;
+            this.numPageCacheSize.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this.numPageCacheSize.Value = new decimal(new int[] {
             10,
             0,
             0,
             0});
-			// 
-			// numInternetCacheSize
-			// 
-			this.numInternetCacheSize.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.numInternetCacheSize.Increment = new decimal(new int[] {
+            // 
+            // numInternetCacheSize
+            // 
+            this.numInternetCacheSize.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.numInternetCacheSize.Increment = new decimal(new int[] {
             10,
             0,
             0,
             0});
-			this.numInternetCacheSize.Location = new System.Drawing.Point(145, 29);
-			this.numInternetCacheSize.Maximum = new decimal(new int[] {
+            this.numInternetCacheSize.Location = new System.Drawing.Point(145, 29);
+            this.numInternetCacheSize.Maximum = new decimal(new int[] {
             1000000,
             0,
             0,
             0});
-			this.numInternetCacheSize.Minimum = new decimal(new int[] {
+            this.numInternetCacheSize.Minimum = new decimal(new int[] {
             10,
             0,
             0,
             0});
-			this.numInternetCacheSize.Name = "numInternetCacheSize";
-			this.numInternetCacheSize.Size = new System.Drawing.Size(67, 20);
-			this.numInternetCacheSize.TabIndex = 1;
-			this.numInternetCacheSize.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-			this.numInternetCacheSize.Value = new decimal(new int[] {
+            this.numInternetCacheSize.Name = "numInternetCacheSize";
+            this.numInternetCacheSize.Size = new System.Drawing.Size(67, 20);
+            this.numInternetCacheSize.TabIndex = 1;
+            this.numInternetCacheSize.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this.numInternetCacheSize.Value = new decimal(new int[] {
             10,
             0,
             0,
             0});
-			// 
-			// btClearThumbnailCache
-			// 
-			this.btClearThumbnailCache.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.btClearThumbnailCache.Location = new System.Drawing.Point(218, 54);
-			this.btClearThumbnailCache.Name = "btClearThumbnailCache";
-			this.btClearThumbnailCache.Size = new System.Drawing.Size(74, 21);
-			this.btClearThumbnailCache.TabIndex = 6;
-			this.btClearThumbnailCache.Text = "Clear";
-			this.btClearThumbnailCache.UseVisualStyleBackColor = true;
-			this.btClearThumbnailCache.Click += new System.EventHandler(this.btClearThumbnailCache_Click);
-			// 
-			// btClearInternetCache
-			// 
-			this.btClearInternetCache.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.btClearInternetCache.Location = new System.Drawing.Point(218, 27);
-			this.btClearInternetCache.Name = "btClearInternetCache";
-			this.btClearInternetCache.Size = new System.Drawing.Size(74, 21);
-			this.btClearInternetCache.TabIndex = 2;
-			this.btClearInternetCache.Text = "Clear";
-			this.btClearInternetCache.UseVisualStyleBackColor = true;
-			this.btClearInternetCache.Click += new System.EventHandler(this.btClearInternetCache_Click);
-			// 
-			// chkEnablePageCache
-			// 
-			this.chkEnablePageCache.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.chkEnablePageCache.AutoSize = true;
-			this.chkEnablePageCache.Location = new System.Drawing.Point(22, 84);
-			this.chkEnablePageCache.Name = "chkEnablePageCache";
-			this.chkEnablePageCache.Size = new System.Drawing.Size(81, 17);
-			this.chkEnablePageCache.TabIndex = 8;
-			this.chkEnablePageCache.Text = "&Pages [MB]";
-			this.chkEnablePageCache.UseVisualStyleBackColor = true;
-			// 
-			// lblPageCacheUsage
-			// 
-			this.lblPageCacheUsage.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.lblPageCacheUsage.AutoSize = true;
-			this.lblPageCacheUsage.Location = new System.Drawing.Point(298, 86);
-			this.lblPageCacheUsage.Name = "lblPageCacheUsage";
-			this.lblPageCacheUsage.Size = new System.Drawing.Size(98, 13);
-			this.lblPageCacheUsage.TabIndex = 11;
-			this.lblPageCacheUsage.Text = "usage Page Cache";
-			// 
-			// numThumbnailCacheSize
-			// 
-			this.numThumbnailCacheSize.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.numThumbnailCacheSize.Increment = new decimal(new int[] {
+            // 
+            // btClearThumbnailCache
+            // 
+            this.btClearThumbnailCache.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.btClearThumbnailCache.Location = new System.Drawing.Point(218, 54);
+            this.btClearThumbnailCache.Name = "btClearThumbnailCache";
+            this.btClearThumbnailCache.Size = new System.Drawing.Size(74, 21);
+            this.btClearThumbnailCache.TabIndex = 6;
+            this.btClearThumbnailCache.Text = "Clear";
+            this.btClearThumbnailCache.UseVisualStyleBackColor = true;
+            this.btClearThumbnailCache.Click += new System.EventHandler(this.btClearThumbnailCache_Click);
+            // 
+            // btClearInternetCache
+            // 
+            this.btClearInternetCache.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.btClearInternetCache.Location = new System.Drawing.Point(218, 27);
+            this.btClearInternetCache.Name = "btClearInternetCache";
+            this.btClearInternetCache.Size = new System.Drawing.Size(74, 21);
+            this.btClearInternetCache.TabIndex = 2;
+            this.btClearInternetCache.Text = "Clear";
+            this.btClearInternetCache.UseVisualStyleBackColor = true;
+            this.btClearInternetCache.Click += new System.EventHandler(this.btClearInternetCache_Click);
+            // 
+            // chkEnablePageCache
+            // 
+            this.chkEnablePageCache.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.chkEnablePageCache.AutoSize = true;
+            this.chkEnablePageCache.Location = new System.Drawing.Point(22, 84);
+            this.chkEnablePageCache.Name = "chkEnablePageCache";
+            this.chkEnablePageCache.Size = new System.Drawing.Size(81, 17);
+            this.chkEnablePageCache.TabIndex = 8;
+            this.chkEnablePageCache.Text = "&Pages [MB]";
+            this.chkEnablePageCache.UseVisualStyleBackColor = true;
+            // 
+            // lblPageCacheUsage
+            // 
+            this.lblPageCacheUsage.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.lblPageCacheUsage.AutoSize = true;
+            this.lblPageCacheUsage.Location = new System.Drawing.Point(298, 86);
+            this.lblPageCacheUsage.Name = "lblPageCacheUsage";
+            this.lblPageCacheUsage.Size = new System.Drawing.Size(98, 13);
+            this.lblPageCacheUsage.TabIndex = 11;
+            this.lblPageCacheUsage.Text = "usage Page Cache";
+            // 
+            // numThumbnailCacheSize
+            // 
+            this.numThumbnailCacheSize.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.numThumbnailCacheSize.Increment = new decimal(new int[] {
             10,
             0,
             0,
             0});
-			this.numThumbnailCacheSize.Location = new System.Drawing.Point(145, 55);
-			this.numThumbnailCacheSize.Maximum = new decimal(new int[] {
+            this.numThumbnailCacheSize.Location = new System.Drawing.Point(145, 55);
+            this.numThumbnailCacheSize.Maximum = new decimal(new int[] {
             1000000,
             0,
             0,
             0});
-			this.numThumbnailCacheSize.Minimum = new decimal(new int[] {
+            this.numThumbnailCacheSize.Minimum = new decimal(new int[] {
             10,
             0,
             0,
             0});
-			this.numThumbnailCacheSize.Name = "numThumbnailCacheSize";
-			this.numThumbnailCacheSize.Size = new System.Drawing.Size(67, 20);
-			this.numThumbnailCacheSize.TabIndex = 5;
-			this.numThumbnailCacheSize.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-			this.numThumbnailCacheSize.Value = new decimal(new int[] {
+            this.numThumbnailCacheSize.Name = "numThumbnailCacheSize";
+            this.numThumbnailCacheSize.Size = new System.Drawing.Size(67, 20);
+            this.numThumbnailCacheSize.TabIndex = 5;
+            this.numThumbnailCacheSize.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this.numThumbnailCacheSize.Value = new decimal(new int[] {
             10,
             0,
             0,
             0});
-			// 
-			// chkEnableThumbnailCache
-			// 
-			this.chkEnableThumbnailCache.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.chkEnableThumbnailCache.AutoSize = true;
-			this.chkEnableThumbnailCache.Location = new System.Drawing.Point(22, 57);
-			this.chkEnableThumbnailCache.Name = "chkEnableThumbnailCache";
-			this.chkEnableThumbnailCache.Size = new System.Drawing.Size(105, 17);
-			this.chkEnableThumbnailCache.TabIndex = 4;
-			this.chkEnableThumbnailCache.Text = "&Thumbnails [MB]";
-			this.chkEnableThumbnailCache.UseVisualStyleBackColor = true;
-			// 
-			// lblThumbCacheUsage
-			// 
-			this.lblThumbCacheUsage.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.lblThumbCacheUsage.AutoSize = true;
-			this.lblThumbCacheUsage.Location = new System.Drawing.Point(298, 58);
-			this.lblThumbCacheUsage.Name = "lblThumbCacheUsage";
-			this.lblThumbCacheUsage.Size = new System.Drawing.Size(106, 13);
-			this.lblThumbCacheUsage.TabIndex = 7;
-			this.lblThumbCacheUsage.Text = "usage Thumb Cache";
-			// 
-			// grpBackupManager
-			// 
-			this.grpBackupManager.Controls.Add(this.gbBackupOn);
-			this.grpBackupManager.Controls.Add(this.lblBackupOptions);
-			this.grpBackupManager.Controls.Add(this.chkIncludeAllAlternateConfigs);
-			this.grpBackupManager.Controls.Add(this.numBackupsToKeep);
-			this.grpBackupManager.Controls.Add(this.lblBackupsToKeep);
-			this.grpBackupManager.Controls.Add(this.lbBackupOptions);
-			this.grpBackupManager.Controls.Add(this.btBackupLocation);
-			this.grpBackupManager.Controls.Add(this.txtBackupLocation);
-			this.grpBackupManager.Controls.Add(this.lblBackupLocation);
-			this.grpBackupManager.Dock = System.Windows.Forms.DockStyle.Top;
-			this.grpBackupManager.Location = new System.Drawing.Point(0, 641);
-			this.grpBackupManager.Name = "grpBackupManager";
-			this.grpBackupManager.Size = new System.Drawing.Size(498, 183);
-			this.grpBackupManager.TabIndex = 4;
-			this.grpBackupManager.Text = "Backup Manager";
-			// 
-			// chkIncludeAlternateConfig
-			// 
-			this.chkIncludeAllAlternateConfigs.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.chkIncludeAllAlternateConfigs.AutoSize = true;
-			this.chkIncludeAllAlternateConfigs.Location = new System.Drawing.Point(12, 154);
-			this.chkIncludeAllAlternateConfigs.Name = "chkIncludeAllAlternateConfigs";
-			this.chkIncludeAllAlternateConfigs.Size = new System.Drawing.Size(139, 17);
-			this.chkIncludeAllAlternateConfigs.TabIndex = 6;
-			this.chkIncludeAllAlternateConfigs.Text = "Include all Alternate Configs";
-			this.chkIncludeAllAlternateConfigs.UseVisualStyleBackColor = true;
-			// 
-			// numBackupsToKeep
-			// 
-			this.numBackupsToKeep.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.numBackupsToKeep.Location = new System.Drawing.Point(414, 154);
-			this.numBackupsToKeep.Name = "numBackupsToKeep";
-			this.numBackupsToKeep.Size = new System.Drawing.Size(69, 20);
-			this.numBackupsToKeep.TabIndex = 5;
-			this.numBackupsToKeep.TextAlign = HorizontalAlignment.Right;
-			this.toolTip.SetToolTip(this.numBackupsToKeep, "Setting this to 0 will keep all backups");
-			//
-			// lblBackupsToKeep
-			// 
-			this.lblBackupsToKeep.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.lblBackupsToKeep.AutoSize = true;
-			this.lblBackupsToKeep.Location = new System.Drawing.Point(296, 156);
-			this.lblBackupsToKeep.Name = "lblBackupsToKeep";
-			this.lblBackupsToKeep.Size = new System.Drawing.Size(117, 13);
-			this.lblBackupsToKeep.TabIndex = 4;
-			this.lblBackupsToKeep.Text = "# of Backups to Keep :";
-			this.lblBackupsToKeep.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			// 
-			// lbBackupOptions
-			// 
-			this.lbBackupOptions.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            // 
+            // chkEnableThumbnailCache
+            // 
+            this.chkEnableThumbnailCache.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.chkEnableThumbnailCache.AutoSize = true;
+            this.chkEnableThumbnailCache.Location = new System.Drawing.Point(22, 57);
+            this.chkEnableThumbnailCache.Name = "chkEnableThumbnailCache";
+            this.chkEnableThumbnailCache.Size = new System.Drawing.Size(105, 17);
+            this.chkEnableThumbnailCache.TabIndex = 4;
+            this.chkEnableThumbnailCache.Text = "&Thumbnails [MB]";
+            this.chkEnableThumbnailCache.UseVisualStyleBackColor = true;
+            // 
+            // lblThumbCacheUsage
+            // 
+            this.lblThumbCacheUsage.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.lblThumbCacheUsage.AutoSize = true;
+            this.lblThumbCacheUsage.Location = new System.Drawing.Point(298, 58);
+            this.lblThumbCacheUsage.Name = "lblThumbCacheUsage";
+            this.lblThumbCacheUsage.Size = new System.Drawing.Size(106, 13);
+            this.lblThumbCacheUsage.TabIndex = 7;
+            this.lblThumbCacheUsage.Text = "usage Thumb Cache";
+            // 
+            // grpBackupManager
+            // 
+            this.grpBackupManager.Controls.Add(this.gbBackupOn);
+            this.grpBackupManager.Controls.Add(this.lblBackupOptions);
+            this.grpBackupManager.Controls.Add(this.chkIncludeAllAlternateConfigs);
+            this.grpBackupManager.Controls.Add(this.numBackupsToKeep);
+            this.grpBackupManager.Controls.Add(this.lblBackupsToKeep);
+            this.grpBackupManager.Controls.Add(this.lbBackupOptions);
+            this.grpBackupManager.Controls.Add(this.btBackupLocation);
+            this.grpBackupManager.Controls.Add(this.txtBackupLocation);
+            this.grpBackupManager.Controls.Add(this.lblBackupLocation);
+            this.grpBackupManager.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpBackupManager.Location = new System.Drawing.Point(0, 665);
+            this.grpBackupManager.Name = "grpBackupManager";
+            this.grpBackupManager.Size = new System.Drawing.Size(498, 183);
+            this.grpBackupManager.TabIndex = 4;
+            this.grpBackupManager.Text = "Backup Manager";
+            // 
+            // gbBackupOn
+            // 
+            this.gbBackupOn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.gbBackupOn.Controls.Add(this.chkBackupOnExit);
+            this.gbBackupOn.Controls.Add(this.chkBackupOnStartup);
+            this.gbBackupOn.Location = new System.Drawing.Point(382, 77);
+            this.gbBackupOn.Name = "gbBackupOn";
+            this.gbBackupOn.Size = new System.Drawing.Size(100, 65);
+            this.gbBackupOn.TabIndex = 8;
+            this.gbBackupOn.TabStop = false;
+            this.gbBackupOn.Text = "Backup On";
+            // 
+            // chkBackupOnExit
+            // 
+            this.chkBackupOnExit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.chkBackupOnExit.AutoSize = true;
+            this.chkBackupOnExit.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.chkBackupOnExit.Location = new System.Drawing.Point(15, 39);
+            this.chkBackupOnExit.Name = "chkBackupOnExit";
+            this.chkBackupOnExit.Size = new System.Drawing.Size(79, 17);
+            this.chkBackupOnExit.TabIndex = 11;
+            this.chkBackupOnExit.Text = "Shut Down";
+            this.chkBackupOnExit.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.chkBackupOnExit.UseVisualStyleBackColor = true;
+            // 
+            // chkBackupOnStartup
+            // 
+            this.chkBackupOnStartup.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.chkBackupOnStartup.AutoSize = true;
+            this.chkBackupOnStartup.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.chkBackupOnStartup.Location = new System.Drawing.Point(34, 18);
+            this.chkBackupOnStartup.Name = "chkBackupOnStartup";
+            this.chkBackupOnStartup.Size = new System.Drawing.Size(60, 17);
+            this.chkBackupOnStartup.TabIndex = 10;
+            this.chkBackupOnStartup.Text = "Startup";
+            this.chkBackupOnStartup.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.chkBackupOnStartup.UseVisualStyleBackColor = true;
+            // 
+            // lblBackupOptions
+            // 
+            this.lblBackupOptions.AutoSize = true;
+            this.lblBackupOptions.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblBackupOptions.Location = new System.Drawing.Point(11, 64);
+            this.lblBackupOptions.Name = "lblBackupOptions";
+            this.lblBackupOptions.Size = new System.Drawing.Size(132, 13);
+            this.lblBackupOptions.TabIndex = 7;
+            this.lblBackupOptions.Text = "Items to include in Backup";
+            // 
+            // chkIncludeAllAlternateConfigs
+            // 
+            this.chkIncludeAllAlternateConfigs.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.chkIncludeAllAlternateConfigs.AutoSize = true;
+            this.chkIncludeAllAlternateConfigs.Location = new System.Drawing.Point(12, 154);
+            this.chkIncludeAllAlternateConfigs.Name = "chkIncludeAllAlternateConfigs";
+            this.chkIncludeAllAlternateConfigs.Size = new System.Drawing.Size(157, 17);
+            this.chkIncludeAllAlternateConfigs.TabIndex = 6;
+            this.chkIncludeAllAlternateConfigs.Text = "Include all Alternate Configs";
+            this.chkIncludeAllAlternateConfigs.UseVisualStyleBackColor = true;
+            // 
+            // lblBackupsToKeep
+            // 
+            this.lblBackupsToKeep.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblBackupsToKeep.AutoSize = true;
+            this.lblBackupsToKeep.Location = new System.Drawing.Point(296, 156);
+            this.lblBackupsToKeep.Name = "lblBackupsToKeep";
+            this.lblBackupsToKeep.Size = new System.Drawing.Size(117, 13);
+            this.lblBackupsToKeep.TabIndex = 4;
+            this.lblBackupsToKeep.Text = "# of Backups to Keep :";
+            this.lblBackupsToKeep.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // lbBackupOptions
+            // 
+            this.lbBackupOptions.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.lbBackupOptions.CheckOnClick = true;
-			this.lbBackupOptions.ColumnWidth = 160;
-			this.lbBackupOptions.FormattingEnabled = true;
-			this.lbBackupOptions.Location = new System.Drawing.Point(12, 83);
-			this.lbBackupOptions.MultiColumn = true;
-			this.lbBackupOptions.Name = "lbBackupOptions";
-			this.lbBackupOptions.Size = new System.Drawing.Size(364, 64);
-			this.lbBackupOptions.TabIndex = 3;
-			this.lbBackupOptions.Resize += new System.EventHandler(this.lbBackupOptions_Resize);
-			// 
-			// btBackupLocation
-			// 
-			this.btBackupLocation.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btBackupLocation.Location = new System.Drawing.Point(411, 34);
-			this.btBackupLocation.Name = "btBackupLocation";
-			this.btBackupLocation.Size = new System.Drawing.Size(75, 23);
-			this.btBackupLocation.TabIndex = 2;
-			this.btBackupLocation.Text = "Browse...";
-			this.btBackupLocation.UseVisualStyleBackColor = true;
-			this.btBackupLocation.Click += new System.EventHandler(this.btBackupLocation_Click);
-			// 
-			// txtBackupLocation
-			// 
-			this.txtBackupLocation.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.lbBackupOptions.CheckOnClick = true;
+            this.lbBackupOptions.ColumnWidth = 160;
+            this.lbBackupOptions.FormattingEnabled = true;
+            this.lbBackupOptions.Location = new System.Drawing.Point(12, 83);
+            this.lbBackupOptions.MultiColumn = true;
+            this.lbBackupOptions.Name = "lbBackupOptions";
+            this.lbBackupOptions.Size = new System.Drawing.Size(364, 64);
+            this.lbBackupOptions.TabIndex = 3;
+            this.lbBackupOptions.Resize += new System.EventHandler(this.lbBackupOptions_Resize);
+            // 
+            // btBackupLocation
+            // 
+            this.btBackupLocation.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btBackupLocation.Location = new System.Drawing.Point(411, 34);
+            this.btBackupLocation.Name = "btBackupLocation";
+            this.btBackupLocation.Size = new System.Drawing.Size(75, 23);
+            this.btBackupLocation.TabIndex = 2;
+            this.btBackupLocation.Text = "Browse...";
+            this.btBackupLocation.UseVisualStyleBackColor = true;
+            this.btBackupLocation.Click += new System.EventHandler(this.btBackupLocation_Click);
+            // 
+            // txtBackupLocation
+            // 
+            this.txtBackupLocation.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txtBackupLocation.Location = new System.Drawing.Point(66, 34);
-			this.txtBackupLocation.Name = "txtBackupLocation";
-			this.txtBackupLocation.Size = new System.Drawing.Size(339, 20);
-			this.txtBackupLocation.TabIndex = 1;
-			// 
-			// lblBackupLocation
-			// 
-			this.lblBackupLocation.AutoSize = true;
-			this.lblBackupLocation.Location = new System.Drawing.Point(12, 37);
-			this.lblBackupLocation.Name = "lblBackupLocation";
-			this.lblBackupLocation.Size = new System.Drawing.Size(48, 13);
-			this.lblBackupLocation.TabIndex = 0;
-			this.lblBackupLocation.Text = "Location";
-			// 
-			// lblBackupOptions
-			// 
-			this.lblBackupOptions.AutoSize = true;
-			this.lblBackupOptions.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.lblBackupOptions.Location = new System.Drawing.Point(11, 64);
-			this.lblBackupOptions.Name = "lblBackupOptions";
-			this.lblBackupOptions.Size = new System.Drawing.Size(132, 13);
-			this.lblBackupOptions.TabIndex = 7;
-			this.lblBackupOptions.Text = "Items to include in Backup";
-			// 
-			// grpDatabaseBackup
-			// 
-			this.grpDatabaseBackup.Controls.Add(this.btRestoreDatabase);
-			this.grpDatabaseBackup.Controls.Add(this.btBackupDatabase);
-			this.grpDatabaseBackup.Dock = System.Windows.Forms.DockStyle.Top;
-			this.grpDatabaseBackup.Location = new System.Drawing.Point(0, 548);
-			this.grpDatabaseBackup.Name = "grpDatabaseBackup";
-			this.grpDatabaseBackup.Size = new System.Drawing.Size(498, 93);
-			this.grpDatabaseBackup.TabIndex = 4;
-			this.grpDatabaseBackup.Text = "Database Backup";
-			// 
-			// btRestoreDatabase
-			// 
-			this.btRestoreDatabase.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.btRestoreDatabase.Location = new System.Drawing.Point(259, 41);
-			this.btRestoreDatabase.Name = "btRestoreDatabase";
-			this.btRestoreDatabase.Size = new System.Drawing.Size(227, 23);
-			this.btRestoreDatabase.TabIndex = 1;
-			this.btRestoreDatabase.Text = "Restore Database...";
-			this.btRestoreDatabase.UseVisualStyleBackColor = true;
-			this.btRestoreDatabase.Click += new System.EventHandler(this.btRestoreDatabase_Click);
-			// 
-			// btBackupDatabase
-			// 
-			this.btBackupDatabase.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.btBackupDatabase.Location = new System.Drawing.Point(9, 41);
-			this.btBackupDatabase.Name = "btBackupDatabase";
-			this.btBackupDatabase.Size = new System.Drawing.Size(247, 23);
-			this.btBackupDatabase.TabIndex = 0;
-			this.btBackupDatabase.Text = "Backup Database...";
-			this.btBackupDatabase.UseVisualStyleBackColor = true;
-			this.btBackupDatabase.Click += new System.EventHandler(this.btBackupDatabase_Click);
-			// 
-			// groupOtherComics
-			// 
-			this.groupOtherComics.Controls.Add(this.chkUpdateComicFiles);
-			this.groupOtherComics.Controls.Add(this.labelExcludeCover);
-			this.groupOtherComics.Controls.Add(this.chkAutoUpdateComicFiles);
-			this.groupOtherComics.Controls.Add(this.txCoverFilter);
-			this.groupOtherComics.Dock = System.Windows.Forms.DockStyle.Top;
-			this.groupOtherComics.Location = new System.Drawing.Point(0, 372);
-			this.groupOtherComics.Name = "groupOtherComics";
-			this.groupOtherComics.Size = new System.Drawing.Size(498, 176);
-			this.groupOtherComics.TabIndex = 5;
-			this.groupOtherComics.Text = "Books";
-			// 
-			// chkUpdateComicFiles
-			// 
-			this.chkUpdateComicFiles.AutoSize = true;
-			this.chkUpdateComicFiles.Location = new System.Drawing.Point(9, 42);
-			this.chkUpdateComicFiles.Name = "chkUpdateComicFiles";
-			this.chkUpdateComicFiles.Size = new System.Drawing.Size(185, 17);
-			this.chkUpdateComicFiles.TabIndex = 0;
-			this.chkUpdateComicFiles.Text = "Allow writing of Book info into files";
-			this.chkUpdateComicFiles.UseVisualStyleBackColor = true;
-			// 
-			// labelExcludeCover
-			// 
-			this.labelExcludeCover.AutoSize = true;
-			this.labelExcludeCover.Location = new System.Drawing.Point(6, 93);
-			this.labelExcludeCover.Name = "labelExcludeCover";
-			this.labelExcludeCover.Size = new System.Drawing.Size(381, 13);
-			this.labelExcludeCover.TabIndex = 2;
-			this.labelExcludeCover.Text = "Semicolon separated list of image names never to be used as cover thumbnails:";
-			// 
-			// chkAutoUpdateComicFiles
-			// 
-			this.chkAutoUpdateComicFiles.AutoSize = true;
-			this.chkAutoUpdateComicFiles.Location = new System.Drawing.Point(9, 65);
-			this.chkAutoUpdateComicFiles.Name = "chkAutoUpdateComicFiles";
-			this.chkAutoUpdateComicFiles.Size = new System.Drawing.Size(196, 17);
-			this.chkAutoUpdateComicFiles.TabIndex = 1;
-			this.chkAutoUpdateComicFiles.Text = "Book files are updated automatically";
-			this.chkAutoUpdateComicFiles.UseVisualStyleBackColor = true;
-			// 
-			// txCoverFilter
-			// 
-			this.txCoverFilter.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.txtBackupLocation.Location = new System.Drawing.Point(66, 34);
+            this.txtBackupLocation.Name = "txtBackupLocation";
+            this.txtBackupLocation.Size = new System.Drawing.Size(339, 20);
+            this.txtBackupLocation.TabIndex = 1;
+            // 
+            // lblBackupLocation
+            // 
+            this.lblBackupLocation.AutoSize = true;
+            this.lblBackupLocation.Location = new System.Drawing.Point(12, 37);
+            this.lblBackupLocation.Name = "lblBackupLocation";
+            this.lblBackupLocation.Size = new System.Drawing.Size(48, 13);
+            this.lblBackupLocation.TabIndex = 0;
+            this.lblBackupLocation.Text = "Location";
+            // 
+            // grpDatabaseBackup
+            // 
+            this.grpDatabaseBackup.Controls.Add(this.btRestoreDatabase);
+            this.grpDatabaseBackup.Controls.Add(this.btBackupDatabase);
+            this.grpDatabaseBackup.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpDatabaseBackup.Location = new System.Drawing.Point(0, 572);
+            this.grpDatabaseBackup.Name = "grpDatabaseBackup";
+            this.grpDatabaseBackup.Size = new System.Drawing.Size(498, 93);
+            this.grpDatabaseBackup.TabIndex = 4;
+            this.grpDatabaseBackup.Text = "Database Backup";
+            // 
+            // btRestoreDatabase
+            // 
+            this.btRestoreDatabase.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.btRestoreDatabase.Location = new System.Drawing.Point(259, 41);
+            this.btRestoreDatabase.Name = "btRestoreDatabase";
+            this.btRestoreDatabase.Size = new System.Drawing.Size(227, 23);
+            this.btRestoreDatabase.TabIndex = 1;
+            this.btRestoreDatabase.Text = "Restore Database...";
+            this.btRestoreDatabase.UseVisualStyleBackColor = true;
+            this.btRestoreDatabase.Click += new System.EventHandler(this.btRestoreDatabase_Click);
+            // 
+            // btBackupDatabase
+            // 
+            this.btBackupDatabase.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.btBackupDatabase.Location = new System.Drawing.Point(9, 41);
+            this.btBackupDatabase.Name = "btBackupDatabase";
+            this.btBackupDatabase.Size = new System.Drawing.Size(247, 23);
+            this.btBackupDatabase.TabIndex = 0;
+            this.btBackupDatabase.Text = "Backup Database...";
+            this.btBackupDatabase.UseVisualStyleBackColor = true;
+            this.btBackupDatabase.Click += new System.EventHandler(this.btBackupDatabase_Click);
+            // 
+            // groupOtherComics
+            // 
+            this.groupOtherComics.Controls.Add(this.chkUpdateComicBookFiles);
+            this.groupOtherComics.Controls.Add(this.chkUpdateComicFiles);
+            this.groupOtherComics.Controls.Add(this.labelExcludeCover);
+            this.groupOtherComics.Controls.Add(this.chkAutoUpdateComicFiles);
+            this.groupOtherComics.Controls.Add(this.txCoverFilter);
+            this.groupOtherComics.Dock = System.Windows.Forms.DockStyle.Top;
+            this.groupOtherComics.Location = new System.Drawing.Point(0, 372);
+            this.groupOtherComics.Name = "groupOtherComics";
+            this.groupOtherComics.Size = new System.Drawing.Size(498, 200);
+            this.groupOtherComics.TabIndex = 5;
+            this.groupOtherComics.Text = "Books";
+            // 
+            // chkUpdateComicFiles
+            // 
+            this.chkUpdateComicFiles.AutoSize = true;
+            this.chkUpdateComicFiles.Location = new System.Drawing.Point(9, 42);
+            this.chkUpdateComicFiles.Name = "chkUpdateComicFiles";
+            this.chkUpdateComicFiles.Size = new System.Drawing.Size(185, 17);
+            this.chkUpdateComicFiles.TabIndex = 0;
+            this.chkUpdateComicFiles.Text = "Allow writing of Book info into files";
+            this.chkUpdateComicFiles.UseVisualStyleBackColor = true;
+            // 
+            // labelExcludeCover
+            // 
+            this.labelExcludeCover.AutoSize = true;
+            this.labelExcludeCover.Location = new System.Drawing.Point(6, 118);
+            this.labelExcludeCover.Name = "labelExcludeCover";
+            this.labelExcludeCover.Size = new System.Drawing.Size(381, 13);
+            this.labelExcludeCover.TabIndex = 2;
+            this.labelExcludeCover.Text = "Semicolon separated list of image names never to be used as cover thumbnails:";
+            // 
+            // chkAutoUpdateComicFiles
+            // 
+            this.chkAutoUpdateComicFiles.AutoSize = true;
+            this.chkAutoUpdateComicFiles.Location = new System.Drawing.Point(9, 89);
+            this.chkAutoUpdateComicFiles.Name = "chkAutoUpdateComicFiles";
+            this.chkAutoUpdateComicFiles.Size = new System.Drawing.Size(196, 17);
+            this.chkAutoUpdateComicFiles.TabIndex = 1;
+            this.chkAutoUpdateComicFiles.Text = "Book files are updated automatically";
+            this.chkAutoUpdateComicFiles.UseVisualStyleBackColor = true;
+            // 
+            // txCoverFilter
+            // 
+            this.txCoverFilter.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txCoverFilter.Location = new System.Drawing.Point(9, 112);
-			this.txCoverFilter.Multiline = true;
-			this.txCoverFilter.Name = "txCoverFilter";
-			this.txCoverFilter.Size = new System.Drawing.Size(482, 54);
-			this.txCoverFilter.TabIndex = 3;
-			// 
-			// grpLanguages
-			// 
-			this.grpLanguages.Controls.Add(this.btTranslate);
-			this.grpLanguages.Controls.Add(this.labelLanguage);
-			this.grpLanguages.Controls.Add(this.lbLanguages);
-			this.grpLanguages.Dock = System.Windows.Forms.DockStyle.Top;
-			this.grpLanguages.Location = new System.Drawing.Point(0, 0);
-			this.grpLanguages.Name = "grpLanguages";
-			this.grpLanguages.Size = new System.Drawing.Size(498, 372);
-			this.grpLanguages.TabIndex = 7;
-			this.grpLanguages.Text = "Languages";
-			// 
-			// btTranslate
-			// 
-			this.btTranslate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btTranslate.Location = new System.Drawing.Point(207, 339);
-			this.btTranslate.Name = "btTranslate";
-			this.btTranslate.Size = new System.Drawing.Size(284, 23);
-			this.btTranslate.TabIndex = 12;
-			this.btTranslate.Text = "Help localizing ComicRack...";
-			this.btTranslate.UseVisualStyleBackColor = true;
-			this.btTranslate.Click += new System.EventHandler(this.btTranslate_Click);
-			// 
-			// labelLanguage
-			// 
-			this.labelLanguage.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.txCoverFilter.Location = new System.Drawing.Point(9, 137);
+            this.txCoverFilter.Multiline = true;
+            this.txCoverFilter.Name = "txCoverFilter";
+            this.txCoverFilter.Size = new System.Drawing.Size(482, 54);
+            this.txCoverFilter.TabIndex = 3;
+            // 
+            // grpLanguages
+            // 
+            this.grpLanguages.Controls.Add(this.btTranslate);
+            this.grpLanguages.Controls.Add(this.labelLanguage);
+            this.grpLanguages.Controls.Add(this.lbLanguages);
+            this.grpLanguages.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpLanguages.Location = new System.Drawing.Point(0, 0);
+            this.grpLanguages.Name = "grpLanguages";
+            this.grpLanguages.Size = new System.Drawing.Size(498, 372);
+            this.grpLanguages.TabIndex = 7;
+            this.grpLanguages.Text = "Languages";
+            // 
+            // btTranslate
+            // 
+            this.btTranslate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btTranslate.Location = new System.Drawing.Point(207, 339);
+            this.btTranslate.Name = "btTranslate";
+            this.btTranslate.Size = new System.Drawing.Size(284, 23);
+            this.btTranslate.TabIndex = 12;
+            this.btTranslate.Text = "Help localizing ComicRack...";
+            this.btTranslate.UseVisualStyleBackColor = true;
+            this.btTranslate.Click += new System.EventHandler(this.btTranslate_Click);
+            // 
+            // labelLanguage
+            // 
+            this.labelLanguage.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.labelLanguage.Location = new System.Drawing.Point(6, 33);
-			this.labelLanguage.Name = "labelLanguage";
-			this.labelLanguage.Size = new System.Drawing.Size(485, 35);
-			this.labelLanguage.TabIndex = 11;
-			this.labelLanguage.Text = "Select the User Interface language for ComicRack (ComicRack must be restarted for" +
+            this.labelLanguage.Location = new System.Drawing.Point(6, 33);
+            this.labelLanguage.Name = "labelLanguage";
+            this.labelLanguage.Size = new System.Drawing.Size(485, 35);
+            this.labelLanguage.TabIndex = 11;
+            this.labelLanguage.Text = "Select the User Interface language for ComicRack (ComicRack must be restarted for" +
     " any change to take effect):";
-			// 
-			// lbLanguages
-			// 
-			this.lbLanguages.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            // 
+            // lbLanguages
+            // 
+            this.lbLanguages.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.lbLanguages.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
-			this.lbLanguages.FormattingEnabled = true;
-			this.lbLanguages.ItemHeight = 15;
-			this.lbLanguages.Location = new System.Drawing.Point(6, 75);
-			this.lbLanguages.Name = "lbLanguages";
-			this.lbLanguages.Size = new System.Drawing.Size(485, 259);
-			this.lbLanguages.TabIndex = 0;
-			this.lbLanguages.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.lbLanguages_DrawItem);
-			// 
-			// pageLibrary
-			// 
-			this.pageLibrary.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.lbLanguages.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.lbLanguages.FormattingEnabled = true;
+            this.lbLanguages.ItemHeight = 15;
+            this.lbLanguages.Location = new System.Drawing.Point(6, 75);
+            this.lbLanguages.Name = "lbLanguages";
+            this.lbLanguages.Size = new System.Drawing.Size(485, 259);
+            this.lbLanguages.TabIndex = 0;
+            this.lbLanguages.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.lbLanguages_DrawItem);
+            // 
+            // pageLibrary
+            // 
+            this.pageLibrary.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.pageLibrary.AutoScroll = true;
-			this.pageLibrary.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.pageLibrary.Controls.Add(this.grpVirtualTags);
-			this.pageLibrary.Controls.Add(this.grpServerSettings);
-			this.pageLibrary.Controls.Add(this.grpSharing);
-			this.pageLibrary.Controls.Add(this.groupLibraryDisplay);
-			this.pageLibrary.Controls.Add(this.grpScanning);
-			this.pageLibrary.Controls.Add(this.groupComicFolders);
-			this.pageLibrary.Location = new System.Drawing.Point(84, 8);
-			this.pageLibrary.Name = "pageLibrary";
-			this.pageLibrary.Size = new System.Drawing.Size(517, 408);
-			this.pageLibrary.TabIndex = 10;
-			// 
-			// grpVirtualTags
-			// 
-			this.grpVirtualTags.Controls.Add(this.btnVTagsHelp);
-			this.grpVirtualTags.Controls.Add(this.grpVtagConfig);
-			this.grpVirtualTags.Controls.Add(this.lblVirtualTags);
-			this.grpVirtualTags.Controls.Add(this.cbVirtualTags);
-			this.grpVirtualTags.Dock = System.Windows.Forms.DockStyle.Top;
-			this.grpVirtualTags.Location = new System.Drawing.Point(0, 1058);
-			this.grpVirtualTags.Name = "grpVirtualTags";
-			this.grpVirtualTags.Size = new System.Drawing.Size(498, 279);
-			this.grpVirtualTags.TabIndex = 0;
-			this.grpVirtualTags.Text = "Virtual Tags";
-			// 
-			// btnVTagsHelp
-			// 
-			this.btnVTagsHelp.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnVTagsHelp.FlatAppearance.BorderSize = 0;
-			this.btnVTagsHelp.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.btnVTagsHelp.ForeColor = System.Drawing.Color.Transparent;
-			this.btnVTagsHelp.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.Help;
-			this.btnVTagsHelp.Location = new System.Drawing.Point(466, 33);
-			this.btnVTagsHelp.Name = "btnVTagsHelp";
-			this.btnVTagsHelp.Size = new System.Drawing.Size(24, 24);
-			this.btnVTagsHelp.TabIndex = 6;
-			this.btnVTagsHelp.UseVisualStyleBackColor = true;
-			this.btnVTagsHelp.Click += new System.EventHandler(this.btnVTagsHelp_Click);
-			// 
-			// grpVtagConfig
-			// 
-			this.grpVtagConfig.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.pageLibrary.AutoScroll = true;
+            this.pageLibrary.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.pageLibrary.Controls.Add(this.grpVirtualTags);
+            this.pageLibrary.Controls.Add(this.grpServerSettings);
+            this.pageLibrary.Controls.Add(this.grpSharing);
+            this.pageLibrary.Controls.Add(this.groupLibraryDisplay);
+            this.pageLibrary.Controls.Add(this.grpScanning);
+            this.pageLibrary.Controls.Add(this.groupComicFolders);
+            this.pageLibrary.Location = new System.Drawing.Point(84, 8);
+            this.pageLibrary.Name = "pageLibrary";
+            this.pageLibrary.Size = new System.Drawing.Size(517, 408);
+            this.pageLibrary.TabIndex = 10;
+            // 
+            // grpVirtualTags
+            // 
+            this.grpVirtualTags.Controls.Add(this.btnVTagsHelp);
+            this.grpVirtualTags.Controls.Add(this.grpVtagConfig);
+            this.grpVirtualTags.Controls.Add(this.lblVirtualTags);
+            this.grpVirtualTags.Controls.Add(this.cbVirtualTags);
+            this.grpVirtualTags.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpVirtualTags.Location = new System.Drawing.Point(0, 1058);
+            this.grpVirtualTags.Name = "grpVirtualTags";
+            this.grpVirtualTags.Size = new System.Drawing.Size(498, 279);
+            this.grpVirtualTags.TabIndex = 0;
+            this.grpVirtualTags.Text = "Virtual Tags";
+            // 
+            // btnVTagsHelp
+            // 
+            this.btnVTagsHelp.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnVTagsHelp.FlatAppearance.BorderSize = 0;
+            this.btnVTagsHelp.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnVTagsHelp.ForeColor = System.Drawing.Color.Transparent;
+            this.btnVTagsHelp.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.Help;
+            this.btnVTagsHelp.Location = new System.Drawing.Point(466, 33);
+            this.btnVTagsHelp.Name = "btnVTagsHelp";
+            this.btnVTagsHelp.Size = new System.Drawing.Size(24, 24);
+            this.btnVTagsHelp.TabIndex = 6;
+            this.btnVTagsHelp.UseVisualStyleBackColor = true;
+            this.btnVTagsHelp.Click += new System.EventHandler(this.btnVTagsHelp_Click);
+            // 
+            // grpVtagConfig
+            // 
+            this.grpVtagConfig.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.grpVtagConfig.Controls.Add(this.lblCaptionFormat);
-			this.grpVtagConfig.Controls.Add(this.txtCaptionFormat);
-			this.grpVtagConfig.Controls.Add(this.btInsertValue);
-			this.grpVtagConfig.Controls.Add(this.lblVirtualTagDescription);
-			this.grpVtagConfig.Controls.Add(this.lblVirtualTagName);
-			this.grpVtagConfig.Controls.Add(this.txtVirtualTagDescription);
-			this.grpVtagConfig.Controls.Add(this.txtVirtualTagName);
-			this.grpVtagConfig.Controls.Add(this.chkVirtualTagEnable);
-			this.grpVtagConfig.Controls.Add(this.lblCaptionText);
-			this.grpVtagConfig.Controls.Add(this.lblCaptionSuffix);
-			this.grpVtagConfig.Controls.Add(this.rtfVirtualTagCaption);
-			this.grpVtagConfig.Controls.Add(this.lblFieldConfig);
-			this.grpVtagConfig.Controls.Add(this.txtCaptionPrefix);
-			this.grpVtagConfig.Controls.Add(this.lblCaptionPrefix);
-			this.grpVtagConfig.Controls.Add(this.btnCaptionInsert);
-			this.grpVtagConfig.Controls.Add(this.txtCaptionSuffix);
-			this.grpVtagConfig.Location = new System.Drawing.Point(14, 63);
-			this.grpVtagConfig.Name = "grpVtagConfig";
-			this.grpVtagConfig.Size = new System.Drawing.Size(472, 199);
-			this.grpVtagConfig.TabIndex = 5;
-			this.grpVtagConfig.TabStop = false;
-			this.grpVtagConfig.Text = "Config";
-			// 
-			// lblCaptionFormat
-			// 
-			this.lblCaptionFormat.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.lblCaptionFormat.AutoSize = true;
-			this.lblCaptionFormat.Location = new System.Drawing.Point(275, 151);
-			this.lblCaptionFormat.Name = "lblCaptionFormat";
-			this.lblCaptionFormat.Size = new System.Drawing.Size(39, 13);
-			this.lblCaptionFormat.TabIndex = 28;
-			this.lblCaptionFormat.Text = "Format";
-			this.lblCaptionFormat.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-			// 
-			// txtCaptionFormat
-			// 
-			this.txtCaptionFormat.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.txtCaptionFormat.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtCaptionFormat.Location = new System.Drawing.Point(269, 167);
-			this.txtCaptionFormat.Name = "txtCaptionFormat";
-			this.txtCaptionFormat.Size = new System.Drawing.Size(50, 20);
-			this.txtCaptionFormat.TabIndex = 27;
-			this.toolTip.SetToolTip(this.txtCaptionFormat, resources.GetString("txtCaptionFormat.ToolTip"));
-			this.txtCaptionFormat.WordWrap = false;
-			// 
-			// btInsertValue
-			// 
-			this.btInsertValue.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.grpVtagConfig.Controls.Add(this.lblCaptionFormat);
+            this.grpVtagConfig.Controls.Add(this.txtCaptionFormat);
+            this.grpVtagConfig.Controls.Add(this.btInsertValue);
+            this.grpVtagConfig.Controls.Add(this.lblVirtualTagDescription);
+            this.grpVtagConfig.Controls.Add(this.lblVirtualTagName);
+            this.grpVtagConfig.Controls.Add(this.txtVirtualTagDescription);
+            this.grpVtagConfig.Controls.Add(this.txtVirtualTagName);
+            this.grpVtagConfig.Controls.Add(this.chkVirtualTagEnable);
+            this.grpVtagConfig.Controls.Add(this.lblCaptionText);
+            this.grpVtagConfig.Controls.Add(this.lblCaptionSuffix);
+            this.grpVtagConfig.Controls.Add(this.rtfVirtualTagCaption);
+            this.grpVtagConfig.Controls.Add(this.lblFieldConfig);
+            this.grpVtagConfig.Controls.Add(this.txtCaptionPrefix);
+            this.grpVtagConfig.Controls.Add(this.lblCaptionPrefix);
+            this.grpVtagConfig.Controls.Add(this.btnCaptionInsert);
+            this.grpVtagConfig.Controls.Add(this.txtCaptionSuffix);
+            this.grpVtagConfig.Location = new System.Drawing.Point(14, 63);
+            this.grpVtagConfig.Name = "grpVtagConfig";
+            this.grpVtagConfig.Size = new System.Drawing.Size(472, 199);
+            this.grpVtagConfig.TabIndex = 5;
+            this.grpVtagConfig.TabStop = false;
+            this.grpVtagConfig.Text = "Config";
+            // 
+            // lblCaptionFormat
+            // 
+            this.lblCaptionFormat.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblCaptionFormat.AutoSize = true;
+            this.lblCaptionFormat.Location = new System.Drawing.Point(275, 151);
+            this.lblCaptionFormat.Name = "lblCaptionFormat";
+            this.lblCaptionFormat.Size = new System.Drawing.Size(39, 13);
+            this.lblCaptionFormat.TabIndex = 28;
+            this.lblCaptionFormat.Text = "Format";
+            this.lblCaptionFormat.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // btInsertValue
+            // 
+            this.btInsertValue.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.btInsertValue.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.SmallArrowDown;
-			this.btInsertValue.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-			this.btInsertValue.Location = new System.Drawing.Point(96, 164);
-			this.btInsertValue.Name = "btInsertValue";
-			this.btInsertValue.Size = new System.Drawing.Size(167, 23);
-			this.btInsertValue.TabIndex = 26;
-			this.btInsertValue.Text = "Choose Value";
+            this.btInsertValue.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.SmallArrowDown;
+            this.btInsertValue.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.btInsertValue.Location = new System.Drawing.Point(96, 164);
+            this.btInsertValue.Name = "btInsertValue";
+            this.btInsertValue.Size = new System.Drawing.Size(167, 23);
+            this.btInsertValue.TabIndex = 26;
+            this.btInsertValue.Text = "Choose Value";
             this.btInsertValue.UseVisualStyleBackColor = true;
-			// 
-			// lblVirtualTagDescription
-			// 
-			this.lblVirtualTagDescription.AutoSize = true;
-			this.lblVirtualTagDescription.Location = new System.Drawing.Point(72, 49);
-			this.lblVirtualTagDescription.Name = "lblVirtualTagDescription";
-			this.lblVirtualTagDescription.Size = new System.Drawing.Size(69, 13);
-			this.lblVirtualTagDescription.TabIndex = 25;
-			this.lblVirtualTagDescription.Text = "Description : ";
-			// 
-			// lblVirtualTagName
-			// 
-			this.lblVirtualTagName.AutoSize = true;
-			this.lblVirtualTagName.Location = new System.Drawing.Point(72, 23);
-			this.lblVirtualTagName.Name = "lblVirtualTagName";
-			this.lblVirtualTagName.Size = new System.Drawing.Size(44, 13);
-			this.lblVirtualTagName.TabIndex = 24;
-			this.lblVirtualTagName.Text = "Name : ";
-			// 
-			// txtVirtualTagDescription
-			// 
-			this.txtVirtualTagDescription.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            // 
+            // lblVirtualTagDescription
+            // 
+            this.lblVirtualTagDescription.AutoSize = true;
+            this.lblVirtualTagDescription.Location = new System.Drawing.Point(72, 49);
+            this.lblVirtualTagDescription.Name = "lblVirtualTagDescription";
+            this.lblVirtualTagDescription.Size = new System.Drawing.Size(69, 13);
+            this.lblVirtualTagDescription.TabIndex = 25;
+            this.lblVirtualTagDescription.Text = "Description : ";
+            // 
+            // lblVirtualTagName
+            // 
+            this.lblVirtualTagName.AutoSize = true;
+            this.lblVirtualTagName.Location = new System.Drawing.Point(72, 23);
+            this.lblVirtualTagName.Name = "lblVirtualTagName";
+            this.lblVirtualTagName.Size = new System.Drawing.Size(44, 13);
+            this.lblVirtualTagName.TabIndex = 24;
+            this.lblVirtualTagName.Text = "Name : ";
+            // 
+            // txtVirtualTagDescription
+            // 
+            this.txtVirtualTagDescription.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txtVirtualTagDescription.Location = new System.Drawing.Point(147, 46);
-			this.txtVirtualTagDescription.Name = "txtVirtualTagDescription";
-			this.txtVirtualTagDescription.Size = new System.Drawing.Size(308, 20);
-			this.txtVirtualTagDescription.TabIndex = 2;
-			this.txtVirtualTagDescription.Validated += new System.EventHandler(this.VirtualTag_Validated);
-			// 
-			// txtVirtualTagName
-			// 
-			this.txtVirtualTagName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.txtVirtualTagDescription.Location = new System.Drawing.Point(147, 46);
+            this.txtVirtualTagDescription.Name = "txtVirtualTagDescription";
+            this.txtVirtualTagDescription.Size = new System.Drawing.Size(308, 20);
+            this.txtVirtualTagDescription.TabIndex = 2;
+            this.txtVirtualTagDescription.Validated += new System.EventHandler(this.VirtualTag_Validated);
+            // 
+            // txtVirtualTagName
+            // 
+            this.txtVirtualTagName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txtVirtualTagName.Location = new System.Drawing.Point(122, 20);
-			this.txtVirtualTagName.Name = "txtVirtualTagName";
-			this.txtVirtualTagName.Size = new System.Drawing.Size(333, 20);
-			this.txtVirtualTagName.TabIndex = 1;
-			this.txtVirtualTagName.Validated += new System.EventHandler(this.UpdateVirtualTagsComboBox);
-			// 
-			// chkVirtualTagEnable
-			// 
-			this.chkVirtualTagEnable.AutoSize = true;
-			this.chkVirtualTagEnable.Location = new System.Drawing.Point(10, 34);
-			this.chkVirtualTagEnable.Name = "chkVirtualTagEnable";
-			this.chkVirtualTagEnable.Size = new System.Drawing.Size(59, 17);
-			this.chkVirtualTagEnable.TabIndex = 3;
-			this.chkVirtualTagEnable.Text = "Enable";
-			this.chkVirtualTagEnable.UseVisualStyleBackColor = true;
-			this.chkVirtualTagEnable.Validated += new System.EventHandler(this.UpdateVirtualTagsComboBox);
-			// 
-			// lblCaptionText
-			// 
-			this.lblCaptionText.AutoSize = true;
-			this.lblCaptionText.Location = new System.Drawing.Point(7, 82);
-			this.lblCaptionText.Name = "lblCaptionText";
-			this.lblCaptionText.Size = new System.Drawing.Size(52, 13);
-			this.lblCaptionText.TabIndex = 3;
-			this.lblCaptionText.Text = "Caption : ";
-			// 
-			// lblCaptionSuffix
-			// 
-			this.lblCaptionSuffix.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.lblCaptionSuffix.AutoSize = true;
-			this.lblCaptionSuffix.Location = new System.Drawing.Point(349, 151);
-			this.lblCaptionSuffix.Name = "lblCaptionSuffix";
-			this.lblCaptionSuffix.Size = new System.Drawing.Size(33, 13);
-			this.lblCaptionSuffix.TabIndex = 20;
-			this.lblCaptionSuffix.Text = "Suffix";
-			// 
-			// rtfVirtualTagCaption
-			// 
-			this.rtfVirtualTagCaption.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.txtVirtualTagName.Location = new System.Drawing.Point(122, 20);
+            this.txtVirtualTagName.Name = "txtVirtualTagName";
+            this.txtVirtualTagName.Size = new System.Drawing.Size(333, 20);
+            this.txtVirtualTagName.TabIndex = 1;
+            this.txtVirtualTagName.Validated += new System.EventHandler(this.UpdateVirtualTagsComboBox);
+            // 
+            // chkVirtualTagEnable
+            // 
+            this.chkVirtualTagEnable.AutoSize = true;
+            this.chkVirtualTagEnable.Location = new System.Drawing.Point(10, 34);
+            this.chkVirtualTagEnable.Name = "chkVirtualTagEnable";
+            this.chkVirtualTagEnable.Size = new System.Drawing.Size(59, 17);
+            this.chkVirtualTagEnable.TabIndex = 3;
+            this.chkVirtualTagEnable.Text = "Enable";
+            this.chkVirtualTagEnable.UseVisualStyleBackColor = true;
+            this.chkVirtualTagEnable.Validated += new System.EventHandler(this.UpdateVirtualTagsComboBox);
+            // 
+            // lblCaptionText
+            // 
+            this.lblCaptionText.AutoSize = true;
+            this.lblCaptionText.Location = new System.Drawing.Point(7, 82);
+            this.lblCaptionText.Name = "lblCaptionText";
+            this.lblCaptionText.Size = new System.Drawing.Size(52, 13);
+            this.lblCaptionText.TabIndex = 3;
+            this.lblCaptionText.Text = "Caption : ";
+            // 
+            // lblCaptionSuffix
+            // 
+            this.lblCaptionSuffix.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblCaptionSuffix.AutoSize = true;
+            this.lblCaptionSuffix.Location = new System.Drawing.Point(349, 151);
+            this.lblCaptionSuffix.Name = "lblCaptionSuffix";
+            this.lblCaptionSuffix.Size = new System.Drawing.Size(33, 13);
+            this.lblCaptionSuffix.TabIndex = 20;
+            this.lblCaptionSuffix.Text = "Suffix";
+            // 
+            // rtfVirtualTagCaption
+            // 
+            this.rtfVirtualTagCaption.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.rtfVirtualTagCaption.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.rtfVirtualTagCaption.DetectUrls = false;
-			this.rtfVirtualTagCaption.Font = new System.Drawing.Font("Courier New", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.rtfVirtualTagCaption.Location = new System.Drawing.Point(64, 79);
-			this.rtfVirtualTagCaption.Name = "rtfVirtualTagCaption";
-			this.rtfVirtualTagCaption.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
-			this.rtfVirtualTagCaption.Size = new System.Drawing.Size(391, 62);
-			this.rtfVirtualTagCaption.TabIndex = 4;
-			this.rtfVirtualTagCaption.Text = "";
-			this.rtfVirtualTagCaption.Validated += new System.EventHandler(this.VirtualTag_Validated);
-			// 
-			// lblFieldConfig
-			// 
-			this.lblFieldConfig.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.lblFieldConfig.AutoSize = true;
-			this.lblFieldConfig.Location = new System.Drawing.Point(165, 151);
-			this.lblFieldConfig.Name = "lblFieldConfig";
-			this.lblFieldConfig.Size = new System.Drawing.Size(29, 13);
-			this.lblFieldConfig.TabIndex = 19;
-			this.lblFieldConfig.Text = "Field";
-			this.lblFieldConfig.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-			// 
-			// txtCaptionPrefix
-			// 
-			this.txtCaptionPrefix.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtCaptionPrefix.Location = new System.Drawing.Point(10, 167);
-			this.txtCaptionPrefix.Name = "txtCaptionPrefix";
-			this.txtCaptionPrefix.Size = new System.Drawing.Size(80, 20);
-			this.txtCaptionPrefix.TabIndex = 5;
-			// 
-			// lblCaptionPrefix
-			// 
-			this.lblCaptionPrefix.AutoSize = true;
-			this.lblCaptionPrefix.Location = new System.Drawing.Point(34, 151);
-			this.lblCaptionPrefix.Name = "lblCaptionPrefix";
-			this.lblCaptionPrefix.Size = new System.Drawing.Size(33, 13);
-			this.lblCaptionPrefix.TabIndex = 18;
-			this.lblCaptionPrefix.Text = "Prefix";
-			// 
-			// btnCaptionInsert
-			// 
-			this.btnCaptionInsert.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnCaptionInsert.Location = new System.Drawing.Point(410, 164);
-			this.btnCaptionInsert.Name = "btnCaptionInsert";
-			this.btnCaptionInsert.Size = new System.Drawing.Size(51, 23);
-			this.btnCaptionInsert.TabIndex = 8;
-			this.btnCaptionInsert.Text = "Insert";
-			this.btnCaptionInsert.UseVisualStyleBackColor = true;
-			this.btnCaptionInsert.Click += new System.EventHandler(this.btnCaptionInsert_Click);
-			// 
-			// txtCaptionSuffix
-			// 
-			this.txtCaptionSuffix.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.txtCaptionSuffix.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtCaptionSuffix.Location = new System.Drawing.Point(325, 167);
-			this.txtCaptionSuffix.Name = "txtCaptionSuffix";
-			this.txtCaptionSuffix.Size = new System.Drawing.Size(80, 20);
-			this.txtCaptionSuffix.TabIndex = 7;
-			// 
-			// lblVirtualTags
-			// 
-			this.lblVirtualTags.AutoSize = true;
-			this.lblVirtualTags.Location = new System.Drawing.Point(10, 39);
-			this.lblVirtualTags.Name = "lblVirtualTags";
-			this.lblVirtualTags.Size = new System.Drawing.Size(45, 13);
-			this.lblVirtualTags.TabIndex = 1;
-			this.lblVirtualTags.Text = "Tag # : ";
-			// 
-			// cbVirtualTags
-			// 
-			this.cbVirtualTags.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.rtfVirtualTagCaption.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.rtfVirtualTagCaption.DetectUrls = false;
+            this.rtfVirtualTagCaption.Font = new System.Drawing.Font("Courier New", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.rtfVirtualTagCaption.Location = new System.Drawing.Point(64, 79);
+            this.rtfVirtualTagCaption.Name = "rtfVirtualTagCaption";
+            this.rtfVirtualTagCaption.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
+            this.rtfVirtualTagCaption.Size = new System.Drawing.Size(391, 62);
+            this.rtfVirtualTagCaption.TabIndex = 4;
+            this.rtfVirtualTagCaption.Text = "";
+            this.rtfVirtualTagCaption.Validated += new System.EventHandler(this.VirtualTag_Validated);
+            // 
+            // lblFieldConfig
+            // 
+            this.lblFieldConfig.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.lblFieldConfig.AutoSize = true;
+            this.lblFieldConfig.Location = new System.Drawing.Point(165, 151);
+            this.lblFieldConfig.Name = "lblFieldConfig";
+            this.lblFieldConfig.Size = new System.Drawing.Size(29, 13);
+            this.lblFieldConfig.TabIndex = 19;
+            this.lblFieldConfig.Text = "Field";
+            this.lblFieldConfig.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // txtCaptionPrefix
+            // 
+            this.txtCaptionPrefix.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtCaptionPrefix.Location = new System.Drawing.Point(10, 167);
+            this.txtCaptionPrefix.Name = "txtCaptionPrefix";
+            this.txtCaptionPrefix.Size = new System.Drawing.Size(80, 20);
+            this.txtCaptionPrefix.TabIndex = 5;
+            // 
+            // lblCaptionPrefix
+            // 
+            this.lblCaptionPrefix.AutoSize = true;
+            this.lblCaptionPrefix.Location = new System.Drawing.Point(34, 151);
+            this.lblCaptionPrefix.Name = "lblCaptionPrefix";
+            this.lblCaptionPrefix.Size = new System.Drawing.Size(33, 13);
+            this.lblCaptionPrefix.TabIndex = 18;
+            this.lblCaptionPrefix.Text = "Prefix";
+            // 
+            // btnCaptionInsert
+            // 
+            this.btnCaptionInsert.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCaptionInsert.Location = new System.Drawing.Point(410, 164);
+            this.btnCaptionInsert.Name = "btnCaptionInsert";
+            this.btnCaptionInsert.Size = new System.Drawing.Size(51, 23);
+            this.btnCaptionInsert.TabIndex = 8;
+            this.btnCaptionInsert.Text = "Insert";
+            this.btnCaptionInsert.UseVisualStyleBackColor = true;
+            this.btnCaptionInsert.Click += new System.EventHandler(this.btnCaptionInsert_Click);
+            // 
+            // txtCaptionSuffix
+            // 
+            this.txtCaptionSuffix.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtCaptionSuffix.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtCaptionSuffix.Location = new System.Drawing.Point(325, 167);
+            this.txtCaptionSuffix.Name = "txtCaptionSuffix";
+            this.txtCaptionSuffix.Size = new System.Drawing.Size(80, 20);
+            this.txtCaptionSuffix.TabIndex = 7;
+            // 
+            // lblVirtualTags
+            // 
+            this.lblVirtualTags.AutoSize = true;
+            this.lblVirtualTags.Location = new System.Drawing.Point(10, 39);
+            this.lblVirtualTags.Name = "lblVirtualTags";
+            this.lblVirtualTags.Size = new System.Drawing.Size(45, 13);
+            this.lblVirtualTags.TabIndex = 1;
+            this.lblVirtualTags.Text = "Tag # : ";
+            // 
+            // cbVirtualTags
+            // 
+            this.cbVirtualTags.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.cbVirtualTags.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cbVirtualTags.FormattingEnabled = true;
-			this.cbVirtualTags.Location = new System.Drawing.Point(61, 36);
-			this.cbVirtualTags.Name = "cbVirtualTags";
-			this.cbVirtualTags.Size = new System.Drawing.Size(400, 21);
-			this.cbVirtualTags.TabIndex = 0;
-			this.cbVirtualTags.SelectedIndexChanged += new System.EventHandler(this.cbVirtualTags_SelectedIndexChanged);
-			// 
-			// grpServerSettings
-			// 
-			this.grpServerSettings.Controls.Add(this.txPrivateListingPassword);
-			this.grpServerSettings.Controls.Add(this.labelPrivateListPassword);
-			this.grpServerSettings.Controls.Add(this.labelPublicServerAddress);
-			this.grpServerSettings.Controls.Add(this.txPublicServerAddress);
-			this.grpServerSettings.Dock = System.Windows.Forms.DockStyle.Top;
-			this.grpServerSettings.Location = new System.Drawing.Point(0, 910);
-			this.grpServerSettings.Name = "grpServerSettings";
-			this.grpServerSettings.Size = new System.Drawing.Size(498, 148);
-			this.grpServerSettings.TabIndex = 3;
-			this.grpServerSettings.Text = "Server Settings";
-			// 
-			// txPrivateListingPassword
-			// 
-			this.txPrivateListingPassword.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.cbVirtualTags.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbVirtualTags.FormattingEnabled = true;
+            this.cbVirtualTags.Location = new System.Drawing.Point(61, 36);
+            this.cbVirtualTags.Name = "cbVirtualTags";
+            this.cbVirtualTags.Size = new System.Drawing.Size(400, 21);
+            this.cbVirtualTags.TabIndex = 0;
+            this.cbVirtualTags.SelectedIndexChanged += new System.EventHandler(this.cbVirtualTags_SelectedIndexChanged);
+            // 
+            // grpServerSettings
+            // 
+            this.grpServerSettings.Controls.Add(this.txPrivateListingPassword);
+            this.grpServerSettings.Controls.Add(this.labelPrivateListPassword);
+            this.grpServerSettings.Controls.Add(this.labelPublicServerAddress);
+            this.grpServerSettings.Controls.Add(this.txPublicServerAddress);
+            this.grpServerSettings.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpServerSettings.Location = new System.Drawing.Point(0, 910);
+            this.grpServerSettings.Name = "grpServerSettings";
+            this.grpServerSettings.Size = new System.Drawing.Size(498, 148);
+            this.grpServerSettings.TabIndex = 3;
+            this.grpServerSettings.Text = "Server Settings";
+            // 
+            // txPrivateListingPassword
+            // 
+            this.txPrivateListingPassword.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txPrivateListingPassword.Location = new System.Drawing.Point(12, 114);
-			this.txPrivateListingPassword.Name = "txPrivateListingPassword";
-			this.txPrivateListingPassword.Password = null;
-			this.txPrivateListingPassword.Size = new System.Drawing.Size(379, 20);
-			this.txPrivateListingPassword.TabIndex = 3;
-			this.txPrivateListingPassword.UseSystemPasswordChar = true;
-			// 
-			// labelPrivateListPassword
-			// 
-			this.labelPrivateListPassword.AutoSize = true;
-			this.labelPrivateListPassword.Location = new System.Drawing.Point(13, 96);
-			this.labelPrivateListPassword.Name = "labelPrivateListPassword";
-			this.labelPrivateListPassword.Size = new System.Drawing.Size(307, 13);
-			this.labelPrivateListPassword.TabIndex = 2;
-			this.labelPrivateListPassword.Text = "Password used to protect your private Internet Share list entries:";
-			// 
-			// labelPublicServerAddress
-			// 
-			this.labelPublicServerAddress.AutoSize = true;
-			this.labelPublicServerAddress.Location = new System.Drawing.Point(14, 41);
-			this.labelPublicServerAddress.Name = "labelPublicServerAddress";
-			this.labelPublicServerAddress.Size = new System.Drawing.Size(368, 13);
-			this.labelPublicServerAddress.TabIndex = 0;
-			this.labelPublicServerAddress.Text = "External IP address of your server if ComicRack should not guess it correctly:";
-			// 
-			// txPublicServerAddress
-			// 
-			this.txPublicServerAddress.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.txPrivateListingPassword.Location = new System.Drawing.Point(12, 114);
+            this.txPrivateListingPassword.Name = "txPrivateListingPassword";
+            this.txPrivateListingPassword.Password = null;
+            this.txPrivateListingPassword.Size = new System.Drawing.Size(379, 20);
+            this.txPrivateListingPassword.TabIndex = 3;
+            this.txPrivateListingPassword.UseSystemPasswordChar = true;
+            // 
+            // labelPrivateListPassword
+            // 
+            this.labelPrivateListPassword.AutoSize = true;
+            this.labelPrivateListPassword.Location = new System.Drawing.Point(13, 96);
+            this.labelPrivateListPassword.Name = "labelPrivateListPassword";
+            this.labelPrivateListPassword.Size = new System.Drawing.Size(307, 13);
+            this.labelPrivateListPassword.TabIndex = 2;
+            this.labelPrivateListPassword.Text = "Password used to protect your private Internet Share list entries:";
+            // 
+            // labelPublicServerAddress
+            // 
+            this.labelPublicServerAddress.AutoSize = true;
+            this.labelPublicServerAddress.Location = new System.Drawing.Point(14, 41);
+            this.labelPublicServerAddress.Name = "labelPublicServerAddress";
+            this.labelPublicServerAddress.Size = new System.Drawing.Size(368, 13);
+            this.labelPublicServerAddress.TabIndex = 0;
+            this.labelPublicServerAddress.Text = "External IP address of your server if ComicRack should not guess it correctly:";
+            // 
+            // txPublicServerAddress
+            // 
+            this.txPublicServerAddress.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txPublicServerAddress.Location = new System.Drawing.Point(12, 60);
-			this.txPublicServerAddress.Name = "txPublicServerAddress";
-			this.txPublicServerAddress.Size = new System.Drawing.Size(379, 20);
-			this.txPublicServerAddress.TabIndex = 1;
-			// 
-			// grpSharing
-			// 
-			this.grpSharing.Controls.Add(this.chkAutoConnectShares);
-			this.grpSharing.Controls.Add(this.btRemoveShare);
-			this.grpSharing.Controls.Add(this.btAddShare);
-			this.grpSharing.Controls.Add(this.tabShares);
-			this.grpSharing.Controls.Add(this.chkLookForShared);
-			this.grpSharing.Dock = System.Windows.Forms.DockStyle.Top;
-			this.grpSharing.Location = new System.Drawing.Point(0, 509);
-			this.grpSharing.Name = "grpSharing";
-			this.grpSharing.Size = new System.Drawing.Size(498, 401);
-			this.grpSharing.TabIndex = 1;
-			this.grpSharing.Text = "Sharing";
-			// 
-			// chkAutoConnectShares
-			// 
-			this.chkAutoConnectShares.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.chkAutoConnectShares.AutoSize = true;
-			this.chkAutoConnectShares.Location = new System.Drawing.Point(261, 36);
-			this.chkAutoConnectShares.Name = "chkAutoConnectShares";
-			this.chkAutoConnectShares.Size = new System.Drawing.Size(130, 17);
-			this.chkAutoConnectShares.TabIndex = 1;
-			this.chkAutoConnectShares.Text = "Connect automatically";
-			this.chkAutoConnectShares.UseVisualStyleBackColor = true;
-			// 
-			// btRemoveShare
-			// 
-			this.btRemoveShare.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btRemoveShare.Location = new System.Drawing.Point(398, 89);
-			this.btRemoveShare.Name = "btRemoveShare";
-			this.btRemoveShare.Size = new System.Drawing.Size(92, 23);
-			this.btRemoveShare.TabIndex = 4;
-			this.btRemoveShare.Text = "Remove";
-			this.btRemoveShare.UseVisualStyleBackColor = true;
-			this.btRemoveShare.Click += new System.EventHandler(this.btRmoveShare_Click);
-			// 
-			// btAddShare
-			// 
-			this.btAddShare.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btAddShare.Location = new System.Drawing.Point(398, 61);
-			this.btAddShare.Name = "btAddShare";
-			this.btAddShare.Size = new System.Drawing.Size(92, 23);
-			this.btAddShare.TabIndex = 3;
-			this.btAddShare.Text = "Add Share";
-			this.btAddShare.UseVisualStyleBackColor = true;
-			this.btAddShare.Click += new System.EventHandler(this.btAddShare_Click);
-			// 
-			// tabShares
-			// 
-			this.tabShares.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.txPublicServerAddress.Location = new System.Drawing.Point(12, 60);
+            this.txPublicServerAddress.Name = "txPublicServerAddress";
+            this.txPublicServerAddress.Size = new System.Drawing.Size(379, 20);
+            this.txPublicServerAddress.TabIndex = 1;
+            // 
+            // grpSharing
+            // 
+            this.grpSharing.Controls.Add(this.chkAutoConnectShares);
+            this.grpSharing.Controls.Add(this.btRemoveShare);
+            this.grpSharing.Controls.Add(this.btAddShare);
+            this.grpSharing.Controls.Add(this.tabShares);
+            this.grpSharing.Controls.Add(this.chkLookForShared);
+            this.grpSharing.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpSharing.Location = new System.Drawing.Point(0, 509);
+            this.grpSharing.Name = "grpSharing";
+            this.grpSharing.Size = new System.Drawing.Size(498, 401);
+            this.grpSharing.TabIndex = 1;
+            this.grpSharing.Text = "Sharing";
+            // 
+            // chkAutoConnectShares
+            // 
+            this.chkAutoConnectShares.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.chkAutoConnectShares.AutoSize = true;
+            this.chkAutoConnectShares.Location = new System.Drawing.Point(261, 36);
+            this.chkAutoConnectShares.Name = "chkAutoConnectShares";
+            this.chkAutoConnectShares.Size = new System.Drawing.Size(130, 17);
+            this.chkAutoConnectShares.TabIndex = 1;
+            this.chkAutoConnectShares.Text = "Connect automatically";
+            this.chkAutoConnectShares.UseVisualStyleBackColor = true;
+            // 
+            // btRemoveShare
+            // 
+            this.btRemoveShare.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btRemoveShare.Location = new System.Drawing.Point(398, 89);
+            this.btRemoveShare.Name = "btRemoveShare";
+            this.btRemoveShare.Size = new System.Drawing.Size(92, 23);
+            this.btRemoveShare.TabIndex = 4;
+            this.btRemoveShare.Text = "Remove";
+            this.btRemoveShare.UseVisualStyleBackColor = true;
+            this.btRemoveShare.Click += new System.EventHandler(this.btRmoveShare_Click);
+            // 
+            // btAddShare
+            // 
+            this.btAddShare.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btAddShare.Location = new System.Drawing.Point(398, 61);
+            this.btAddShare.Name = "btAddShare";
+            this.btAddShare.Size = new System.Drawing.Size(92, 23);
+            this.btAddShare.TabIndex = 3;
+            this.btAddShare.Text = "Add Share";
+            this.btAddShare.UseVisualStyleBackColor = true;
+            this.btAddShare.Click += new System.EventHandler(this.btAddShare_Click);
+            // 
+            // tabShares
+            // 
+            this.tabShares.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.tabShares.Location = new System.Drawing.Point(12, 59);
-			this.tabShares.Name = "tabShares";
-			this.tabShares.SelectedIndex = 0;
-			this.tabShares.Size = new System.Drawing.Size(381, 336);
-			this.tabShares.TabIndex = 2;
-			// 
-			// chkLookForShared
-			// 
-			this.chkLookForShared.AutoSize = true;
-			this.chkLookForShared.Location = new System.Drawing.Point(12, 36);
-			this.chkLookForShared.Name = "chkLookForShared";
-			this.chkLookForShared.Size = new System.Drawing.Size(154, 17);
-			this.chkLookForShared.TabIndex = 0;
-			this.chkLookForShared.Text = "Look for local Book Shares";
-			this.chkLookForShared.UseVisualStyleBackColor = true;
-			// 
-			// groupLibraryDisplay
-			// 
-			this.groupLibraryDisplay.Controls.Add(this.chkLibraryGaugesTotal);
-			this.groupLibraryDisplay.Controls.Add(this.chkLibraryGaugesUnread);
-			this.groupLibraryDisplay.Controls.Add(this.chkLibraryGaugesNumeric);
-			this.groupLibraryDisplay.Controls.Add(this.chkLibraryGaugesNew);
-			this.groupLibraryDisplay.Controls.Add(this.chkLibraryGauges);
-			this.groupLibraryDisplay.Dock = System.Windows.Forms.DockStyle.Top;
-			this.groupLibraryDisplay.Location = new System.Drawing.Point(0, 339);
-			this.groupLibraryDisplay.Name = "groupLibraryDisplay";
-			this.groupLibraryDisplay.Size = new System.Drawing.Size(498, 170);
-			this.groupLibraryDisplay.TabIndex = 4;
-			this.groupLibraryDisplay.Text = "Display";
-			// 
-			// chkLibraryGaugesTotal
-			// 
-			this.chkLibraryGaugesTotal.AutoSize = true;
-			this.chkLibraryGaugesTotal.Location = new System.Drawing.Point(33, 111);
-			this.chkLibraryGaugesTotal.Name = "chkLibraryGaugesTotal";
-			this.chkLibraryGaugesTotal.Size = new System.Drawing.Size(113, 17);
-			this.chkLibraryGaugesTotal.TabIndex = 1;
-			this.chkLibraryGaugesTotal.Text = "For Total of Books";
-			this.chkLibraryGaugesTotal.UseVisualStyleBackColor = true;
-			// 
-			// chkLibraryGaugesUnread
-			// 
-			this.chkLibraryGaugesUnread.AutoSize = true;
-			this.chkLibraryGaugesUnread.Location = new System.Drawing.Point(33, 92);
-			this.chkLibraryGaugesUnread.Name = "chkLibraryGaugesUnread";
-			this.chkLibraryGaugesUnread.Size = new System.Drawing.Size(112, 17);
-			this.chkLibraryGaugesUnread.TabIndex = 1;
-			this.chkLibraryGaugesUnread.Text = "For Unread Books";
-			this.chkLibraryGaugesUnread.UseVisualStyleBackColor = true;
-			// 
-			// chkLibraryGaugesNumeric
-			// 
-			this.chkLibraryGaugesNumeric.AutoSize = true;
-			this.chkLibraryGaugesNumeric.Location = new System.Drawing.Point(33, 131);
-			this.chkLibraryGaugesNumeric.Name = "chkLibraryGaugesNumeric";
-			this.chkLibraryGaugesNumeric.Size = new System.Drawing.Size(201, 17);
-			this.chkLibraryGaugesNumeric.TabIndex = 1;
-			this.chkLibraryGaugesNumeric.Text = "Also show numbers and not only bars";
-			this.chkLibraryGaugesNumeric.UseVisualStyleBackColor = true;
-			// 
-			// chkLibraryGaugesNew
-			// 
-			this.chkLibraryGaugesNew.AutoSize = true;
-			this.chkLibraryGaugesNew.Location = new System.Drawing.Point(33, 72);
-			this.chkLibraryGaugesNew.Name = "chkLibraryGaugesNew";
-			this.chkLibraryGaugesNew.Size = new System.Drawing.Size(99, 17);
-			this.chkLibraryGaugesNew.TabIndex = 1;
-			this.chkLibraryGaugesNew.Text = "For New Books";
-			this.chkLibraryGaugesNew.UseVisualStyleBackColor = true;
-			// 
-			// chkLibraryGauges
-			// 
-			this.chkLibraryGauges.AutoSize = true;
-			this.chkLibraryGauges.Location = new System.Drawing.Point(12, 42);
-			this.chkLibraryGauges.Name = "chkLibraryGauges";
-			this.chkLibraryGauges.Size = new System.Drawing.Size(127, 17);
-			this.chkLibraryGauges.TabIndex = 0;
-			this.chkLibraryGauges.Text = "Enable Live Counters";
-			this.chkLibraryGauges.UseVisualStyleBackColor = true;
-			this.chkLibraryGauges.CheckedChanged += new System.EventHandler(this.chkLibraryGauges_CheckedChanged);
-			// 
-			// grpScanning
-			// 
-			this.grpScanning.Controls.Add(this.chkDontAddRemovedFiles);
-			this.grpScanning.Controls.Add(this.chkAutoRemoveMissing);
-			this.grpScanning.Controls.Add(this.lblScan);
-			this.grpScanning.Controls.Add(this.btScan);
-			this.grpScanning.Dock = System.Windows.Forms.DockStyle.Top;
-			this.grpScanning.Location = new System.Drawing.Point(0, 203);
-			this.grpScanning.Name = "grpScanning";
-			this.grpScanning.Size = new System.Drawing.Size(498, 136);
-			this.grpScanning.TabIndex = 0;
-			this.grpScanning.Text = "Scanning";
-			// 
-			// chkDontAddRemovedFiles
-			// 
-			this.chkDontAddRemovedFiles.AutoSize = true;
-			this.chkDontAddRemovedFiles.CheckAlign = System.Drawing.ContentAlignment.TopLeft;
-			this.chkDontAddRemovedFiles.Location = new System.Drawing.Point(12, 58);
-			this.chkDontAddRemovedFiles.Name = "chkDontAddRemovedFiles";
-			this.chkDontAddRemovedFiles.Size = new System.Drawing.Size(322, 17);
-			this.chkDontAddRemovedFiles.TabIndex = 1;
-			this.chkDontAddRemovedFiles.Text = "Files manually removed from the Library will not be added again";
-			this.chkDontAddRemovedFiles.TextAlign = System.Drawing.ContentAlignment.TopLeft;
-			this.chkDontAddRemovedFiles.UseVisualStyleBackColor = true;
-			// 
-			// chkAutoRemoveMissing
-			// 
-			this.chkAutoRemoveMissing.AutoSize = true;
-			this.chkAutoRemoveMissing.CheckAlign = System.Drawing.ContentAlignment.TopLeft;
-			this.chkAutoRemoveMissing.Location = new System.Drawing.Point(12, 35);
-			this.chkAutoRemoveMissing.Name = "chkAutoRemoveMissing";
-			this.chkAutoRemoveMissing.Size = new System.Drawing.Size(301, 17);
-			this.chkAutoRemoveMissing.TabIndex = 0;
-			this.chkAutoRemoveMissing.Text = "Automatically remove missing files from Library during Scan";
-			this.chkAutoRemoveMissing.TextAlign = System.Drawing.ContentAlignment.TopLeft;
-			this.chkAutoRemoveMissing.UseVisualStyleBackColor = true;
-			// 
-			// lblScan
-			// 
-			this.lblScan.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.tabShares.Location = new System.Drawing.Point(12, 59);
+            this.tabShares.Name = "tabShares";
+            this.tabShares.SelectedIndex = 0;
+            this.tabShares.Size = new System.Drawing.Size(381, 336);
+            this.tabShares.TabIndex = 2;
+            // 
+            // chkLookForShared
+            // 
+            this.chkLookForShared.AutoSize = true;
+            this.chkLookForShared.Location = new System.Drawing.Point(12, 36);
+            this.chkLookForShared.Name = "chkLookForShared";
+            this.chkLookForShared.Size = new System.Drawing.Size(154, 17);
+            this.chkLookForShared.TabIndex = 0;
+            this.chkLookForShared.Text = "Look for local Book Shares";
+            this.chkLookForShared.UseVisualStyleBackColor = true;
+            // 
+            // groupLibraryDisplay
+            // 
+            this.groupLibraryDisplay.Controls.Add(this.chkLibraryGaugesTotal);
+            this.groupLibraryDisplay.Controls.Add(this.chkLibraryGaugesUnread);
+            this.groupLibraryDisplay.Controls.Add(this.chkLibraryGaugesNumeric);
+            this.groupLibraryDisplay.Controls.Add(this.chkLibraryGaugesNew);
+            this.groupLibraryDisplay.Controls.Add(this.chkLibraryGauges);
+            this.groupLibraryDisplay.Dock = System.Windows.Forms.DockStyle.Top;
+            this.groupLibraryDisplay.Location = new System.Drawing.Point(0, 339);
+            this.groupLibraryDisplay.Name = "groupLibraryDisplay";
+            this.groupLibraryDisplay.Size = new System.Drawing.Size(498, 170);
+            this.groupLibraryDisplay.TabIndex = 4;
+            this.groupLibraryDisplay.Text = "Display";
+            // 
+            // chkLibraryGaugesTotal
+            // 
+            this.chkLibraryGaugesTotal.AutoSize = true;
+            this.chkLibraryGaugesTotal.Location = new System.Drawing.Point(33, 111);
+            this.chkLibraryGaugesTotal.Name = "chkLibraryGaugesTotal";
+            this.chkLibraryGaugesTotal.Size = new System.Drawing.Size(113, 17);
+            this.chkLibraryGaugesTotal.TabIndex = 1;
+            this.chkLibraryGaugesTotal.Text = "For Total of Books";
+            this.chkLibraryGaugesTotal.UseVisualStyleBackColor = true;
+            // 
+            // chkLibraryGaugesUnread
+            // 
+            this.chkLibraryGaugesUnread.AutoSize = true;
+            this.chkLibraryGaugesUnread.Location = new System.Drawing.Point(33, 92);
+            this.chkLibraryGaugesUnread.Name = "chkLibraryGaugesUnread";
+            this.chkLibraryGaugesUnread.Size = new System.Drawing.Size(112, 17);
+            this.chkLibraryGaugesUnread.TabIndex = 1;
+            this.chkLibraryGaugesUnread.Text = "For Unread Books";
+            this.chkLibraryGaugesUnread.UseVisualStyleBackColor = true;
+            // 
+            // chkLibraryGaugesNumeric
+            // 
+            this.chkLibraryGaugesNumeric.AutoSize = true;
+            this.chkLibraryGaugesNumeric.Location = new System.Drawing.Point(33, 131);
+            this.chkLibraryGaugesNumeric.Name = "chkLibraryGaugesNumeric";
+            this.chkLibraryGaugesNumeric.Size = new System.Drawing.Size(201, 17);
+            this.chkLibraryGaugesNumeric.TabIndex = 1;
+            this.chkLibraryGaugesNumeric.Text = "Also show numbers and not only bars";
+            this.chkLibraryGaugesNumeric.UseVisualStyleBackColor = true;
+            // 
+            // chkLibraryGaugesNew
+            // 
+            this.chkLibraryGaugesNew.AutoSize = true;
+            this.chkLibraryGaugesNew.Location = new System.Drawing.Point(33, 72);
+            this.chkLibraryGaugesNew.Name = "chkLibraryGaugesNew";
+            this.chkLibraryGaugesNew.Size = new System.Drawing.Size(99, 17);
+            this.chkLibraryGaugesNew.TabIndex = 1;
+            this.chkLibraryGaugesNew.Text = "For New Books";
+            this.chkLibraryGaugesNew.UseVisualStyleBackColor = true;
+            // 
+            // chkLibraryGauges
+            // 
+            this.chkLibraryGauges.AutoSize = true;
+            this.chkLibraryGauges.Location = new System.Drawing.Point(12, 42);
+            this.chkLibraryGauges.Name = "chkLibraryGauges";
+            this.chkLibraryGauges.Size = new System.Drawing.Size(127, 17);
+            this.chkLibraryGauges.TabIndex = 0;
+            this.chkLibraryGauges.Text = "Enable Live Counters";
+            this.chkLibraryGauges.UseVisualStyleBackColor = true;
+            this.chkLibraryGauges.CheckedChanged += new System.EventHandler(this.chkLibraryGauges_CheckedChanged);
+            // 
+            // grpScanning
+            // 
+            this.grpScanning.Controls.Add(this.chkDontAddRemovedFiles);
+            this.grpScanning.Controls.Add(this.chkAutoRemoveMissing);
+            this.grpScanning.Controls.Add(this.lblScan);
+            this.grpScanning.Controls.Add(this.btScan);
+            this.grpScanning.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpScanning.Location = new System.Drawing.Point(0, 203);
+            this.grpScanning.Name = "grpScanning";
+            this.grpScanning.Size = new System.Drawing.Size(498, 136);
+            this.grpScanning.TabIndex = 0;
+            this.grpScanning.Text = "Scanning";
+            // 
+            // chkDontAddRemovedFiles
+            // 
+            this.chkDontAddRemovedFiles.AutoSize = true;
+            this.chkDontAddRemovedFiles.CheckAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chkDontAddRemovedFiles.Location = new System.Drawing.Point(12, 58);
+            this.chkDontAddRemovedFiles.Name = "chkDontAddRemovedFiles";
+            this.chkDontAddRemovedFiles.Size = new System.Drawing.Size(322, 17);
+            this.chkDontAddRemovedFiles.TabIndex = 1;
+            this.chkDontAddRemovedFiles.Text = "Files manually removed from the Library will not be added again";
+            this.chkDontAddRemovedFiles.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chkDontAddRemovedFiles.UseVisualStyleBackColor = true;
+            // 
+            // chkAutoRemoveMissing
+            // 
+            this.chkAutoRemoveMissing.AutoSize = true;
+            this.chkAutoRemoveMissing.CheckAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chkAutoRemoveMissing.Location = new System.Drawing.Point(12, 35);
+            this.chkAutoRemoveMissing.Name = "chkAutoRemoveMissing";
+            this.chkAutoRemoveMissing.Size = new System.Drawing.Size(301, 17);
+            this.chkAutoRemoveMissing.TabIndex = 0;
+            this.chkAutoRemoveMissing.Text = "Automatically remove missing files from Library during Scan";
+            this.chkAutoRemoveMissing.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chkAutoRemoveMissing.UseVisualStyleBackColor = true;
+            // 
+            // lblScan
+            // 
+            this.lblScan.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.lblScan.Location = new System.Drawing.Point(9, 83);
-			this.lblScan.Name = "lblScan";
-			this.lblScan.Size = new System.Drawing.Size(480, 43);
-			this.lblScan.TabIndex = 8;
-			this.lblScan.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// btScan
-			// 
-			this.btScan.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btScan.Location = new System.Drawing.Point(403, 33);
-			this.btScan.Name = "btScan";
-			this.btScan.Size = new System.Drawing.Size(88, 23);
-			this.btScan.TabIndex = 2;
-			this.btScan.Text = "Scan";
-			this.btScan.UseVisualStyleBackColor = true;
-			this.btScan.Click += new System.EventHandler(this.btScan_Click);
-			// 
-			// groupComicFolders
-			// 
-			this.groupComicFolders.Controls.Add(this.btOpenFolder);
-			this.groupComicFolders.Controls.Add(this.btChangeFolder);
-			this.groupComicFolders.Controls.Add(this.lbPaths);
-			this.groupComicFolders.Controls.Add(this.labelWatchedFolders);
-			this.groupComicFolders.Controls.Add(this.btRemoveFolder);
-			this.groupComicFolders.Controls.Add(this.btAddFolder);
-			this.groupComicFolders.Dock = System.Windows.Forms.DockStyle.Top;
-			this.groupComicFolders.Location = new System.Drawing.Point(0, 0);
-			this.groupComicFolders.Name = "groupComicFolders";
-			this.groupComicFolders.Size = new System.Drawing.Size(498, 203);
-			this.groupComicFolders.TabIndex = 0;
-			this.groupComicFolders.Text = "Book Folders";
-			// 
-			// btOpenFolder
-			// 
-			this.btOpenFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btOpenFolder.Location = new System.Drawing.Point(400, 134);
-			this.btOpenFolder.Name = "btOpenFolder";
-			this.btOpenFolder.Size = new System.Drawing.Size(89, 23);
-			this.btOpenFolder.TabIndex = 4;
-			this.btOpenFolder.Text = "Open";
-			this.btOpenFolder.UseVisualStyleBackColor = true;
-			this.btOpenFolder.Click += new System.EventHandler(this.btOpenFolder_Click);
-			// 
-			// btChangeFolder
-			// 
-			this.btChangeFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btChangeFolder.Location = new System.Drawing.Point(400, 66);
-			this.btChangeFolder.Name = "btChangeFolder";
-			this.btChangeFolder.Size = new System.Drawing.Size(89, 23);
-			this.btChangeFolder.TabIndex = 2;
-			this.btChangeFolder.Text = "&Change...";
-			this.btChangeFolder.UseVisualStyleBackColor = true;
-			this.btChangeFolder.Click += new System.EventHandler(this.btChangeFolder_Click);
-			// 
-			// lbPaths
-			// 
-			this.lbPaths.AllowDrop = true;
-			this.lbPaths.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.lblScan.Location = new System.Drawing.Point(9, 83);
+            this.lblScan.Name = "lblScan";
+            this.lblScan.Size = new System.Drawing.Size(480, 43);
+            this.lblScan.TabIndex = 8;
+            this.lblScan.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // btScan
+            // 
+            this.btScan.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btScan.Location = new System.Drawing.Point(403, 33);
+            this.btScan.Name = "btScan";
+            this.btScan.Size = new System.Drawing.Size(88, 23);
+            this.btScan.TabIndex = 2;
+            this.btScan.Text = "Scan";
+            this.btScan.UseVisualStyleBackColor = true;
+            this.btScan.Click += new System.EventHandler(this.btScan_Click);
+            // 
+            // groupComicFolders
+            // 
+            this.groupComicFolders.Controls.Add(this.btOpenFolder);
+            this.groupComicFolders.Controls.Add(this.btChangeFolder);
+            this.groupComicFolders.Controls.Add(this.lbPaths);
+            this.groupComicFolders.Controls.Add(this.labelWatchedFolders);
+            this.groupComicFolders.Controls.Add(this.btRemoveFolder);
+            this.groupComicFolders.Controls.Add(this.btAddFolder);
+            this.groupComicFolders.Dock = System.Windows.Forms.DockStyle.Top;
+            this.groupComicFolders.Location = new System.Drawing.Point(0, 0);
+            this.groupComicFolders.Name = "groupComicFolders";
+            this.groupComicFolders.Size = new System.Drawing.Size(498, 203);
+            this.groupComicFolders.TabIndex = 0;
+            this.groupComicFolders.Text = "Book Folders";
+            // 
+            // btOpenFolder
+            // 
+            this.btOpenFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btOpenFolder.Location = new System.Drawing.Point(400, 134);
+            this.btOpenFolder.Name = "btOpenFolder";
+            this.btOpenFolder.Size = new System.Drawing.Size(89, 23);
+            this.btOpenFolder.TabIndex = 4;
+            this.btOpenFolder.Text = "Open";
+            this.btOpenFolder.UseVisualStyleBackColor = true;
+            this.btOpenFolder.Click += new System.EventHandler(this.btOpenFolder_Click);
+            // 
+            // btChangeFolder
+            // 
+            this.btChangeFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btChangeFolder.Location = new System.Drawing.Point(400, 66);
+            this.btChangeFolder.Name = "btChangeFolder";
+            this.btChangeFolder.Size = new System.Drawing.Size(89, 23);
+            this.btChangeFolder.TabIndex = 2;
+            this.btChangeFolder.Text = "&Change...";
+            this.btChangeFolder.UseVisualStyleBackColor = true;
+            this.btChangeFolder.Click += new System.EventHandler(this.btChangeFolder_Click);
+            // 
+            // lbPaths
+            // 
+            this.lbPaths.AllowDrop = true;
+            this.lbPaths.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.lbPaths.FormattingEnabled = true;
-			this.lbPaths.IntegralHeight = false;
-			this.lbPaths.Location = new System.Drawing.Point(12, 37);
-			this.lbPaths.Name = "lbPaths";
-			this.lbPaths.Size = new System.Drawing.Size(377, 120);
-			this.lbPaths.TabIndex = 0;
-			this.lbPaths.DrawItemText += new System.Windows.Forms.DrawItemEventHandler(this.lbPaths_DrawItemText);
-			this.lbPaths.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.lbPaths_DrawItem);
-			this.lbPaths.SelectedIndexChanged += new System.EventHandler(this.lbPaths_SelectedIndexChanged);
-			this.lbPaths.DragDrop += new System.Windows.Forms.DragEventHandler(this.lbPaths_DragDrop);
-			this.lbPaths.DragOver += new System.Windows.Forms.DragEventHandler(this.lbPaths_DragOver);
-			// 
-			// labelWatchedFolders
-			// 
-			this.labelWatchedFolders.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.lbPaths.FormattingEnabled = true;
+            this.lbPaths.IntegralHeight = false;
+            this.lbPaths.Location = new System.Drawing.Point(12, 37);
+            this.lbPaths.Name = "lbPaths";
+            this.lbPaths.Size = new System.Drawing.Size(377, 120);
+            this.lbPaths.TabIndex = 0;
+            this.lbPaths.DrawItemText += new System.Windows.Forms.DrawItemEventHandler(this.lbPaths_DrawItemText);
+            this.lbPaths.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.lbPaths_DrawItem);
+            this.lbPaths.SelectedIndexChanged += new System.EventHandler(this.lbPaths_SelectedIndexChanged);
+            this.lbPaths.DragDrop += new System.Windows.Forms.DragEventHandler(this.lbPaths_DragDrop);
+            this.lbPaths.DragOver += new System.Windows.Forms.DragEventHandler(this.lbPaths_DragOver);
+            // 
+            // labelWatchedFolders
+            // 
+            this.labelWatchedFolders.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.labelWatchedFolders.Location = new System.Drawing.Point(9, 163);
-			this.labelWatchedFolders.Name = "labelWatchedFolders";
-			this.labelWatchedFolders.Size = new System.Drawing.Size(480, 26);
-			this.labelWatchedFolders.TabIndex = 0;
-			this.labelWatchedFolders.Text = "Checked folders will be watched for changes (rename, move) while the program is r" +
+            this.labelWatchedFolders.Location = new System.Drawing.Point(9, 163);
+            this.labelWatchedFolders.Name = "labelWatchedFolders";
+            this.labelWatchedFolders.Size = new System.Drawing.Size(480, 26);
+            this.labelWatchedFolders.TabIndex = 0;
+            this.labelWatchedFolders.Text = "Checked folders will be watched for changes (rename, move) while the program is r" +
     "unning.";
-			this.labelWatchedFolders.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
-			// 
-			// btRemoveFolder
-			// 
-			this.btRemoveFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btRemoveFolder.Location = new System.Drawing.Point(400, 95);
-			this.btRemoveFolder.Name = "btRemoveFolder";
-			this.btRemoveFolder.Size = new System.Drawing.Size(89, 23);
-			this.btRemoveFolder.TabIndex = 3;
-			this.btRemoveFolder.Text = "&Remove";
-			this.btRemoveFolder.UseVisualStyleBackColor = true;
-			this.btRemoveFolder.Click += new System.EventHandler(this.btRemoveFolder_Click);
-			// 
-			// btAddFolder
-			// 
-			this.btAddFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btAddFolder.Location = new System.Drawing.Point(400, 37);
-			this.btAddFolder.Name = "btAddFolder";
-			this.btAddFolder.Size = new System.Drawing.Size(89, 23);
-			this.btAddFolder.TabIndex = 1;
-			this.btAddFolder.Text = "&Add...";
-			this.btAddFolder.UseVisualStyleBackColor = true;
-			this.btAddFolder.Click += new System.EventHandler(this.btAddFolder_Click);
-			// 
-			// memCacheUpate
-			// 
-			this.memCacheUpate.Enabled = true;
-			this.memCacheUpate.Interval = 1000;
-			this.memCacheUpate.Tick += new System.EventHandler(this.memCacheUpate_Tick);
-			// 
-			// pageScripts
-			// 
-			this.pageScripts.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.labelWatchedFolders.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
+            // 
+            // btRemoveFolder
+            // 
+            this.btRemoveFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btRemoveFolder.Location = new System.Drawing.Point(400, 95);
+            this.btRemoveFolder.Name = "btRemoveFolder";
+            this.btRemoveFolder.Size = new System.Drawing.Size(89, 23);
+            this.btRemoveFolder.TabIndex = 3;
+            this.btRemoveFolder.Text = "&Remove";
+            this.btRemoveFolder.UseVisualStyleBackColor = true;
+            this.btRemoveFolder.Click += new System.EventHandler(this.btRemoveFolder_Click);
+            // 
+            // btAddFolder
+            // 
+            this.btAddFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btAddFolder.Location = new System.Drawing.Point(400, 37);
+            this.btAddFolder.Name = "btAddFolder";
+            this.btAddFolder.Size = new System.Drawing.Size(89, 23);
+            this.btAddFolder.TabIndex = 1;
+            this.btAddFolder.Text = "&Add...";
+            this.btAddFolder.UseVisualStyleBackColor = true;
+            this.btAddFolder.Click += new System.EventHandler(this.btAddFolder_Click);
+            // 
+            // memCacheUpate
+            // 
+            this.memCacheUpate.Enabled = true;
+            this.memCacheUpate.Interval = 1000;
+            this.memCacheUpate.Tick += new System.EventHandler(this.memCacheUpate_Tick);
+            // 
+            // pageScripts
+            // 
+            this.pageScripts.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.pageScripts.AutoScroll = true;
-			this.pageScripts.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.pageScripts.Controls.Add(this.grpScriptSettings);
-			this.pageScripts.Controls.Add(this.grpScripts);
-			this.pageScripts.Controls.Add(this.grpPackages);
-			this.pageScripts.Location = new System.Drawing.Point(84, 8);
-			this.pageScripts.Name = "pageScripts";
-			this.pageScripts.Size = new System.Drawing.Size(517, 408);
-			this.pageScripts.TabIndex = 11;
-			// 
-			// grpScriptSettings
-			// 
-			this.grpScriptSettings.Controls.Add(this.btAddLibraryFolder);
-			this.grpScriptSettings.Controls.Add(this.chkDisableScripting);
-			this.grpScriptSettings.Controls.Add(this.labelScriptPaths);
-			this.grpScriptSettings.Controls.Add(this.txLibraries);
-			this.grpScriptSettings.Dock = System.Windows.Forms.DockStyle.Top;
-			this.grpScriptSettings.Location = new System.Drawing.Point(0, 752);
-			this.grpScriptSettings.Name = "grpScriptSettings";
-			this.grpScriptSettings.Size = new System.Drawing.Size(498, 192);
-			this.grpScriptSettings.TabIndex = 5;
-			this.grpScriptSettings.Text = "Script Settings";
-			// 
-			// btAddLibraryFolder
-			// 
-			this.btAddLibraryFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btAddLibraryFolder.Location = new System.Drawing.Point(369, 163);
-			this.btAddLibraryFolder.Name = "btAddLibraryFolder";
-			this.btAddLibraryFolder.Size = new System.Drawing.Size(121, 23);
-			this.btAddLibraryFolder.TabIndex = 3;
-			this.btAddLibraryFolder.Text = "Add Folder...";
-			this.btAddLibraryFolder.UseVisualStyleBackColor = true;
-			this.btAddLibraryFolder.Click += new System.EventHandler(this.btAddLibraryFolder_Click);
-			// 
-			// chkDisableScripting
-			// 
-			this.chkDisableScripting.AutoSize = true;
-			this.chkDisableScripting.Location = new System.Drawing.Point(9, 39);
-			this.chkDisableScripting.Name = "chkDisableScripting";
-			this.chkDisableScripting.Size = new System.Drawing.Size(109, 17);
-			this.chkDisableScripting.TabIndex = 0;
-			this.chkDisableScripting.Text = "Disable all Scripts";
-			this.chkDisableScripting.UseVisualStyleBackColor = true;
-			// 
-			// labelScriptPaths
-			// 
-			this.labelScriptPaths.Location = new System.Drawing.Point(6, 60);
-			this.labelScriptPaths.Name = "labelScriptPaths";
-			this.labelScriptPaths.Size = new System.Drawing.Size(478, 29);
-			this.labelScriptPaths.TabIndex = 1;
-			this.labelScriptPaths.Text = "Semicolon separated list of library paths for scripts (e.g. python libraries):";
-			this.labelScriptPaths.TextAlign = System.Drawing.ContentAlignment.BottomLeft;
-			// 
-			// txLibraries
-			// 
-			this.txLibraries.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.pageScripts.AutoScroll = true;
+            this.pageScripts.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.pageScripts.Controls.Add(this.grpScriptSettings);
+            this.pageScripts.Controls.Add(this.grpScripts);
+            this.pageScripts.Controls.Add(this.grpPackages);
+            this.pageScripts.Location = new System.Drawing.Point(84, 8);
+            this.pageScripts.Name = "pageScripts";
+            this.pageScripts.Size = new System.Drawing.Size(517, 408);
+            this.pageScripts.TabIndex = 11;
+            // 
+            // grpScriptSettings
+            // 
+            this.grpScriptSettings.Controls.Add(this.btAddLibraryFolder);
+            this.grpScriptSettings.Controls.Add(this.chkDisableScripting);
+            this.grpScriptSettings.Controls.Add(this.labelScriptPaths);
+            this.grpScriptSettings.Controls.Add(this.txLibraries);
+            this.grpScriptSettings.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpScriptSettings.Location = new System.Drawing.Point(0, 752);
+            this.grpScriptSettings.Name = "grpScriptSettings";
+            this.grpScriptSettings.Size = new System.Drawing.Size(498, 192);
+            this.grpScriptSettings.TabIndex = 5;
+            this.grpScriptSettings.Text = "Script Settings";
+            // 
+            // btAddLibraryFolder
+            // 
+            this.btAddLibraryFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btAddLibraryFolder.Location = new System.Drawing.Point(369, 163);
+            this.btAddLibraryFolder.Name = "btAddLibraryFolder";
+            this.btAddLibraryFolder.Size = new System.Drawing.Size(121, 23);
+            this.btAddLibraryFolder.TabIndex = 3;
+            this.btAddLibraryFolder.Text = "Add Folder...";
+            this.btAddLibraryFolder.UseVisualStyleBackColor = true;
+            this.btAddLibraryFolder.Click += new System.EventHandler(this.btAddLibraryFolder_Click);
+            // 
+            // chkDisableScripting
+            // 
+            this.chkDisableScripting.AutoSize = true;
+            this.chkDisableScripting.Location = new System.Drawing.Point(9, 39);
+            this.chkDisableScripting.Name = "chkDisableScripting";
+            this.chkDisableScripting.Size = new System.Drawing.Size(109, 17);
+            this.chkDisableScripting.TabIndex = 0;
+            this.chkDisableScripting.Text = "Disable all Scripts";
+            this.chkDisableScripting.UseVisualStyleBackColor = true;
+            // 
+            // labelScriptPaths
+            // 
+            this.labelScriptPaths.Location = new System.Drawing.Point(6, 60);
+            this.labelScriptPaths.Name = "labelScriptPaths";
+            this.labelScriptPaths.Size = new System.Drawing.Size(478, 29);
+            this.labelScriptPaths.TabIndex = 1;
+            this.labelScriptPaths.Text = "Semicolon separated list of library paths for scripts (e.g. python libraries):";
+            this.labelScriptPaths.TextAlign = System.Drawing.ContentAlignment.BottomLeft;
+            // 
+            // txLibraries
+            // 
+            this.txLibraries.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txLibraries.Location = new System.Drawing.Point(7, 92);
-			this.txLibraries.Multiline = true;
-			this.txLibraries.Name = "txLibraries";
-			this.txLibraries.Size = new System.Drawing.Size(482, 63);
-			this.txLibraries.TabIndex = 2;
-			// 
-			// grpScripts
-			// 
-			this.grpScripts.Controls.Add(this.chkHideSampleScripts);
-			this.grpScripts.Controls.Add(this.btConfigScript);
-			this.grpScripts.Controls.Add(this.lvScripts);
-			this.grpScripts.Dock = System.Windows.Forms.DockStyle.Top;
-			this.grpScripts.Location = new System.Drawing.Point(0, 378);
-			this.grpScripts.Name = "grpScripts";
-			this.grpScripts.Size = new System.Drawing.Size(498, 374);
-			this.grpScripts.TabIndex = 4;
-			this.grpScripts.Text = "Available Scripts";
-			// 
-			// chkHideSampleScripts
-			// 
-			this.chkHideSampleScripts.AutoSize = true;
-			this.chkHideSampleScripts.Location = new System.Drawing.Point(9, 345);
-			this.chkHideSampleScripts.Name = "chkHideSampleScripts";
-			this.chkHideSampleScripts.Size = new System.Drawing.Size(119, 17);
-			this.chkHideSampleScripts.TabIndex = 8;
-			this.chkHideSampleScripts.Text = "Hide sample Scripts";
-			this.chkHideSampleScripts.UseVisualStyleBackColor = true;
-			this.chkHideSampleScripts.CheckedChanged += new System.EventHandler(this.chkHideSampleScripts_CheckedChanged);
-			// 
-			// btConfigScript
-			// 
-			this.btConfigScript.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btConfigScript.Enabled = false;
-			this.btConfigScript.Location = new System.Drawing.Point(398, 339);
-			this.btConfigScript.Name = "btConfigScript";
-			this.btConfigScript.Size = new System.Drawing.Size(87, 23);
-			this.btConfigScript.TabIndex = 7;
-			this.btConfigScript.Text = "Configure...";
-			this.btConfigScript.UseVisualStyleBackColor = true;
-			this.btConfigScript.Click += new System.EventHandler(this.btConfigScript_Click);
-			// 
-			// lvScripts
-			// 
-			this.lvScripts.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.txLibraries.Location = new System.Drawing.Point(7, 92);
+            this.txLibraries.Multiline = true;
+            this.txLibraries.Name = "txLibraries";
+            this.txLibraries.Size = new System.Drawing.Size(482, 63);
+            this.txLibraries.TabIndex = 2;
+            // 
+            // grpScripts
+            // 
+            this.grpScripts.Controls.Add(this.chkHideSampleScripts);
+            this.grpScripts.Controls.Add(this.btConfigScript);
+            this.grpScripts.Controls.Add(this.lvScripts);
+            this.grpScripts.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpScripts.Location = new System.Drawing.Point(0, 378);
+            this.grpScripts.Name = "grpScripts";
+            this.grpScripts.Size = new System.Drawing.Size(498, 374);
+            this.grpScripts.TabIndex = 4;
+            this.grpScripts.Text = "Available Scripts";
+            // 
+            // chkHideSampleScripts
+            // 
+            this.chkHideSampleScripts.AutoSize = true;
+            this.chkHideSampleScripts.Location = new System.Drawing.Point(9, 345);
+            this.chkHideSampleScripts.Name = "chkHideSampleScripts";
+            this.chkHideSampleScripts.Size = new System.Drawing.Size(119, 17);
+            this.chkHideSampleScripts.TabIndex = 8;
+            this.chkHideSampleScripts.Text = "Hide sample Scripts";
+            this.chkHideSampleScripts.UseVisualStyleBackColor = true;
+            this.chkHideSampleScripts.CheckedChanged += new System.EventHandler(this.chkHideSampleScripts_CheckedChanged);
+            // 
+            // btConfigScript
+            // 
+            this.btConfigScript.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btConfigScript.Enabled = false;
+            this.btConfigScript.Location = new System.Drawing.Point(398, 339);
+            this.btConfigScript.Name = "btConfigScript";
+            this.btConfigScript.Size = new System.Drawing.Size(87, 23);
+            this.btConfigScript.TabIndex = 7;
+            this.btConfigScript.Text = "Configure...";
+            this.btConfigScript.UseVisualStyleBackColor = true;
+            this.btConfigScript.Click += new System.EventHandler(this.btConfigScript_Click);
+            // 
+            // lvScripts
+            // 
+            this.lvScripts.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.lvScripts.CheckBoxes = true;
-			this.lvScripts.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.lvScripts.CheckBoxes = true;
+            this.lvScripts.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.chScriptName,
             this.chScriptPackage});
-			this.lvScripts.FullRowSelect = true;
-			this.lvScripts.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
-			this.lvScripts.HideSelection = false;
-			this.lvScripts.Location = new System.Drawing.Point(9, 42);
-			this.lvScripts.MultiSelect = false;
-			this.lvScripts.Name = "lvScripts";
-			this.lvScripts.ShowItemToolTips = true;
-			this.lvScripts.Size = new System.Drawing.Size(476, 291);
-			this.lvScripts.SmallImageList = this.imageList;
-			this.lvScripts.Sorting = System.Windows.Forms.SortOrder.Ascending;
-			this.lvScripts.TabIndex = 6;
-			this.lvScripts.UseCompatibleStateImageBehavior = false;
-			this.lvScripts.View = System.Windows.Forms.View.Details;
-			this.lvScripts.ItemChecked += new System.Windows.Forms.ItemCheckedEventHandler(this.lvScripts_ItemChecked);
-			this.lvScripts.SelectedIndexChanged += new System.EventHandler(this.lvScripts_SelectedIndexChanged);
-			// 
-			// chScriptName
-			// 
-			this.chScriptName.Text = "Name";
-			this.chScriptName.Width = 250;
-			// 
-			// chScriptPackage
-			// 
-			this.chScriptPackage.Text = "Package";
-			this.chScriptPackage.Width = 190;
-			// 
-			// grpPackages
-			// 
-			this.grpPackages.Controls.Add(this.btRemovePackage);
-			this.grpPackages.Controls.Add(this.btInstallPackage);
-			this.grpPackages.Controls.Add(this.lvPackages);
-			this.grpPackages.Dock = System.Windows.Forms.DockStyle.Top;
-			this.grpPackages.Location = new System.Drawing.Point(0, 0);
-			this.grpPackages.Name = "grpPackages";
-			this.grpPackages.Size = new System.Drawing.Size(498, 378);
-			this.grpPackages.TabIndex = 13;
-			this.grpPackages.Text = "Script Packages";
-			// 
-			// btRemovePackage
-			// 
-			this.btRemovePackage.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btRemovePackage.Location = new System.Drawing.Point(398, 344);
-			this.btRemovePackage.Name = "btRemovePackage";
-			this.btRemovePackage.Size = new System.Drawing.Size(86, 23);
-			this.btRemovePackage.TabIndex = 2;
-			this.btRemovePackage.Text = "Remove";
-			this.btRemovePackage.UseVisualStyleBackColor = true;
-			this.btRemovePackage.Click += new System.EventHandler(this.btRemovePackage_Click);
-			// 
-			// btInstallPackage
-			// 
-			this.btInstallPackage.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btInstallPackage.Location = new System.Drawing.Point(306, 344);
-			this.btInstallPackage.Name = "btInstallPackage";
-			this.btInstallPackage.Size = new System.Drawing.Size(86, 23);
-			this.btInstallPackage.TabIndex = 1;
-			this.btInstallPackage.Text = "Install...";
-			this.btInstallPackage.UseVisualStyleBackColor = true;
-			this.btInstallPackage.Click += new System.EventHandler(this.btInstallPackage_Click);
-			// 
-			// lvPackages
-			// 
-			this.lvPackages.AllowDrop = true;
-			this.lvPackages.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.lvScripts.FullRowSelect = true;
+            this.lvScripts.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.lvScripts.HideSelection = false;
+            this.lvScripts.Location = new System.Drawing.Point(9, 42);
+            this.lvScripts.MultiSelect = false;
+            this.lvScripts.Name = "lvScripts";
+            this.lvScripts.ShowItemToolTips = true;
+            this.lvScripts.Size = new System.Drawing.Size(476, 291);
+            this.lvScripts.SmallImageList = this.imageList;
+            this.lvScripts.Sorting = System.Windows.Forms.SortOrder.Ascending;
+            this.lvScripts.TabIndex = 6;
+            this.lvScripts.UseCompatibleStateImageBehavior = false;
+            this.lvScripts.View = System.Windows.Forms.View.Details;
+            this.lvScripts.ItemChecked += new System.Windows.Forms.ItemCheckedEventHandler(this.lvScripts_ItemChecked);
+            this.lvScripts.SelectedIndexChanged += new System.EventHandler(this.lvScripts_SelectedIndexChanged);
+            // 
+            // chScriptName
+            // 
+            this.chScriptName.Text = "Name";
+            this.chScriptName.Width = 250;
+            // 
+            // chScriptPackage
+            // 
+            this.chScriptPackage.Text = "Package";
+            this.chScriptPackage.Width = 190;
+            // 
+            // grpPackages
+            // 
+            this.grpPackages.Controls.Add(this.btRemovePackage);
+            this.grpPackages.Controls.Add(this.btInstallPackage);
+            this.grpPackages.Controls.Add(this.lvPackages);
+            this.grpPackages.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpPackages.Location = new System.Drawing.Point(0, 0);
+            this.grpPackages.Name = "grpPackages";
+            this.grpPackages.Size = new System.Drawing.Size(498, 378);
+            this.grpPackages.TabIndex = 13;
+            this.grpPackages.Text = "Script Packages";
+            // 
+            // btRemovePackage
+            // 
+            this.btRemovePackage.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btRemovePackage.Location = new System.Drawing.Point(398, 344);
+            this.btRemovePackage.Name = "btRemovePackage";
+            this.btRemovePackage.Size = new System.Drawing.Size(86, 23);
+            this.btRemovePackage.TabIndex = 2;
+            this.btRemovePackage.Text = "Remove";
+            this.btRemovePackage.UseVisualStyleBackColor = true;
+            this.btRemovePackage.Click += new System.EventHandler(this.btRemovePackage_Click);
+            // 
+            // btInstallPackage
+            // 
+            this.btInstallPackage.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btInstallPackage.Location = new System.Drawing.Point(306, 344);
+            this.btInstallPackage.Name = "btInstallPackage";
+            this.btInstallPackage.Size = new System.Drawing.Size(86, 23);
+            this.btInstallPackage.TabIndex = 1;
+            this.btInstallPackage.Text = "Install...";
+            this.btInstallPackage.UseVisualStyleBackColor = true;
+            this.btInstallPackage.Click += new System.EventHandler(this.btInstallPackage_Click);
+            // 
+            // lvPackages
+            // 
+            this.lvPackages.AllowDrop = true;
+            this.lvPackages.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.lvPackages.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.lvPackages.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.chPackageName,
             this.chPackageAuthor,
             this.chPackageDescription});
-			listViewGroup1.Header = "Installed";
-			listViewGroup1.Name = "packageGroupInstalled";
-			listViewGroup2.Header = "To be removed (requires restart)";
-			listViewGroup2.Name = "packageGroupRemove";
-			listViewGroup3.Header = "To be installed (requires restart)";
-			listViewGroup3.Name = "packageGroupInstall";
-			this.lvPackages.Groups.AddRange(new System.Windows.Forms.ListViewGroup[] {
-            listViewGroup1,
-            listViewGroup2,
-            listViewGroup3});
-			this.lvPackages.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
-			this.lvPackages.HideSelection = false;
-			this.lvPackages.LargeImageList = this.packageImageList;
-			this.lvPackages.Location = new System.Drawing.Point(16, 37);
-			this.lvPackages.Name = "lvPackages";
-			this.lvPackages.ShowItemToolTips = true;
-			this.lvPackages.Size = new System.Drawing.Size(468, 301);
-			this.lvPackages.SmallImageList = this.packageImageList;
-			this.lvPackages.Sorting = System.Windows.Forms.SortOrder.Ascending;
-			this.lvPackages.TabIndex = 0;
-			this.lvPackages.UseCompatibleStateImageBehavior = false;
-			this.lvPackages.View = System.Windows.Forms.View.Details;
-			this.lvPackages.DragDrop += new System.Windows.Forms.DragEventHandler(this.lvPackages_DragDrop);
-			this.lvPackages.DragOver += new System.Windows.Forms.DragEventHandler(this.lvPackages_DragOver);
-			this.lvPackages.DoubleClick += new System.EventHandler(this.lvPackages_DoubleClick);
-			// 
-			// chPackageName
-			// 
-			this.chPackageName.Text = "Package";
-			this.chPackageName.Width = 130;
-			// 
-			// chPackageAuthor
-			// 
-			this.chPackageAuthor.Text = "Author";
-			this.chPackageAuthor.Width = 89;
-			// 
-			// chPackageDescription
-			// 
-			this.chPackageDescription.Text = "Description";
-			this.chPackageDescription.Width = 217;
-			// 
-			// packageImageList
-			// 
-			this.packageImageList.ColorDepth = System.Windows.Forms.ColorDepth.Depth32Bit;
-			this.packageImageList.ImageSize = new System.Drawing.Size(32, 32);
-			this.packageImageList.TransparentColor = System.Drawing.Color.Transparent;
-			// 
-			// tabReader
-			// 
-			this.tabReader.Appearance = System.Windows.Forms.Appearance.Button;
-			this.tabReader.AutoEllipsis = true;
-			this.tabReader.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.ReaderPref;
-			this.tabReader.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-			this.tabReader.Location = new System.Drawing.Point(3, 7);
-			this.tabReader.Name = "tabReader";
-			this.tabReader.Size = new System.Drawing.Size(75, 56);
-			this.tabReader.TabIndex = 13;
-			this.tabReader.Text = "Reader";
-			this.tabReader.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
-			this.tabReader.UseVisualStyleBackColor = true;
-			this.tabReader.CheckedChanged += new System.EventHandler(this.chkAdvanced_CheckedChanged);
-			// 
-			// tabLibraries
-			// 
-			this.tabLibraries.Appearance = System.Windows.Forms.Appearance.Button;
-			this.tabLibraries.AutoEllipsis = true;
-			this.tabLibraries.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.LibraryPref;
-			this.tabLibraries.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-			this.tabLibraries.Location = new System.Drawing.Point(3, 66);
-			this.tabLibraries.Name = "tabLibraries";
-			this.tabLibraries.Size = new System.Drawing.Size(75, 56);
-			this.tabLibraries.TabIndex = 14;
-			this.tabLibraries.Text = "Libraries";
-			this.tabLibraries.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
-			this.tabLibraries.UseVisualStyleBackColor = true;
-			this.tabLibraries.CheckedChanged += new System.EventHandler(this.chkAdvanced_CheckedChanged);
-			// 
-			// tabBehavior
-			// 
-			this.tabBehavior.Appearance = System.Windows.Forms.Appearance.Button;
-			this.tabBehavior.AutoEllipsis = true;
-			this.tabBehavior.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.BehaviorPref;
-			this.tabBehavior.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-			this.tabBehavior.Location = new System.Drawing.Point(3, 126);
-			this.tabBehavior.Name = "tabBehavior";
-			this.tabBehavior.Size = new System.Drawing.Size(75, 56);
-			this.tabBehavior.TabIndex = 15;
-			this.tabBehavior.Text = "Behavior";
-			this.tabBehavior.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
-			this.tabBehavior.UseVisualStyleBackColor = true;
-			this.tabBehavior.CheckedChanged += new System.EventHandler(this.chkAdvanced_CheckedChanged);
-			// 
-			// tabScripts
-			// 
-			this.tabScripts.Appearance = System.Windows.Forms.Appearance.Button;
-			this.tabScripts.AutoEllipsis = true;
-			this.tabScripts.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.ScriptingPref;
-			this.tabScripts.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-			this.tabScripts.Location = new System.Drawing.Point(3, 187);
-			this.tabScripts.Name = "tabScripts";
-			this.tabScripts.Size = new System.Drawing.Size(75, 56);
-			this.tabScripts.TabIndex = 16;
-			this.tabScripts.Text = "Scripts";
-			this.tabScripts.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
-			this.tabScripts.UseVisualStyleBackColor = true;
-			this.tabScripts.CheckedChanged += new System.EventHandler(this.chkAdvanced_CheckedChanged);
-			// 
-			// tabAdvanced
-			// 
-			this.tabAdvanced.Appearance = System.Windows.Forms.Appearance.Button;
-			this.tabAdvanced.AutoEllipsis = true;
-			this.tabAdvanced.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.AdvancedPref;
-			this.tabAdvanced.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-			this.tabAdvanced.Location = new System.Drawing.Point(3, 248);
-			this.tabAdvanced.Name = "tabAdvanced";
-			this.tabAdvanced.Size = new System.Drawing.Size(75, 56);
-			this.tabAdvanced.TabIndex = 17;
-			this.tabAdvanced.Text = "Advanced";
-			this.tabAdvanced.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
-			this.tabAdvanced.UseVisualStyleBackColor = true;
-			this.tabAdvanced.CheckedChanged += new System.EventHandler(this.chkAdvanced_CheckedChanged);
-			// 
-			// gbBackupOn
-			// 
-			this.gbBackupOn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.gbBackupOn.Controls.Add(this.chkBackupOnExit);
-			this.gbBackupOn.Controls.Add(this.chkBackupOnStartup);
-			this.gbBackupOn.Location = new System.Drawing.Point(382, 77);
-			this.gbBackupOn.Name = "gbBackupOn";
-			this.gbBackupOn.Size = new System.Drawing.Size(100, 65);
-			this.gbBackupOn.TabIndex = 8;
-			this.gbBackupOn.TabStop = false;
-			this.gbBackupOn.Text = "Backup On";
-			// 
-			// chkBackupOnExit
-			// 
-			this.chkBackupOnExit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.chkBackupOnExit.AutoSize = true;
-			this.chkBackupOnExit.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-			this.chkBackupOnExit.Location = new System.Drawing.Point(15, 39);
-			this.chkBackupOnExit.Name = "chkBackupOnExit";
-			this.chkBackupOnExit.Size = new System.Drawing.Size(79, 17);
-			this.chkBackupOnExit.TabIndex = 11;
-			this.chkBackupOnExit.Text = "Shut Down";
-			this.chkBackupOnExit.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			this.chkBackupOnExit.UseVisualStyleBackColor = true;
-			// 
-			// chkBackupOnStartup
-			// 
-			this.chkBackupOnStartup.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.chkBackupOnStartup.AutoSize = true;
-			this.chkBackupOnStartup.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-			this.chkBackupOnStartup.Location = new System.Drawing.Point(34, 18);
-			this.chkBackupOnStartup.Name = "chkBackupOnStartup";
-			this.chkBackupOnStartup.Size = new System.Drawing.Size(60, 17);
-			this.chkBackupOnStartup.TabIndex = 10;
-			this.chkBackupOnStartup.Text = "Startup";
-			this.chkBackupOnStartup.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-			this.chkBackupOnStartup.UseVisualStyleBackColor = true;
-			// 
-			// PreferencesDialog
-			// 
-			this.AcceptButton = this.btOK;
-			this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
-			this.CancelButton = this.btCancel;
-			this.ClientSize = new System.Drawing.Size(610, 453);
-			this.Controls.Add(this.pageAdvanced);
-			this.Controls.Add(this.tabAdvanced);
-			this.Controls.Add(this.tabScripts);
-			this.Controls.Add(this.tabBehavior);
-			this.Controls.Add(this.tabLibraries);
-			this.Controls.Add(this.tabReader);
-			this.Controls.Add(this.pageReader);
-			this.Controls.Add(this.pageLibrary);
-			this.Controls.Add(this.pageScripts);
-			this.Controls.Add(this.pageBehavior);
-			this.Controls.Add(this.btApply);
-			this.Controls.Add(this.btCancel);
-			this.Controls.Add(this.btOK);
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.MinimumSize = new System.Drawing.Size(626, 492);
-			this.Name = "PreferencesDialog";
-			this.ShowIcon = false;
-			this.ShowInTaskbar = false;
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Preferences";
-			this.pageReader.ResumeLayout(false);
-			this.groupHardwareAcceleration.ResumeLayout(false);
-			this.groupHardwareAcceleration.PerformLayout();
-			this.grpMouse.ResumeLayout(false);
-			this.grpMouse.PerformLayout();
-			this.groupOverlays.ResumeLayout(false);
-			this.groupOverlays.PerformLayout();
-			this.panelReaderOverlays.ResumeLayout(false);
-			this.grpKeyboard.ResumeLayout(false);
-			this.cmKeyboardLayout.ResumeLayout(false);
-			this.grpDisplay.ResumeLayout(false);
-			this.grpDisplay.PerformLayout();
-			this.pageAdvanced.ResumeLayout(false);
-			this.grpWirelessSetup.ResumeLayout(false);
-			this.grpWirelessSetup.PerformLayout();
-			this.grpIntegration.ResumeLayout(false);
-			this.grpIntegration.PerformLayout();
-			this.groupMessagesAndSocial.ResumeLayout(false);
-			this.groupMemory.ResumeLayout(false);
-			this.grpMaximumMemoryUsage.ResumeLayout(false);
-			this.grpMaximumMemoryUsage.PerformLayout();
-			this.grpMemoryCache.ResumeLayout(false);
-			this.grpMemoryCache.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.numMemPageCount)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.numMemThumbSize)).EndInit();
-			this.grpDiskCache.ResumeLayout(false);
-			this.grpDiskCache.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.numPageCacheSize)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.numInternetCacheSize)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.numThumbnailCacheSize)).EndInit();
-			this.grpBackupManager.ResumeLayout(false);
-			this.grpBackupManager.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.numBackupsToKeep)).EndInit();
-			this.grpDatabaseBackup.ResumeLayout(false);
-			this.groupOtherComics.ResumeLayout(false);
-			this.groupOtherComics.PerformLayout();
-			this.grpLanguages.ResumeLayout(false);
-			this.pageLibrary.ResumeLayout(false);
-			this.grpVirtualTags.ResumeLayout(false);
-			this.grpVirtualTags.PerformLayout();
-			this.grpVtagConfig.ResumeLayout(false);
-			this.grpVtagConfig.PerformLayout();
-			this.grpServerSettings.ResumeLayout(false);
-			this.grpServerSettings.PerformLayout();
-			this.grpSharing.ResumeLayout(false);
-			this.grpSharing.PerformLayout();
-			this.groupLibraryDisplay.ResumeLayout(false);
-			this.groupLibraryDisplay.PerformLayout();
-			this.grpScanning.ResumeLayout(false);
-			this.grpScanning.PerformLayout();
-			this.groupComicFolders.ResumeLayout(false);
-			this.pageScripts.ResumeLayout(false);
-			this.grpScriptSettings.ResumeLayout(false);
-			this.grpScriptSettings.PerformLayout();
-			this.grpScripts.ResumeLayout(false);
-			this.grpScripts.PerformLayout();
-			this.grpPackages.ResumeLayout(false);
-			this.gbBackupOn.ResumeLayout(false);
-			this.gbBackupOn.PerformLayout();
-			this.ResumeLayout(false);
+            listViewGroup4.Header = "Installed";
+            listViewGroup4.Name = "packageGroupInstalled";
+            listViewGroup5.Header = "To be removed (requires restart)";
+            listViewGroup5.Name = "packageGroupRemove";
+            listViewGroup6.Header = "To be installed (requires restart)";
+            listViewGroup6.Name = "packageGroupInstall";
+            this.lvPackages.Groups.AddRange(new System.Windows.Forms.ListViewGroup[] {
+            listViewGroup4,
+            listViewGroup5,
+            listViewGroup6});
+            this.lvPackages.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.lvPackages.HideSelection = false;
+            this.lvPackages.LargeImageList = this.packageImageList;
+            this.lvPackages.Location = new System.Drawing.Point(16, 37);
+            this.lvPackages.Name = "lvPackages";
+            this.lvPackages.ShowItemToolTips = true;
+            this.lvPackages.Size = new System.Drawing.Size(468, 301);
+            this.lvPackages.SmallImageList = this.packageImageList;
+            this.lvPackages.Sorting = System.Windows.Forms.SortOrder.Ascending;
+            this.lvPackages.TabIndex = 0;
+            this.lvPackages.UseCompatibleStateImageBehavior = false;
+            this.lvPackages.View = System.Windows.Forms.View.Details;
+            this.lvPackages.DragDrop += new System.Windows.Forms.DragEventHandler(this.lvPackages_DragDrop);
+            this.lvPackages.DragOver += new System.Windows.Forms.DragEventHandler(this.lvPackages_DragOver);
+            this.lvPackages.DoubleClick += new System.EventHandler(this.lvPackages_DoubleClick);
+            // 
+            // chPackageName
+            // 
+            this.chPackageName.Text = "Package";
+            this.chPackageName.Width = 130;
+            // 
+            // chPackageAuthor
+            // 
+            this.chPackageAuthor.Text = "Author";
+            this.chPackageAuthor.Width = 89;
+            // 
+            // chPackageDescription
+            // 
+            this.chPackageDescription.Text = "Description";
+            this.chPackageDescription.Width = 217;
+            // 
+            // packageImageList
+            // 
+            this.packageImageList.ColorDepth = System.Windows.Forms.ColorDepth.Depth32Bit;
+            this.packageImageList.ImageSize = new System.Drawing.Size(32, 32);
+            this.packageImageList.TransparentColor = System.Drawing.Color.Transparent;
+            // 
+            // tabReader
+            // 
+            this.tabReader.Appearance = System.Windows.Forms.Appearance.Button;
+            this.tabReader.AutoEllipsis = true;
+            this.tabReader.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.ReaderPref;
+            this.tabReader.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.tabReader.Location = new System.Drawing.Point(3, 7);
+            this.tabReader.Name = "tabReader";
+            this.tabReader.Size = new System.Drawing.Size(75, 56);
+            this.tabReader.TabIndex = 13;
+            this.tabReader.Text = "Reader";
+            this.tabReader.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
+            this.tabReader.UseVisualStyleBackColor = true;
+            this.tabReader.CheckedChanged += new System.EventHandler(this.chkAdvanced_CheckedChanged);
+            // 
+            // tabLibraries
+            // 
+            this.tabLibraries.Appearance = System.Windows.Forms.Appearance.Button;
+            this.tabLibraries.AutoEllipsis = true;
+            this.tabLibraries.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.LibraryPref;
+            this.tabLibraries.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.tabLibraries.Location = new System.Drawing.Point(3, 66);
+            this.tabLibraries.Name = "tabLibraries";
+            this.tabLibraries.Size = new System.Drawing.Size(75, 56);
+            this.tabLibraries.TabIndex = 14;
+            this.tabLibraries.Text = "Libraries";
+            this.tabLibraries.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
+            this.tabLibraries.UseVisualStyleBackColor = true;
+            this.tabLibraries.CheckedChanged += new System.EventHandler(this.chkAdvanced_CheckedChanged);
+            // 
+            // tabBehavior
+            // 
+            this.tabBehavior.Appearance = System.Windows.Forms.Appearance.Button;
+            this.tabBehavior.AutoEllipsis = true;
+            this.tabBehavior.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.BehaviorPref;
+            this.tabBehavior.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.tabBehavior.Location = new System.Drawing.Point(3, 126);
+            this.tabBehavior.Name = "tabBehavior";
+            this.tabBehavior.Size = new System.Drawing.Size(75, 56);
+            this.tabBehavior.TabIndex = 15;
+            this.tabBehavior.Text = "Behavior";
+            this.tabBehavior.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
+            this.tabBehavior.UseVisualStyleBackColor = true;
+            this.tabBehavior.CheckedChanged += new System.EventHandler(this.chkAdvanced_CheckedChanged);
+            // 
+            // tabScripts
+            // 
+            this.tabScripts.Appearance = System.Windows.Forms.Appearance.Button;
+            this.tabScripts.AutoEllipsis = true;
+            this.tabScripts.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.ScriptingPref;
+            this.tabScripts.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.tabScripts.Location = new System.Drawing.Point(3, 187);
+            this.tabScripts.Name = "tabScripts";
+            this.tabScripts.Size = new System.Drawing.Size(75, 56);
+            this.tabScripts.TabIndex = 16;
+            this.tabScripts.Text = "Scripts";
+            this.tabScripts.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
+            this.tabScripts.UseVisualStyleBackColor = true;
+            this.tabScripts.CheckedChanged += new System.EventHandler(this.chkAdvanced_CheckedChanged);
+            // 
+            // tabAdvanced
+            // 
+            this.tabAdvanced.Appearance = System.Windows.Forms.Appearance.Button;
+            this.tabAdvanced.AutoEllipsis = true;
+            this.tabAdvanced.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.AdvancedPref;
+            this.tabAdvanced.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.tabAdvanced.Location = new System.Drawing.Point(3, 248);
+            this.tabAdvanced.Name = "tabAdvanced";
+            this.tabAdvanced.Size = new System.Drawing.Size(75, 56);
+            this.tabAdvanced.TabIndex = 17;
+            this.tabAdvanced.Text = "Advanced";
+            this.tabAdvanced.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
+            this.tabAdvanced.UseVisualStyleBackColor = true;
+            this.tabAdvanced.CheckedChanged += new System.EventHandler(this.chkAdvanced_CheckedChanged);
+            // 
+            // chkUpdateComicBookFiles
+            // 
+            this.chkUpdateComicBookFiles.AutoSize = true;
+            this.chkUpdateComicBookFiles.Location = new System.Drawing.Point(9, 65);
+            this.chkUpdateComicBookFiles.Name = "chkUpdateComicBookFiles";
+            this.chkUpdateComicBookFiles.Size = new System.Drawing.Size(191, 17);
+            this.chkUpdateComicBookFiles.TabIndex = 4;
+            this.chkUpdateComicBookFiles.Text = "Allow writing of Library info into files";
+            this.chkUpdateComicBookFiles.UseVisualStyleBackColor = true;
+            // 
+            // PreferencesDialog
+            // 
+            this.AcceptButton = this.btOK;
+            this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
+            this.CancelButton = this.btCancel;
+            this.ClientSize = new System.Drawing.Size(610, 453);
+            this.Controls.Add(this.pageAdvanced);
+            this.Controls.Add(this.tabAdvanced);
+            this.Controls.Add(this.tabScripts);
+            this.Controls.Add(this.tabBehavior);
+            this.Controls.Add(this.tabLibraries);
+            this.Controls.Add(this.tabReader);
+            this.Controls.Add(this.pageReader);
+            this.Controls.Add(this.pageLibrary);
+            this.Controls.Add(this.pageScripts);
+            this.Controls.Add(this.pageBehavior);
+            this.Controls.Add(this.btApply);
+            this.Controls.Add(this.btCancel);
+            this.Controls.Add(this.btOK);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(626, 492);
+            this.Name = "PreferencesDialog";
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Preferences";
+            ((System.ComponentModel.ISupportInitialize)(this.numBackupsToKeep)).EndInit();
+            this.pageReader.ResumeLayout(false);
+            this.groupHardwareAcceleration.ResumeLayout(false);
+            this.groupHardwareAcceleration.PerformLayout();
+            this.grpMouse.ResumeLayout(false);
+            this.grpMouse.PerformLayout();
+            this.groupOverlays.ResumeLayout(false);
+            this.groupOverlays.PerformLayout();
+            this.panelReaderOverlays.ResumeLayout(false);
+            this.grpKeyboard.ResumeLayout(false);
+            this.cmKeyboardLayout.ResumeLayout(false);
+            this.grpDisplay.ResumeLayout(false);
+            this.grpDisplay.PerformLayout();
+            this.pageAdvanced.ResumeLayout(false);
+            this.grpWirelessSetup.ResumeLayout(false);
+            this.grpWirelessSetup.PerformLayout();
+            this.grpIntegration.ResumeLayout(false);
+            this.grpIntegration.PerformLayout();
+            this.groupMessagesAndSocial.ResumeLayout(false);
+            this.groupMemory.ResumeLayout(false);
+            this.grpMaximumMemoryUsage.ResumeLayout(false);
+            this.grpMaximumMemoryUsage.PerformLayout();
+            this.grpMemoryCache.ResumeLayout(false);
+            this.grpMemoryCache.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numMemPageCount)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numMemThumbSize)).EndInit();
+            this.grpDiskCache.ResumeLayout(false);
+            this.grpDiskCache.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numPageCacheSize)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numInternetCacheSize)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numThumbnailCacheSize)).EndInit();
+            this.grpBackupManager.ResumeLayout(false);
+            this.grpBackupManager.PerformLayout();
+            this.gbBackupOn.ResumeLayout(false);
+            this.gbBackupOn.PerformLayout();
+            this.grpDatabaseBackup.ResumeLayout(false);
+            this.groupOtherComics.ResumeLayout(false);
+            this.groupOtherComics.PerformLayout();
+            this.grpLanguages.ResumeLayout(false);
+            this.pageLibrary.ResumeLayout(false);
+            this.grpVirtualTags.ResumeLayout(false);
+            this.grpVirtualTags.PerformLayout();
+            this.grpVtagConfig.ResumeLayout(false);
+            this.grpVtagConfig.PerformLayout();
+            this.grpServerSettings.ResumeLayout(false);
+            this.grpServerSettings.PerformLayout();
+            this.grpSharing.ResumeLayout(false);
+            this.grpSharing.PerformLayout();
+            this.groupLibraryDisplay.ResumeLayout(false);
+            this.groupLibraryDisplay.PerformLayout();
+            this.grpScanning.ResumeLayout(false);
+            this.grpScanning.PerformLayout();
+            this.groupComicFolders.ResumeLayout(false);
+            this.pageScripts.ResumeLayout(false);
+            this.grpScriptSettings.ResumeLayout(false);
+            this.grpScriptSettings.PerformLayout();
+            this.grpScripts.ResumeLayout(false);
+            this.grpScripts.PerformLayout();
+            this.grpPackages.ResumeLayout(false);
+            this.ResumeLayout(false);
 
 		}
 		
@@ -2732,7 +2744,8 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 				Program.ImagePool.Thumbs.DiskCache.SizeChanged -= UpdateDiskCacheStatus;
 				if (components != null)
 				{
-					components.Dispose();
+                    IdleProcess.Idle -= OnIdle;
+                    components.Dispose();
 				}
 			}
 			base.Dispose(disposing);
@@ -2938,5 +2951,6 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 		private GroupBox gbBackupOn;
 		private CheckBox chkBackupOnExit;
 		private CheckBox chkBackupOnStartup;
-	}
+        private CheckBox chkUpdateComicBookFiles;
+    }
 }

--- a/ComicRack/Dialogs/PreferencesDialog.Designer.cs
+++ b/ComicRack/Dialogs/PreferencesDialog.Designer.cs
@@ -501,7 +501,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             // panelReaderOverlays
             // 
             this.panelReaderOverlays.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.panelReaderOverlays.BackColor = System.Drawing.Color.WhiteSmoke;
+            this.panelReaderOverlays.BackColor = ThemeColors.Preferences.PanelReader;
             this.panelReaderOverlays.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.panelReaderOverlays.Controls.Add(this.labelVisiblePartOverlay);
             this.panelReaderOverlays.Controls.Add(this.labelNavigationOverlay);
@@ -515,7 +515,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             // labelVisiblePartOverlay
             // 
             this.labelVisiblePartOverlay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.labelVisiblePartOverlay.BackColor = System.Drawing.Color.Gainsboro;
+            this.labelVisiblePartOverlay.BackColor = ThemeColors.Preferences.LabelOverlays;
             this.labelVisiblePartOverlay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.labelVisiblePartOverlay.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.labelVisiblePartOverlay.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -530,7 +530,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             // labelNavigationOverlay
             // 
             this.labelNavigationOverlay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.labelNavigationOverlay.BackColor = System.Drawing.Color.Gainsboro;
+            this.labelNavigationOverlay.BackColor = ThemeColors.Preferences.LabelOverlays;
             this.labelNavigationOverlay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.labelNavigationOverlay.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.labelNavigationOverlay.Location = new System.Drawing.Point(55, 100);
@@ -543,7 +543,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             // 
             // labelStatusOverlay
             // 
-            this.labelStatusOverlay.BackColor = System.Drawing.Color.Gainsboro;
+            this.labelStatusOverlay.BackColor = ThemeColors.Preferences.LabelOverlays;
             this.labelStatusOverlay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.labelStatusOverlay.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.labelStatusOverlay.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -558,7 +558,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
             // labelPageOverlay
             // 
             this.labelPageOverlay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.labelPageOverlay.BackColor = System.Drawing.Color.Gainsboro;
+            this.labelPageOverlay.BackColor = ThemeColors.Preferences.LabelOverlays;
             this.labelPageOverlay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.labelPageOverlay.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.labelPageOverlay.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));

--- a/ComicRack/Dialogs/PreferencesDialog.cs
+++ b/ComicRack/Dialogs/PreferencesDialog.cs
@@ -34,118 +34,119 @@ using cYo.Projects.ComicRack.Viewer.Properties;
 
 namespace cYo.Projects.ComicRack.Viewer.Dialogs
 {
-    public partial class PreferencesDialog : FormEx
-    {
-        private const int MaximumMemoryStepSize = 32;
+	public partial class PreferencesDialog : FormEx
+	{
+		private const int MaximumMemoryStepSize = 32;
 
 		private static readonly string DuplicatePackageText = TR.Messages["ScriptPackageExists", "A Script Package with the same name already exists! Do you want to overwrite this Package?"];
 
-        private PluginEngine pluginEngine;
+		private PluginEngine pluginEngine;
 
-        private bool blockSetTab;
+		private bool blockSetTab;
 
-        public string AutoInstallPlugin
-        {
-            get;
-            set;
-        }
+		public string AutoInstallPlugin
+		{
+			get;
+			set;
+		}
 
-        public bool NeedsRestart
-        {
-            get;
-            set;
-        }
+		public bool NeedsRestart
+		{
+			get;
+			set;
+		}
 
-        public string BackupFile
-        {
-            get;
-            set;
-        }
+		public string BackupFile
+		{
+			get;
+			set;
+		}
 
-        public PluginEngine Plugins
-        {
-            get
-            {
-                return pluginEngine;
-            }
-            set
-            {
-                pluginEngine = value;
-                FillScriptsList();
-            }
-        }
+		public PluginEngine Plugins
+		{
+			get
+			{
+				return pluginEngine;
+			}
+			set
+			{
+				pluginEngine = value;
+				FillScriptsList();
+			}
+		}
 
-        public PreferencesDialog()
-        {
-            LocalizeUtility.UpdateRightToLeft(this);
-            InitializeComponent();
-            lvPackages.Columns.ScaleDpi();
-            lvScripts.Columns.ScaleDpi();
-            this.RestorePosition();
-            this.RestorePanelStates();
-            tabReader.Tag = pageReader;
-            tabBehavior.Tag = pageBehavior;
-            tabLibraries.Tag = pageLibrary;
-            tabScripts.Tag = pageScripts;
-            tabAdvanced.Tag = pageAdvanced;
-            tabButtons.AddRange(new CheckBox[5]
-            {
-                tabReader,
-                tabBehavior,
-                tabLibraries,
-                tabScripts,
-                tabAdvanced
-            });
-            lbLanguages.ItemHeight = FormUtility.ScaleDpiY(lbLanguages.ItemHeight);
-            tabReader.Image = ((Bitmap)tabReader.Image).ScaleDpi();
-            tabAdvanced.Image = ((Bitmap)tabAdvanced.Image).ScaleDpi();
-            tabBehavior.Image = ((Bitmap)tabBehavior.Image).ScaleDpi();
-            tabLibraries.Image = ((Bitmap)tabLibraries.Image).ScaleDpi();
-            tabScripts.Image = ((Bitmap)tabScripts.Image).ScaleDpi();
-            FormUtility.FillPanelWithOptions(pageBehavior, Program.Settings, TR.Load("Settings"));
-            packageImageList.Images.Add(Resources.Package);
-            LocalizeUtility.Localize(this, components);
-            LocalizeUtility.Localize(TR.Load(base.Name), cbNavigationOverlayPosition);
-            Program.Scanner.ScanNotify += DatabaseScanNotify;
-            IdleProcess.Idle += ApplicationIdle;
-            numMemPageCount.Minimum = 20m;
-            numMemPageCount.Maximum = 100m;
-            numMemThumbSize.Minimum = 5m;
-            numMemThumbSize.Maximum = 500m;
-            lbLanguages.Items.Add(new TRInfo());
-            lbLanguages.Items.Add(new TRInfo("en"));
-            TRInfo[] installedLanguages = Program.InstalledLanguages;
-            foreach (TRInfo item in installedLanguages)
-            {
-                lbLanguages.Items.Add(item);
-            }
-            SetSettings();
-            foreach (WatchFolder watchFolder in Program.Database.WatchFolders)
-            {
-                lbPaths.Items.Add(watchFolder.Folder, watchFolder.Watch);
-            }
-            lbPaths_SelectedIndexChanged(lbPaths, EventArgs.Empty);
-            SetScanButtonText();
-            btResetMessages.Enabled = Program.Settings.HiddenMessageBoxes != HiddenMessageBoxes.None;
-            FillExtensionsList();
-            FillBackupOptions();
-            chkOverwriteAssociations.Checked = Program.Settings.OverwriteAssociations;
-            if (!FileFormat.CanRegisterShell)
-            {
-                Win7.ShowShield(btAssociateExtensions);
-            }
-            else
-            {
-                btAssociateExtensions.Visible = false;
-                lbFormats.Width = btAssociateExtensions.Right - lbFormats.Left;
-            }
-            Program.InternetCache.SizeChanged += UpdateDiskCacheStatus;
-            Program.ImagePool.Pages.DiskCache.SizeChanged += UpdateDiskCacheStatus;
-            Program.ImagePool.Thumbs.DiskCache.SizeChanged += UpdateDiskCacheStatus;
-            UpdateDiskCacheStatus(this, null);
-            UpdateMemoryCacheStatus();
-            RefreshPackageList();
-        }
+		public PreferencesDialog()
+		{
+			LocalizeUtility.UpdateRightToLeft(this);
+			InitializeComponent();
+			lvPackages.Columns.ScaleDpi();
+			lvScripts.Columns.ScaleDpi();
+			this.RestorePosition();
+			this.RestorePanelStates();
+			tabReader.Tag = pageReader;
+			tabBehavior.Tag = pageBehavior;
+			tabLibraries.Tag = pageLibrary;
+			tabScripts.Tag = pageScripts;
+			tabAdvanced.Tag = pageAdvanced;
+			tabButtons.AddRange(new CheckBox[5]
+			{
+				tabReader,
+				tabBehavior,
+				tabLibraries,
+				tabScripts,
+				tabAdvanced
+			});
+			lbLanguages.ItemHeight = FormUtility.ScaleDpiY(lbLanguages.ItemHeight);
+			tabReader.Image = ((Bitmap)tabReader.Image).ScaleDpi();
+			tabAdvanced.Image = ((Bitmap)tabAdvanced.Image).ScaleDpi();
+			tabBehavior.Image = ((Bitmap)tabBehavior.Image).ScaleDpi();
+			tabLibraries.Image = ((Bitmap)tabLibraries.Image).ScaleDpi();
+			tabScripts.Image = ((Bitmap)tabScripts.Image).ScaleDpi();
+			FormUtility.FillPanelWithOptions(pageBehavior, Program.Settings, TR.Load("Settings"));
+			packageImageList.Images.Add(Resources.Package);
+			LocalizeUtility.Localize(this, components);
+			LocalizeUtility.Localize(TR.Load(base.Name), cbNavigationOverlayPosition);
+			Program.Scanner.ScanNotify += DatabaseScanNotify;
+			IdleProcess.Idle += ApplicationIdle;
+			numMemPageCount.Minimum = 20m;
+			numMemPageCount.Maximum = 100m;
+			numMemThumbSize.Minimum = 5m;
+			numMemThumbSize.Maximum = 500m;
+			lbLanguages.Items.Add(new TRInfo());
+			lbLanguages.Items.Add(new TRInfo("en"));
+			TRInfo[] installedLanguages = Program.InstalledLanguages;
+			foreach (TRInfo item in installedLanguages)
+			{
+				lbLanguages.Items.Add(item);
+			}
+			SetSettings();
+			foreach (WatchFolder watchFolder in Program.Database.WatchFolders)
+			{
+				lbPaths.Items.Add(watchFolder.Folder, watchFolder.Watch);
+			}
+			lbPaths_SelectedIndexChanged(lbPaths, EventArgs.Empty);
+			SetScanButtonText();
+			btResetMessages.Enabled = Program.Settings.HiddenMessageBoxes != HiddenMessageBoxes.None;
+			FillExtensionsList();
+			FillBackupOptions();
+			chkOverwriteAssociations.Checked = Program.Settings.OverwriteAssociations;
+			if (!FileFormat.CanRegisterShell)
+			{
+				Win7.ShowShield(btAssociateExtensions);
+			}
+			else
+			{
+				btAssociateExtensions.Visible = false;
+				lbFormats.Width = btAssociateExtensions.Right - lbFormats.Left;
+			}
+			Program.InternetCache.SizeChanged += UpdateDiskCacheStatus;
+			Program.ImagePool.Pages.DiskCache.SizeChanged += UpdateDiskCacheStatus;
+			Program.ImagePool.Thumbs.DiskCache.SizeChanged += UpdateDiskCacheStatus;
+			UpdateDiskCacheStatus(this, null);
+			UpdateMemoryCacheStatus();
+			RefreshPackageList();
+			IdleProcess.Idle += OnIdle;
+		}
 
 		public static Size SafeSize { get; set; }
 
@@ -153,20 +154,20 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 		{
 			base.OnResizeEnd(e);
 			UpdateSafeSize();
-            AutoSizeColumn();
+			AutoSizeColumn();
 		}
 
 		private void SetSize()
 		{
 			Size = !SafeSize.IsEmpty ? SafeSize : MinimumSize;
-            this.CenterToParent();
+			this.CenterToParent();
 			AutoSizeColumn();
 		}
 
 		private void AutoSizeColumn()
 		{
-            this.FindServices<ListView>().ForEach((ListView lv) => lv.AutoResizeColumn(0, 32));
-        }
+			this.FindServices<ListView>().ForEach((ListView lv) => lv.AutoResizeColumn(0, 32));
+		}
 
 		private void UpdateSafeSize()
 		{
@@ -177,849 +178,857 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 		}
 
 		protected override void OnLoad(EventArgs e)
-        {
-            base.OnLoad(e);
+		{
+			base.OnLoad(e);
 			SetSize(); //Set size here because base.OnLoad(e) sets the previous dimension overriding what we set.
-            //If this is in the Init portion and it loads via settings, the form will not be drawn correctly.
+					   //If this is in the Init portion and it loads via settings, the form will not be drawn correctly.
 			FormUtility.RegisterPanelToTabToggle(pageReader, PropertyCaller.CreateFlagsValueStore(Program.Settings, "TabLayouts", TabLayouts.ReaderSettings));
 			FormUtility.RegisterPanelToTabToggle(pageBehavior, PropertyCaller.CreateFlagsValueStore(Program.Settings, "TabLayouts", TabLayouts.BehaviorSettings));
 			FormUtility.RegisterPanelToTabToggle(pageLibrary, PropertyCaller.CreateFlagsValueStore(Program.Settings, "TabLayouts", TabLayouts.LibrarySettings));
 			FormUtility.RegisterPanelToTabToggle(pageScripts, PropertyCaller.CreateFlagsValueStore(Program.Settings, "TabLayouts", TabLayouts.ScriptSettings));
 			FormUtility.RegisterPanelToTabToggle(pageAdvanced, PropertyCaller.CreateFlagsValueStore(Program.Settings, "TabLayouts", TabLayouts.AdvancedSettings));
 			SetTab((activeTab != -1) ? tabButtons[activeTab] : tabReader);
-            //Fix Auto Word Selection bug
-            rtfVirtualTagCaption.AutoWordSelection = false;
+			//Fix Auto Word Selection bug
+			rtfVirtualTagCaption.AutoWordSelection = false;
+		}
+
+		private void OnIdle(object sender, EventArgs e)
+		{
+			chkUpdateComicBookFiles.Enabled = chkAutoUpdateComicFiles.Enabled = chkUpdateComicFiles.Checked;
+			if (!chkUpdateComicFiles.Checked)
+                chkAutoUpdateComicFiles.Checked = chkUpdateComicBookFiles.Checked = false;
         }
 
-        protected override void OnShown(EventArgs e)
-        {
-            base.OnShown(e);
-            if (!string.IsNullOrEmpty(AutoInstallPlugin))
-            {
-                SetTab(tabScripts);
-                if (InstallPlugin(AutoInstallPlugin))
-                {
-                    RefreshPackageList();
-                }
-            }
-        }
+		protected override void OnShown(EventArgs e)
+		{
+			base.OnShown(e);
+			if (!string.IsNullOrEmpty(AutoInstallPlugin))
+			{
+				SetTab(tabScripts);
+				if (InstallPlugin(AutoInstallPlugin))
+				{
+					RefreshPackageList();
+				}
+			}
+		}
 
-        private void btTestWifi_Click(object sender, EventArgs e)
-        {
-            string text = string.Empty;
-            using (new WaitCursor(this))
-            {
-                foreach (ISyncProvider item in DeviceSyncFactory.Discover(DeviceSyncFactory.ParseWifiAddressList(txWifiAddresses.Text)))
-                {
-                    text = text.AppendWithSeparator(", ", item.Device.Model);
-                }
-            }
-            lblWifiStatus.Text = (string.IsNullOrEmpty(text) ? TR.Load(base.Name)["msgNoDevicesFound", "No devices found!"] : TR.Load(base.Name)["msgDevicesFound", "{0} found!"].SafeFormat(text));
-        }
+		private void btTestWifi_Click(object sender, EventArgs e)
+		{
+			string text = string.Empty;
+			using (new WaitCursor(this))
+			{
+				foreach (ISyncProvider item in DeviceSyncFactory.Discover(DeviceSyncFactory.ParseWifiAddressList(txWifiAddresses.Text)))
+				{
+					text = text.AppendWithSeparator(", ", item.Device.Model);
+				}
+			}
+			lblWifiStatus.Text = (string.IsNullOrEmpty(text) ? TR.Load(base.Name)["msgNoDevicesFound", "No devices found!"] : TR.Load(base.Name)["msgDevicesFound", "{0} found!"].SafeFormat(text));
+		}
 
-        private void chkAdvanced_CheckedChanged(object sender, EventArgs e)
-        {
-            CheckBox checkBox = sender as CheckBox;
-            if (checkBox.Checked)
-            {
-                SetTab(checkBox);
-            }
-        }
+		private void chkAdvanced_CheckedChanged(object sender, EventArgs e)
+		{
+			CheckBox checkBox = sender as CheckBox;
+			if (checkBox.Checked)
+			{
+				SetTab(checkBox);
+			}
+		}
 
-        private void chkLibraryGauges_CheckedChanged(object sender, EventArgs e)
-        {
-            CheckBox checkBox = chkLibraryGaugesNew;
-            CheckBox checkBox2 = chkLibraryGaugesUnread;
-            CheckBox checkBox3 = chkLibraryGaugesTotal;
-            bool flag = (chkLibraryGaugesNumeric.Enabled = chkLibraryGauges.Checked);
-            bool flag3 = (checkBox3.Enabled = flag);
-            bool enabled = (checkBox2.Enabled = flag3);
-            checkBox.Enabled = enabled;
-        }
+		private void chkLibraryGauges_CheckedChanged(object sender, EventArgs e)
+		{
+			CheckBox checkBox = chkLibraryGaugesNew;
+			CheckBox checkBox2 = chkLibraryGaugesUnread;
+			CheckBox checkBox3 = chkLibraryGaugesTotal;
+			bool flag = (chkLibraryGaugesNumeric.Enabled = chkLibraryGauges.Checked);
+			bool flag3 = (checkBox3.Enabled = flag);
+			bool enabled = (checkBox2.Enabled = flag3);
+			checkBox.Enabled = enabled;
+		}
 
-        private void tbSystemMemory_ValueChanged(object sender, EventArgs e)
-        {
-            int num = tbMaximumMemoryUsage.Value * MaximumMemoryStepSize;
-            if (num == Settings.UnlimitedSystemMemory)
-            {
-                lblMaximumMemoryUsageValue.Text = TR.Default["Unlimited"];
-            }
-            else
-            {
-                lblMaximumMemoryUsageValue.Text = $"{num} MB";
-            }
-        }
+		private void tbSystemMemory_ValueChanged(object sender, EventArgs e)
+		{
+			int num = tbMaximumMemoryUsage.Value * MaximumMemoryStepSize;
+			if (num == Settings.UnlimitedSystemMemory)
+			{
+				lblMaximumMemoryUsageValue.Text = TR.Default["Unlimited"];
+			}
+			else
+			{
+				lblMaximumMemoryUsageValue.Text = $"{num} MB";
+			}
+		}
 
-        private void lbPaths_DragDrop(object sender, DragEventArgs e)
-        {
-            (from d in (e.Data.GetData(DataFormats.FileDrop) as string[])?.Select((string d) => (!Directory.Exists(d)) ? Path.GetDirectoryName(d) : d)
-             where !lbPaths.Items.Contains(d)
-             select d).ForEach(delegate (string d)
-             {
-                 lbPaths.Items.Add(d);
-             });
-        }
+		private void lbPaths_DragDrop(object sender, DragEventArgs e)
+		{
+			(from d in (e.Data.GetData(DataFormats.FileDrop) as string[])?.Select((string d) => (!Directory.Exists(d)) ? Path.GetDirectoryName(d) : d)
+			 where !lbPaths.Items.Contains(d)
+			 select d).ForEach(delegate (string d)
+			 {
+				 lbPaths.Items.Add(d);
+			 });
+		}
 
-        private void lbPaths_DragOver(object sender, DragEventArgs e)
-        {
-            e.Effect = (e.Data.GetDataPresent(DataFormats.FileDrop) ? DragDropEffects.Copy : DragDropEffects.None);
-        }
+		private void lbPaths_DragOver(object sender, DragEventArgs e)
+		{
+			e.Effect = (e.Data.GetDataPresent(DataFormats.FileDrop) ? DragDropEffects.Copy : DragDropEffects.None);
+		}
 
-        private void lvScripts_ItemChecked(object sender, ItemCheckedEventArgs e)
-        {
-            Command command = e.Item.Tag as Command;
-            if (command != null)
-            {
-                command.Enabled = e.Item.Checked;
-            }
-        }
+		private void lvScripts_ItemChecked(object sender, ItemCheckedEventArgs e)
+		{
+			Command command = e.Item.Tag as Command;
+			if (command != null)
+			{
+				command.Enabled = e.Item.Checked;
+			}
+		}
 
-        private void lvScripts_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            Command command = (from lvi in lvScripts.SelectedItems.OfType<ListViewItem>()
-                               select lvi.Tag as Command).FirstOrDefault();
-            btConfigScript.Enabled = command != null && command.Configure != null;
-            if (btConfigScript.Enabled)
-            {
-                btConfigScript.Tag = command.Configure;
-            }
-        }
+		private void lvScripts_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			Command command = (from lvi in lvScripts.SelectedItems.OfType<ListViewItem>()
+							   select lvi.Tag as Command).FirstOrDefault();
+			btConfigScript.Enabled = command != null && command.Configure != null;
+			if (btConfigScript.Enabled)
+			{
+				btConfigScript.Tag = command.Configure;
+			}
+		}
 
-        private void btConfigScript_Click(object sender, EventArgs e)
-        {
-            (btConfigScript.Tag as Command)?.Invoke(new object[0], catchErrors: true);
-        }
+		private void btConfigScript_Click(object sender, EventArgs e)
+		{
+			(btConfigScript.Tag as Command)?.Invoke(new object[0], catchErrors: true);
+		}
 
-        private void lbPaths_DrawItemText(object sender, DrawItemEventArgs e)
-        {
-            CheckedListBoxEx checkedListBoxEx = (CheckedListBoxEx)sender;
-            using (StringFormat format = new StringFormat
-            {
-                LineAlignment = StringAlignment.Center,
-                Trimming = StringTrimming.EllipsisPath
-            })
-            {
-                checkedListBoxEx.DrawDefaultItemText(e, format);
-            }
-        }
+		private void lbPaths_DrawItemText(object sender, DrawItemEventArgs e)
+		{
+			CheckedListBoxEx checkedListBoxEx = (CheckedListBoxEx)sender;
+			using (StringFormat format = new StringFormat
+			{
+				LineAlignment = StringAlignment.Center,
+				Trimming = StringTrimming.EllipsisPath
+			})
+			{
+				checkedListBoxEx.DrawDefaultItemText(e, format);
+			}
+		}
 
-        private void DatabaseScanNotify(object sender, ComicScanNotifyEventArgs e)
-        {
-            try
-            {
-                if (!this.BeginInvokeIfRequired(delegate
-                {
-                    DatabaseScanNotify(sender, e);
-                }))
-                {
-                    if (string.IsNullOrEmpty(e.File))
-                    {
-                        lblScan.Text = string.Empty;
-                    }
-                    else
-                    {
-                        lblScan.Text = StringUtility.Format(LocalizeUtility.GetText(this, "Scanning", "Scanning '{0}' ..."), e.File);
-                    }
-                    SetScanButtonText();
-                }
-            }
-            catch (Exception)
-            {
-            }
-        }
+		private void DatabaseScanNotify(object sender, ComicScanNotifyEventArgs e)
+		{
+			try
+			{
+				if (!this.BeginInvokeIfRequired(delegate
+				{
+					DatabaseScanNotify(sender, e);
+				}))
+				{
+					if (string.IsNullOrEmpty(e.File))
+					{
+						lblScan.Text = string.Empty;
+					}
+					else
+					{
+						lblScan.Text = StringUtility.Format(LocalizeUtility.GetText(this, "Scanning", "Scanning '{0}' ..."), e.File);
+					}
+					SetScanButtonText();
+				}
+			}
+			catch (Exception)
+			{
+			}
+		}
 
-        private void btClearThumbnailCache_Click(object sender, EventArgs e)
-        {
-            using (new WaitCursor())
-            {
-                Program.ImagePool.Thumbs.DiskCache.Clear();
-            }
-        }
+		private void btClearThumbnailCache_Click(object sender, EventArgs e)
+		{
+			using (new WaitCursor())
+			{
+				Program.ImagePool.Thumbs.DiskCache.Clear();
+			}
+		}
 
-        private void btClearPageCache_Click(object sender, EventArgs e)
-        {
-            using (new WaitCursor())
-            {
-                Program.ImagePool.Pages.DiskCache.Clear();
-            }
-        }
+		private void btClearPageCache_Click(object sender, EventArgs e)
+		{
+			using (new WaitCursor())
+			{
+				Program.ImagePool.Pages.DiskCache.Clear();
+			}
+		}
 
-        private void btClearInternetCache_Click(object sender, EventArgs e)
-        {
-            using (new WaitCursor())
-            {
-                Program.InternetCache.Clear();
-            }
-        }
+		private void btClearInternetCache_Click(object sender, EventArgs e)
+		{
+			using (new WaitCursor())
+			{
+				Program.InternetCache.Clear();
+			}
+		}
 
-        private void btAddFolder_Click(object sender, EventArgs e)
-        {
-            using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
-            {
-                folderBrowserDialog.Description = LocalizeUtility.GetText(this, "SelectComicFolder", "Please select a folder containing Books");
-                folderBrowserDialog.ShowNewFolderButton = true;
-                if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
-                {
-                    lbPaths.Items.Add(folderBrowserDialog.SelectedPath);
-                    if (lbPaths.SelectedIndex == -1)
-                    {
-                        lbPaths.SelectedIndex = 0;
-                    }
-                }
-            }
-        }
+		private void btAddFolder_Click(object sender, EventArgs e)
+		{
+			using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
+			{
+				folderBrowserDialog.Description = LocalizeUtility.GetText(this, "SelectComicFolder", "Please select a folder containing Books");
+				folderBrowserDialog.ShowNewFolderButton = true;
+				if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
+				{
+					lbPaths.Items.Add(folderBrowserDialog.SelectedPath);
+					if (lbPaths.SelectedIndex == -1)
+					{
+						lbPaths.SelectedIndex = 0;
+					}
+				}
+			}
+		}
 
-        private void btChangeFolder_Click(object sender, EventArgs e)
-        {
-            string text = lbPaths.SelectedItem as string;
-            if (text == null)
-            {
-                return;
-            }
-            using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
-            {
-                folderBrowserDialog.Description = LocalizeUtility.GetText(this, "SelectComicFolder", "Please select a folder containing Books");
-                folderBrowserDialog.ShowNewFolderButton = true;
-                folderBrowserDialog.SelectedPath = text;
-                if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
-                {
-                    lbPaths.Items[lbPaths.SelectedIndex] = folderBrowserDialog.SelectedPath;
-                }
-            }
-        }
+		private void btChangeFolder_Click(object sender, EventArgs e)
+		{
+			string text = lbPaths.SelectedItem as string;
+			if (text == null)
+			{
+				return;
+			}
+			using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
+			{
+				folderBrowserDialog.Description = LocalizeUtility.GetText(this, "SelectComicFolder", "Please select a folder containing Books");
+				folderBrowserDialog.ShowNewFolderButton = true;
+				folderBrowserDialog.SelectedPath = text;
+				if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
+				{
+					lbPaths.Items[lbPaths.SelectedIndex] = folderBrowserDialog.SelectedPath;
+				}
+			}
+		}
 
-        private void btAddLibraryFolder_Click(object sender, EventArgs e)
-        {
-            using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
-            {
-                folderBrowserDialog.Description = LocalizeUtility.GetText(this, "SelectScriptFolder", "Please select a script library folder");
-                folderBrowserDialog.ShowNewFolderButton = false;
-                if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
-                {
-                    if (txLibraries.Text.Trim().Length > 0)
-                    {
-                        txLibraries.Text += ";";
-                    }
-                    txLibraries.Text += folderBrowserDialog.SelectedPath;
-                }
-            }
-        }
+		private void btAddLibraryFolder_Click(object sender, EventArgs e)
+		{
+			using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
+			{
+				folderBrowserDialog.Description = LocalizeUtility.GetText(this, "SelectScriptFolder", "Please select a script library folder");
+				folderBrowserDialog.ShowNewFolderButton = false;
+				if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
+				{
+					if (txLibraries.Text.Trim().Length > 0)
+					{
+						txLibraries.Text += ";";
+					}
+					txLibraries.Text += folderBrowserDialog.SelectedPath;
+				}
+			}
+		}
 
-        private void btRemoveFolder_Click(object sender, EventArgs e)
-        {
-            int selectedIndex = lbPaths.SelectedIndex;
-            if (selectedIndex != -1)
-            {
-                lbPaths.Items.RemoveAt(selectedIndex);
-            }
-        }
+		private void btRemoveFolder_Click(object sender, EventArgs e)
+		{
+			int selectedIndex = lbPaths.SelectedIndex;
+			if (selectedIndex != -1)
+			{
+				lbPaths.Items.RemoveAt(selectedIndex);
+			}
+		}
 
-        private void btOpenFolder_Click(object sender, EventArgs e)
-        {
-            Program.ShowExplorer(lbPaths.SelectedItem as string);
-        }
+		private void btOpenFolder_Click(object sender, EventArgs e)
+		{
+			Program.ShowExplorer(lbPaths.SelectedItem as string);
+		}
 
-        private void btScan_Click(object sender, EventArgs e)
-        {
-            if (Program.Scanner.IsScanning)
-            {
-                Program.Scanner.Stop(clearQueue: true);
-                return;
-            }
-            foreach (string item in lbPaths.Items)
-            {
-                Program.Scanner.ScanFileOrFolder(item, all: true, chkAutoRemoveMissing.Checked);
-            }
-        }
+		private void btScan_Click(object sender, EventArgs e)
+		{
+			if (Program.Scanner.IsScanning)
+			{
+				Program.Scanner.Stop(clearQueue: true);
+				return;
+			}
+			foreach (string item in lbPaths.Items)
+			{
+				Program.Scanner.ScanFileOrFolder(item, all: true, chkAutoRemoveMissing.Checked);
+			}
+		}
 
-        private void lbPaths_DrawItem(object sender, DrawItemEventArgs e)
-        {
-            e.DrawThemeBackground();
-            string s = lbPaths.Items[e.Index] as string;
-            using (StringFormat format = new StringFormat
-            {
-                Trimming = StringTrimming.EllipsisPath
-            })
-            {
-                using (Brush brush = new SolidBrush(e.ForeColor))
-                {
-                    e.Graphics.DrawString(s, e.Font, brush, e.Bounds, format);
-                }
-            }
-            e.DrawThemeFocusRectangle();
-        }
+		private void lbPaths_DrawItem(object sender, DrawItemEventArgs e)
+		{
+			e.DrawThemeBackground();
+			string s = lbPaths.Items[e.Index] as string;
+			using (StringFormat format = new StringFormat
+			{
+				Trimming = StringTrimming.EllipsisPath
+			})
+			{
+				using (Brush brush = new SolidBrush(e.ForeColor))
+				{
+					e.Graphics.DrawString(s, e.Font, brush, e.Bounds, format);
+				}
+			}
+			e.DrawThemeFocusRectangle();
+		}
 
-        private void lbPaths_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            Button button = btOpenFolder;
-            bool enabled = (btRemoveFolder.Enabled = lbPaths.SelectedIndex != -1);
-            button.Enabled = enabled;
-            btScan.Enabled = lbPaths.Items.Count > 0;
-        }
+		private void lbPaths_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			Button button = btOpenFolder;
+			bool enabled = (btRemoveFolder.Enabled = lbPaths.SelectedIndex != -1);
+			button.Enabled = enabled;
+			btScan.Enabled = lbPaths.Items.Count > 0;
+		}
 
-        private void btResetMessages_Click(object sender, EventArgs e)
-        {
-            Program.Settings.HiddenMessageBoxes = HiddenMessageBoxes.None;
-            btResetMessages.Enabled = false;
-        }
+		private void btResetMessages_Click(object sender, EventArgs e)
+		{
+			Program.Settings.HiddenMessageBoxes = HiddenMessageBoxes.None;
+			btResetMessages.Enabled = false;
+		}
 
-        private void ApplicationIdle(object sender, EventArgs e)
-        {
-            CheckBox checkBox = chkEnableDisplayChangeAnimation;
-            CheckBox checkBox2 = chkEnableHardwareFiltering;
-            CheckBox checkBox3 = chkEnableSoftwareFiltering;
-            bool flag = (chkEnableInertialMouseScrolling.Enabled = chkEnableHardware.Checked);
-            bool flag3 = (checkBox3.Enabled = flag);
-            bool enabled = (checkBox2.Enabled = flag3);
-            checkBox.Enabled = enabled;
-            chkAutoConnectShares.Enabled = chkLookForShared.Checked;
-            btRemovePackage.Enabled = lvPackages.SelectedItems.Count > 0;
-            labelPageOverlay.Enabled = chkShowCurrentPageOverlay.Checked;
-            labelVisiblePartOverlay.Enabled = chkShowVisiblePartOverlay.Checked;
-            labelStatusOverlay.Enabled = chkShowStatusOverlay.Checked;
-            labelNavigationOverlay.Top = ((cbNavigationOverlayPosition.SelectedIndex != 0) ? labelPageOverlay.Top : (labelVisiblePartOverlay.Bottom - labelNavigationOverlay.Height));
-            labelPageOverlay.Text = (chkShowPageNames.Checked ? LocalizeUtility.GetText(this, "PageNumberAndName", "Page\nName") : LocalizeUtility.GetText(this, "PageNumberOnly", "Page"));
-        }
+		private void ApplicationIdle(object sender, EventArgs e)
+		{
+			CheckBox checkBox = chkEnableDisplayChangeAnimation;
+			CheckBox checkBox2 = chkEnableHardwareFiltering;
+			CheckBox checkBox3 = chkEnableSoftwareFiltering;
+			bool flag = (chkEnableInertialMouseScrolling.Enabled = chkEnableHardware.Checked);
+			bool flag3 = (checkBox3.Enabled = flag);
+			bool enabled = (checkBox2.Enabled = flag3);
+			checkBox.Enabled = enabled;
+			chkAutoConnectShares.Enabled = chkLookForShared.Checked;
+			btRemovePackage.Enabled = lvPackages.SelectedItems.Count > 0;
+			labelPageOverlay.Enabled = chkShowCurrentPageOverlay.Checked;
+			labelVisiblePartOverlay.Enabled = chkShowVisiblePartOverlay.Checked;
+			labelStatusOverlay.Enabled = chkShowStatusOverlay.Checked;
+			labelNavigationOverlay.Top = ((cbNavigationOverlayPosition.SelectedIndex != 0) ? labelPageOverlay.Top : (labelVisiblePartOverlay.Bottom - labelNavigationOverlay.Height));
+			labelPageOverlay.Text = (chkShowPageNames.Checked ? LocalizeUtility.GetText(this, "PageNumberAndName", "Page\nName") : LocalizeUtility.GetText(this, "PageNumberOnly", "Page"));
+		}
 
-        private void btApply_Click(object sender, EventArgs e)
-        {
-            Apply();
-        }
+		private void btApply_Click(object sender, EventArgs e)
+		{
+			Apply();
+		}
 
-        private void tbSaturation_DoubleClick(object sender, EventArgs e)
-        {
-            tbSaturation.Value = 0;
-        }
+		private void tbSaturation_DoubleClick(object sender, EventArgs e)
+		{
+			tbSaturation.Value = 0;
+		}
 
-        private void tbBrightness_DoubleClick(object sender, EventArgs e)
-        {
-            tbBrightness.Value = 0;
-        }
+		private void tbBrightness_DoubleClick(object sender, EventArgs e)
+		{
+			tbBrightness.Value = 0;
+		}
 
-        private void tbContrast_DoubleClick(object sender, EventArgs e)
-        {
-            tbContrast.Value = 0;
-        }
+		private void tbContrast_DoubleClick(object sender, EventArgs e)
+		{
+			tbContrast.Value = 0;
+		}
 
-        private void tbSharpening_DoubleClick(object sender, EventArgs e)
-        {
-            tbSharpening.Value = 0;
-        }
+		private void tbSharpening_DoubleClick(object sender, EventArgs e)
+		{
+			tbSharpening.Value = 0;
+		}
 
-        private void tbGamma_DoubleClick(object sender, EventArgs e)
-        {
-            tbGamma.Value = 0;
-        }
+		private void tbGamma_DoubleClick(object sender, EventArgs e)
+		{
+			tbGamma.Value = 0;
+		}
 
-        private void btReset_Click(object sender, EventArgs e)
-        {
-            TrackBarLite trackBarLite = tbSaturation;
-            TrackBarLite trackBarLite2 = tbBrightness;
-            TrackBarLite trackBarLite3 = tbContrast;
-            int num2 = (tbGamma.Value = 0);
-            int num4 = (trackBarLite3.Value = num2);
-            int num7 = (trackBarLite.Value = (trackBarLite2.Value = num4));
-        }
+		private void btReset_Click(object sender, EventArgs e)
+		{
+			TrackBarLite trackBarLite = tbSaturation;
+			TrackBarLite trackBarLite2 = tbBrightness;
+			TrackBarLite trackBarLite3 = tbContrast;
+			int num2 = (tbGamma.Value = 0);
+			int num4 = (trackBarLite3.Value = num2);
+			int num7 = (trackBarLite.Value = (trackBarLite2.Value = num4));
+		}
 
-        private void tbOverlayScalingChanged(object sender, EventArgs e)
-        {
-            toolTip.SetToolTip(tbOverlayScaling, $"{tbOverlayScaling.Value}%");
-        }
+		private void tbOverlayScalingChanged(object sender, EventArgs e)
+		{
+			toolTip.SetToolTip(tbOverlayScaling, $"{tbOverlayScaling.Value}%");
+		}
 
-        private void tbColorAdjustmentChanged(object sender, EventArgs e)
-        {
-            TrackBarLite trackBarLite = (TrackBarLite)sender;
-            toolTip.SetToolTip(trackBarLite, string.Format("{1}{0}%", trackBarLite.Value, (trackBarLite.Value > 0) ? "+" : string.Empty));
-        }
+		private void tbColorAdjustmentChanged(object sender, EventArgs e)
+		{
+			TrackBarLite trackBarLite = (TrackBarLite)sender;
+			toolTip.SetToolTip(trackBarLite, string.Format("{1}{0}%", trackBarLite.Value, (trackBarLite.Value > 0) ? "+" : string.Empty));
+		}
 
-        private void lbLanguages_DrawItem(object sender, DrawItemEventArgs e)
-        {
-            if (e.Index == -1)
-            {
-                return;
-            }
-            TRInfo tRInfo = (TRInfo)lbLanguages.Items[e.Index];
-            //e.DrawBackground();
-            e.DrawThemeBackground(focused: ActiveForm == this);
-            using (Brush brush = new SolidBrush((tRInfo.CompletionPercent > 95f) ? ForeColor : Color.Red))
-            {
-                Rectangle bounds = e.Bounds;
-                string cultureCode = tRInfo.CultureName ?? CultureInfo.InstalledUICulture.Name;
-                using (Image image = Flags.GetFlagFromCulture(cultureCode))
-                {
-                    if (image != null)
-                    {
-                        float scale = image.Size.GetScale(bounds.Pad(2).Size);
-                        e.Graphics.DrawImage(image, bounds.X + 1, bounds.Y + 2, (float)image.Width * scale, (float)image.Height * scale);
-                    }
-                }
-                bounds.X += FormUtility.ScaleDpiX(20);
-                bounds.Width -= FormUtility.ScaleDpiX(20);
-                string[] array = tRInfo.ToString().Split('\t');
-                using (StringFormat stringFormat = new StringFormat(StringFormatFlags.NoWrap)
-                {
-                    Trimming = StringTrimming.Character,
-                    LineAlignment = StringAlignment.Center
-                })
-                {
-                    e.Graphics.DrawString(array[0], e.Font, brush, bounds, stringFormat);
-                    if (array.Length > 1)
-                    {
-                        stringFormat.Alignment = StringAlignment.Far;
-                        e.Graphics.DrawString(array[1], e.Font, brush, bounds, stringFormat);
-                    }
-                }
-            }
-            //if ((e.State & DrawItemState.Focus) != 0)
-            //{
-            //    ControlPaint.DrawFocusRectangle(e.Graphics, e.Bounds);
-            //}
+		private void lbLanguages_DrawItem(object sender, DrawItemEventArgs e)
+		{
+			if (e.Index == -1)
+			{
+				return;
+			}
+			TRInfo tRInfo = (TRInfo)lbLanguages.Items[e.Index];
+			//e.DrawBackground();
+			e.DrawThemeBackground(focused: ActiveForm == this);
+			using (Brush brush = new SolidBrush((tRInfo.CompletionPercent > 95f) ? ForeColor : Color.Red))
+			{
+				Rectangle bounds = e.Bounds;
+				string cultureCode = tRInfo.CultureName ?? CultureInfo.InstalledUICulture.Name;
+				using (Image image = Flags.GetFlagFromCulture(cultureCode))
+				{
+					if (image != null)
+					{
+						float scale = image.Size.GetScale(bounds.Pad(2).Size);
+						e.Graphics.DrawImage(image, bounds.X + 1, bounds.Y + 2, (float)image.Width * scale, (float)image.Height * scale);
+					}
+				}
+				bounds.X += FormUtility.ScaleDpiX(20);
+				bounds.Width -= FormUtility.ScaleDpiX(20);
+				string[] array = tRInfo.ToString().Split('\t');
+				using (StringFormat stringFormat = new StringFormat(StringFormatFlags.NoWrap)
+				{
+					Trimming = StringTrimming.Character,
+					LineAlignment = StringAlignment.Center
+				})
+				{
+					e.Graphics.DrawString(array[0], e.Font, brush, bounds, stringFormat);
+					if (array.Length > 1)
+					{
+						stringFormat.Alignment = StringAlignment.Far;
+						e.Graphics.DrawString(array[1], e.Font, brush, bounds, stringFormat);
+					}
+				}
+			}
+			//if ((e.State & DrawItemState.Focus) != 0)
+			//{
+			//    ControlPaint.DrawFocusRectangle(e.Graphics, e.Bounds);
+			//}
 
-            // Default theme : ControlPaint.DrawFocusRectangle() -> e.DrawFocusRectangle()
-            // e.DrawFocusRectangle() considers DrawItemState.NoFocusRect + DrawItemState.Focus
-            e.DrawThemeFocusRectangle(focused: ActiveForm == this);
-        }
+			// Default theme : ControlPaint.DrawFocusRectangle() -> e.DrawFocusRectangle()
+			// e.DrawFocusRectangle() considers DrawItemState.NoFocusRect + DrawItemState.Focus
+			e.DrawThemeFocusRectangle(focused: ActiveForm == this);
+		}
 
-        private void btBackupDatabase_Click(object sender, EventArgs e)
-        {
-            SaveFileDialog dlg = new SaveFileDialog();
-            try
-            {
-                dlg.Title = btBackupDatabase.Text.Replace(".", string.Empty);
-                dlg.FileName = string.Format("ComicDB Backup {0}.zip", DateTime.Now.ToString("yyyy-MM-dd"));
-                dlg.Filter = TR.Load("FileFilter")["ComicRackBackup", "ComicRack Database|*.zip"];
-                dlg.DefaultExt = ".zip";
-                if (dlg.ShowDialog(this) != DialogResult.OK)
-                {
-                    return;
-                }
-                try
-                {
-                    AutomaticProgressDialog.Process(this, TR.Messages["DatabaseBackup", "Database Backup"], TR.Messages["DatabaseBackupText", "Creating and saving the Backup File"], 1000, delegate
-                    {
-                        Program.DatabaseManager.BackupTo(dlg.FileName, Program.Paths.CustomThumbnailPath);
-                    }, AutomaticProgressDialogOptions.None);
-                }
-                catch
-                {
-                    MessageBox.Show(this, TR.Messages["DatabaseBackupError", "There was an error saving the Database backup"], TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-                }
-            }
-            finally
-            {
-                if (dlg != null)
-                {
-                    ((IDisposable)dlg).Dispose();
-                }
-            }
-        }
+		private void btBackupDatabase_Click(object sender, EventArgs e)
+		{
+			SaveFileDialog dlg = new SaveFileDialog();
+			try
+			{
+				dlg.Title = btBackupDatabase.Text.Replace(".", string.Empty);
+				dlg.FileName = string.Format("ComicDB Backup {0}.zip", DateTime.Now.ToString("yyyy-MM-dd"));
+				dlg.Filter = TR.Load("FileFilter")["ComicRackBackup", "ComicRack Database|*.zip"];
+				dlg.DefaultExt = ".zip";
+				if (dlg.ShowDialog(this) != DialogResult.OK)
+				{
+					return;
+				}
+				try
+				{
+					AutomaticProgressDialog.Process(this, TR.Messages["DatabaseBackup", "Database Backup"], TR.Messages["DatabaseBackupText", "Creating and saving the Backup File"], 1000, delegate
+					{
+						Program.DatabaseManager.BackupTo(dlg.FileName, Program.Paths.CustomThumbnailPath);
+					}, AutomaticProgressDialogOptions.None);
+				}
+				catch
+				{
+					MessageBox.Show(this, TR.Messages["DatabaseBackupError", "There was an error saving the Database backup"], TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+				}
+			}
+			finally
+			{
+				if (dlg != null)
+				{
+					((IDisposable)dlg).Dispose();
+				}
+			}
+		}
 
-        private void btRestoreDatabase_Click(object sender, EventArgs e)
-        {
-            using (OpenFileDialog openFileDialog = new OpenFileDialog())
-            {
-                openFileDialog.Title = btRestoreDatabase.Text.Replace(".", string.Empty);
-                openFileDialog.Filter = TR.Load("FileFilter")["ComicRackBackup", "ComicRack Backup|*.zip"];
-                openFileDialog.CheckFileExists = true;
-                if (openFileDialog.ShowDialog(this) == DialogResult.OK)
-                {
-                    BackupFile = openFileDialog.FileName;
-                }
-            }
-        }
+		private void btRestoreDatabase_Click(object sender, EventArgs e)
+		{
+			using (OpenFileDialog openFileDialog = new OpenFileDialog())
+			{
+				openFileDialog.Title = btRestoreDatabase.Text.Replace(".", string.Empty);
+				openFileDialog.Filter = TR.Load("FileFilter")["ComicRackBackup", "ComicRack Backup|*.zip"];
+				openFileDialog.CheckFileExists = true;
+				if (openFileDialog.ShowDialog(this) == DialogResult.OK)
+				{
+					BackupFile = openFileDialog.FileName;
+				}
+			}
+		}
 
-        private void btTranslate_Click(object sender, EventArgs e)
-        {
-            Program.StartDocument(Program.DefaultLocalizePage);
-        }
+		private void btTranslate_Click(object sender, EventArgs e)
+		{
+			Program.StartDocument(Program.DefaultLocalizePage);
+		}
 
-        private void memCacheUpate_Tick(object sender, EventArgs e)
-        {
-            UpdateMemoryCacheStatus();
-        }
+		private void memCacheUpate_Tick(object sender, EventArgs e)
+		{
+			UpdateMemoryCacheStatus();
+		}
 
-        private void btInstallPackage_Click(object sender, EventArgs e)
-        {
-            using (OpenFileDialog openFileDialog = new OpenFileDialog())
-            {
-                openFileDialog.Title = btInstallPackage.Text.Replace(".", string.Empty);
-                openFileDialog.Filter = TR.Load("FileFilter")["ScriptPackageOpen", "ComicRack Plugin|*.crplugin|Script Archive|*.zip"];
-                openFileDialog.CheckFileExists = true;
-                if (openFileDialog.ShowDialog(this) == DialogResult.OK && InstallPlugin(openFileDialog.FileName))
-                {
-                    RefreshPackageList();
-                }
-            }
-        }
+		private void btInstallPackage_Click(object sender, EventArgs e)
+		{
+			using (OpenFileDialog openFileDialog = new OpenFileDialog())
+			{
+				openFileDialog.Title = btInstallPackage.Text.Replace(".", string.Empty);
+				openFileDialog.Filter = TR.Load("FileFilter")["ScriptPackageOpen", "ComicRack Plugin|*.crplugin|Script Archive|*.zip"];
+				openFileDialog.CheckFileExists = true;
+				if (openFileDialog.ShowDialog(this) == DialogResult.OK && InstallPlugin(openFileDialog.FileName))
+				{
+					RefreshPackageList();
+				}
+			}
+		}
 
-        private void btRemovePackage_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem selectedItem in lvPackages.SelectedItems)
-            {
-                NeedsRestart = true;
-                if (!Program.ScriptPackages.Uninstall(selectedItem.Tag as PackageManager.Package))
-                {
-                    MessageBox.Show(this, TR.Messages["FailedRemovePackage", "Failed to uninstall package. Please restart ComicRack and try again!"], TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-                }
-            }
-            RefreshPackageList();
-        }
+		private void btRemovePackage_Click(object sender, EventArgs e)
+		{
+			foreach (ListViewItem selectedItem in lvPackages.SelectedItems)
+			{
+				NeedsRestart = true;
+				if (!Program.ScriptPackages.Uninstall(selectedItem.Tag as PackageManager.Package))
+				{
+					MessageBox.Show(this, TR.Messages["FailedRemovePackage", "Failed to uninstall package. Please restart ComicRack and try again!"], TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+				}
+			}
+			RefreshPackageList();
+		}
 
-        private void lvPackages_DoubleClick(object sender, EventArgs e)
-        {
-            ListViewItem listViewItem = lvPackages.SelectedItems.OfType<ListViewItem>().FirstOrDefault();
-            if (listViewItem != null)
-            {
-                PackageManager.Package package = listViewItem.Tag as PackageManager.Package;
-                if (package.PackageType == PackageManager.PackageType.Installed)
-                {
-                    Program.ShowExplorer(package.PackagePath);
-                }
-            }
-        }
+		private void lvPackages_DoubleClick(object sender, EventArgs e)
+		{
+			ListViewItem listViewItem = lvPackages.SelectedItems.OfType<ListViewItem>().FirstOrDefault();
+			if (listViewItem != null)
+			{
+				PackageManager.Package package = listViewItem.Tag as PackageManager.Package;
+				if (package.PackageType == PackageManager.PackageType.Installed)
+				{
+					Program.ShowExplorer(package.PackagePath);
+				}
+			}
+		}
 
-        private void lvPackages_DragDrop(object sender, DragEventArgs e)
-        {
-            try
-            {
-                string[] array = e.Data.GetData(DataFormats.FileDrop) as string[];
-                string[] array2 = array;
-                foreach (string f in array2)
-                {
-                    if (!InstallPlugin(f))
-                    {
-                        break;
-                    }
-                }
-                RefreshPackageList();
-            }
-            catch (Exception)
-            {
-            }
-        }
+		private void lvPackages_DragDrop(object sender, DragEventArgs e)
+		{
+			try
+			{
+				string[] array = e.Data.GetData(DataFormats.FileDrop) as string[];
+				string[] array2 = array;
+				foreach (string f in array2)
+				{
+					if (!InstallPlugin(f))
+					{
+						break;
+					}
+				}
+				RefreshPackageList();
+			}
+			catch (Exception)
+			{
+			}
+		}
 
-        private void lvPackages_DragOver(object sender, DragEventArgs e)
-        {
-            e.Effect = (e.Data.GetDataPresent(DataFormats.FileDrop) ? DragDropEffects.Copy : DragDropEffects.None);
-        }
+		private void lvPackages_DragOver(object sender, DragEventArgs e)
+		{
+			e.Effect = (e.Data.GetDataPresent(DataFormats.FileDrop) ? DragDropEffects.Copy : DragDropEffects.None);
+		}
 
-        private void keyboardShortcutEditor_DragOver(object sender, DragEventArgs e)
-        {
-            e.Effect = (e.Data.GetDataPresent(DataFormats.FileDrop) ? DragDropEffects.Copy : DragDropEffects.None);
-        }
+		private void keyboardShortcutEditor_DragOver(object sender, DragEventArgs e)
+		{
+			e.Effect = (e.Data.GetDataPresent(DataFormats.FileDrop) ? DragDropEffects.Copy : DragDropEffects.None);
+		}
 
-        private void keyboardShortcutEditor_DragDrop(object sender, DragEventArgs e)
-        {
-            try
-            {
-                LoadKeyboard(((string[])e.Data.GetData(DataFormats.FileDrop))[0]);
-            }
-            catch (Exception)
-            {
-            }
-        }
+		private void keyboardShortcutEditor_DragDrop(object sender, DragEventArgs e)
+		{
+			try
+			{
+				LoadKeyboard(((string[])e.Data.GetData(DataFormats.FileDrop))[0]);
+			}
+			catch (Exception)
+			{
+			}
+		}
 
-        private void btExportKeyboard_Click(object sender, EventArgs e)
-        {
-            using (SaveFileDialog saveFileDialog = new SaveFileDialog())
-            {
-                saveFileDialog.Title = btExportKeyboard.Text.Replace("&", string.Empty);
-                saveFileDialog.FileName = TR.Load("FileFilter")["KeyboardLayout", "Keyboard Layout"] + ".xml";
-                saveFileDialog.Filter = TR.Load("FileFilter")["KeyboardLayoutFilter", "Keyboard Layout|*.xml"];
-                saveFileDialog.DefaultExt = ".xml";
-                saveFileDialog.CheckPathExists = true;
-                saveFileDialog.OverwritePrompt = true;
-                if (saveFileDialog.ShowDialog(this) != DialogResult.Cancel)
-                {
-                    try
-                    {
-                        List<StringPair> data = keyboardShortcutEditor.Shortcuts.GetKeyMapping().ToList();
-                        XmlUtility.Store(saveFileDialog.FileName, data);
-                        Program.Settings.KeyboardLayouts.UpdateMostRecent(saveFileDialog.FileName);
-                    }
-                    catch (Exception ex)
-                    {
-                        MessageBox.Show(this, string.Format(TR.Messages["CouldNotExportKeyboardLayout", "Could not export Keyboard Layout!\nReason: {0}"], ex.Message), TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-                    }
-                }
-            }
-        }
+		private void btExportKeyboard_Click(object sender, EventArgs e)
+		{
+			using (SaveFileDialog saveFileDialog = new SaveFileDialog())
+			{
+				saveFileDialog.Title = btExportKeyboard.Text.Replace("&", string.Empty);
+				saveFileDialog.FileName = TR.Load("FileFilter")["KeyboardLayout", "Keyboard Layout"] + ".xml";
+				saveFileDialog.Filter = TR.Load("FileFilter")["KeyboardLayoutFilter", "Keyboard Layout|*.xml"];
+				saveFileDialog.DefaultExt = ".xml";
+				saveFileDialog.CheckPathExists = true;
+				saveFileDialog.OverwritePrompt = true;
+				if (saveFileDialog.ShowDialog(this) != DialogResult.Cancel)
+				{
+					try
+					{
+						List<StringPair> data = keyboardShortcutEditor.Shortcuts.GetKeyMapping().ToList();
+						XmlUtility.Store(saveFileDialog.FileName, data);
+						Program.Settings.KeyboardLayouts.UpdateMostRecent(saveFileDialog.FileName);
+					}
+					catch (Exception ex)
+					{
+						MessageBox.Show(this, string.Format(TR.Messages["CouldNotExportKeyboardLayout", "Could not export Keyboard Layout!\nReason: {0}"], ex.Message), TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+					}
+				}
+			}
+		}
 
-        private void btLoadKeyboard_Click(object sender, EventArgs e)
-        {
-            using (OpenFileDialog openFileDialog = new OpenFileDialog())
-            {
-                openFileDialog.Title = btImportKeyboard.Text.Replace("&", string.Empty);
-                openFileDialog.Filter = TR.Load("FileFilter")["KeyboardLayoutFilter", "Keyboard Layout|*.xml"];
-                openFileDialog.DefaultExt = ".xml";
-                openFileDialog.CheckFileExists = true;
-                if (openFileDialog.ShowDialog(this) != DialogResult.Cancel)
-                {
-                    LoadKeyboard(openFileDialog.FileName);
-                }
-            }
-        }
+		private void btLoadKeyboard_Click(object sender, EventArgs e)
+		{
+			using (OpenFileDialog openFileDialog = new OpenFileDialog())
+			{
+				openFileDialog.Title = btImportKeyboard.Text.Replace("&", string.Empty);
+				openFileDialog.Filter = TR.Load("FileFilter")["KeyboardLayoutFilter", "Keyboard Layout|*.xml"];
+				openFileDialog.DefaultExt = ".xml";
+				openFileDialog.CheckFileExists = true;
+				if (openFileDialog.ShowDialog(this) != DialogResult.Cancel)
+				{
+					LoadKeyboard(openFileDialog.FileName);
+				}
+			}
+		}
 
-        private void btImportKeyboard_ShowContextMenu(object sender, EventArgs e)
-        {
-            FormUtility.SafeToolStripClear(cmKeyboardLayout.Items, 2);
-            foreach (string keyboardLayout in Program.Settings.KeyboardLayouts)
-            {
-                string file = keyboardLayout;
-                cmKeyboardLayout.Items.Add(keyboardLayout, null, delegate
-                {
-                    LoadKeyboard(file);
-                });
-            }
-            cmKeyboardLayout.Items[1].Visible = cmKeyboardLayout.Items.Count > 2;
-        }
+		private void btImportKeyboard_ShowContextMenu(object sender, EventArgs e)
+		{
+			FormUtility.SafeToolStripClear(cmKeyboardLayout.Items, 2);
+			foreach (string keyboardLayout in Program.Settings.KeyboardLayouts)
+			{
+				string file = keyboardLayout;
+				cmKeyboardLayout.Items.Add(keyboardLayout, null, delegate
+				{
+					LoadKeyboard(file);
+				});
+			}
+			cmKeyboardLayout.Items[1].Visible = cmKeyboardLayout.Items.Count > 2;
+		}
 
-        private void miDefaultKeyboardLayout_Click(object sender, EventArgs e)
-        {
-            keyboardShortcutEditor.Shortcuts.SetKeyMapping(Program.DefaultKeyboardMapping);
-            keyboardShortcutEditor.RefreshList();
-        }
+		private void miDefaultKeyboardLayout_Click(object sender, EventArgs e)
+		{
+			keyboardShortcutEditor.Shortcuts.SetKeyMapping(Program.DefaultKeyboardMapping);
+			keyboardShortcutEditor.RefreshList();
+		}
 
-        private void chkHideSampleScripts_CheckedChanged(object sender, EventArgs e)
-        {
-            FillScriptsList();
-        }
+		private void chkHideSampleScripts_CheckedChanged(object sender, EventArgs e)
+		{
+			FillScriptsList();
+		}
 
-        private void FillScriptsList()
-        {
-            lvScripts.BeginUpdate();
-            try
-            {
-                lvScripts.Items.Clear();
-                if (pluginEngine == null)
-                {
-                    return;
-                }
-                foreach (Command allCommand in pluginEngine.GetAllCommands())
-                {
-                    if (!lvScripts.Items.ContainsKey(allCommand.Key) && (!allCommand.Name.Contains("[Code Sample]") || !chkHideSampleScripts.Checked))
-                    {
-                        string value = IniFile.GetValue(Path.Combine(allCommand.Environment.CommandPath, "package.ini"), "Name", "Other");
-                        string hookDescription = PluginEngine.GetHookDescription(allCommand.Hook);
-                        ListViewGroup group = lvScripts.Groups[hookDescription] ?? lvScripts.Groups.Add(hookDescription, hookDescription);
-                        ListViewItem listViewItem = lvScripts.Items.Add(allCommand.Key, allCommand.GetLocalizedName(), allCommand.Key);
-                        listViewItem.SubItems.Add(value);
-                        listViewItem.Tag = allCommand;
-                        listViewItem.Checked = allCommand.Enabled;
-                        listViewItem.ToolTipText = allCommand.GetLocalizedDescription();
-                        listViewItem.Group = group;
-                        Image commandImage = allCommand.CommandImage;
-                        if (commandImage != null)
-                        {
-                            imageList.Images.Add(allCommand.Key, commandImage);
-                        }
-                    }
-                }
-                lvScripts.SortGroups();
-            }
-            finally
-            {
-                lvScripts.EndUpdate();
-            }
-        }
+		private void FillScriptsList()
+		{
+			lvScripts.BeginUpdate();
+			try
+			{
+				lvScripts.Items.Clear();
+				if (pluginEngine == null)
+				{
+					return;
+				}
+				foreach (Command allCommand in pluginEngine.GetAllCommands())
+				{
+					if (!lvScripts.Items.ContainsKey(allCommand.Key) && (!allCommand.Name.Contains("[Code Sample]") || !chkHideSampleScripts.Checked))
+					{
+						string value = IniFile.GetValue(Path.Combine(allCommand.Environment.CommandPath, "package.ini"), "Name", "Other");
+						string hookDescription = PluginEngine.GetHookDescription(allCommand.Hook);
+						ListViewGroup group = lvScripts.Groups[hookDescription] ?? lvScripts.Groups.Add(hookDescription, hookDescription);
+						ListViewItem listViewItem = lvScripts.Items.Add(allCommand.Key, allCommand.GetLocalizedName(), allCommand.Key);
+						listViewItem.SubItems.Add(value);
+						listViewItem.Tag = allCommand;
+						listViewItem.Checked = allCommand.Enabled;
+						listViewItem.ToolTipText = allCommand.GetLocalizedDescription();
+						listViewItem.Group = group;
+						Image commandImage = allCommand.CommandImage;
+						if (commandImage != null)
+						{
+							imageList.Images.Add(allCommand.Key, commandImage);
+						}
+					}
+				}
+				lvScripts.SortGroups();
+			}
+			finally
+			{
+				lvScripts.EndUpdate();
+			}
+		}
 
-        private void LoadKeyboard(string f)
-        {
-            try
-            {
-                keyboardShortcutEditor.Shortcuts.SetKeyMapping(XmlUtility.Load<List<StringPair>>(f));
-                keyboardShortcutEditor.RefreshList();
-                Program.Settings.KeyboardLayouts.UpdateMostRecent(f);
-            }
-            catch (Exception ex)
-            {
-                Program.Settings.KeyboardLayouts.Remove(f);
-                MessageBox.Show(this, string.Format(TR.Messages["CouldNotImportKeyboardLayout", "Could not import Keyboard Layout!\nReason: {0}"], ex.Message), TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-            }
-        }
+		private void LoadKeyboard(string f)
+		{
+			try
+			{
+				keyboardShortcutEditor.Shortcuts.SetKeyMapping(XmlUtility.Load<List<StringPair>>(f));
+				keyboardShortcutEditor.RefreshList();
+				Program.Settings.KeyboardLayouts.UpdateMostRecent(f);
+			}
+			catch (Exception ex)
+			{
+				Program.Settings.KeyboardLayouts.Remove(f);
+				MessageBox.Show(this, string.Format(TR.Messages["CouldNotImportKeyboardLayout", "Could not import Keyboard Layout!\nReason: {0}"], ex.Message), TR.Messages["Attention", "Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+			}
+		}
 
-        private bool InstallPlugin(string f)
-        {
-            if (Program.ScriptPackages.PackageFileExists(f) && !QuestionDialog.Ask(this, DuplicatePackageText, TR.Default["Yes", "Yes"]))
-            {
-                return false;
-            }
-            bool flag = Program.ScriptPackages.Install(f);
-            NeedsRestart |= flag;
-            return flag;
-        }
+		private bool InstallPlugin(string f)
+		{
+			if (Program.ScriptPackages.PackageFileExists(f) && !QuestionDialog.Ask(this, DuplicatePackageText, TR.Default["Yes", "Yes"]))
+			{
+				return false;
+			}
+			bool flag = Program.ScriptPackages.Install(f);
+			NeedsRestart |= flag;
+			return flag;
+		}
 
-        private void FillExtensionsList()
-        {
-            lbFormats.Items.Clear();
-            foreach (FileFormat item in from f in Providers.Readers.GetSourceFormats()
-                                        orderby f
-                                        select f)
-            {
-                int index = lbFormats.Items.Add(item);
-                lbFormats.SetItemChecked(index, item.IsShellRegistered(Program.ComicRackTypeId));
-            }
-        }
+		private void FillExtensionsList()
+		{
+			lbFormats.Items.Clear();
+			foreach (FileFormat item in from f in Providers.Readers.GetSourceFormats()
+										orderby f
+										select f)
+			{
+				int index = lbFormats.Items.Add(item);
+				lbFormats.SetItemChecked(index, item.IsShellRegistered(Program.ComicRackTypeId));
+			}
+		}
 
-        private void FillBackupOptions()
-        {
-            BackupManagerOptions backupManagerOptions = Program.Settings.BackupManager;
+		private void FillBackupOptions()
+		{
+			BackupManagerOptions backupManagerOptions = Program.Settings.BackupManager;
 
-            txtBackupLocation.Text = backupManagerOptions.Location;
+			txtBackupLocation.Text = backupManagerOptions.Location;
 			chkIncludeAllAlternateConfigs.Checked = backupManagerOptions.IncludeAllAlternateConfigs;
-            numBackupsToKeep.Value = backupManagerOptions.BackupsToKeep;
-            chkBackupOnStartup.Checked = backupManagerOptions.OnStartup;
-            chkBackupOnExit.Checked = backupManagerOptions.OnExit;
+			numBackupsToKeep.Value = backupManagerOptions.BackupsToKeep;
+			chkBackupOnStartup.Checked = backupManagerOptions.OnStartup;
+			chkBackupOnExit.Checked = backupManagerOptions.OnExit;
 
-            // Fill the CheckedListBox
-            lbBackupOptions.Items.Clear();
+			// Fill the CheckedListBox
+			lbBackupOptions.Items.Clear();
 			foreach (BackupOptions option in Enum.GetValues(typeof(BackupOptions)))
-            {
-                if (option != BackupOptions.None && option != BackupOptions.Full && option != BackupOptions.FullWithCache)
-                {
-                    bool value = backupManagerOptions.Options.HasFlag(option);
-                    int index = lbBackupOptions.Items.Add(option, value); 
-                }
-            }
-        }
+			{
+				if (option != BackupOptions.None && option != BackupOptions.Full && option != BackupOptions.FullWithCache)
+				{
+					bool value = backupManagerOptions.Options.HasFlag(option);
+					int index = lbBackupOptions.Items.Add(option, value);
+				}
+			}
+		}
 
 		private void SaveBackupManagerOptions()
 		{
-            BackupOptions backupOptions = BackupOptions.None;
-            foreach (BackupOptions item in lbBackupOptions.CheckedItems)
-            {
-                backupOptions |= item; 
-            }
+			BackupOptions backupOptions = BackupOptions.None;
+			foreach (BackupOptions item in lbBackupOptions.CheckedItems)
+			{
+				backupOptions |= item;
+			}
 
-            Program.Settings.BackupManager.Location = string.IsNullOrWhiteSpace(txtBackupLocation.Text) ? null : txtBackupLocation.Text;
-            Program.Settings.BackupManager.BackupsToKeep = (int)numBackupsToKeep.Value;
-            Program.Settings.BackupManager.IncludeAllAlternateConfigs = chkIncludeAllAlternateConfigs.Checked;
-            Program.Settings.BackupManager.OnStartup = chkBackupOnStartup.Checked;
-            Program.Settings.BackupManager.OnExit = chkBackupOnExit.Checked;
-            Program.Settings.BackupManager.Options = backupOptions;
+			Program.Settings.BackupManager.Location = string.IsNullOrWhiteSpace(txtBackupLocation.Text) ? null : txtBackupLocation.Text;
+			Program.Settings.BackupManager.BackupsToKeep = (int)numBackupsToKeep.Value;
+			Program.Settings.BackupManager.IncludeAllAlternateConfigs = chkIncludeAllAlternateConfigs.Checked;
+			Program.Settings.BackupManager.OnStartup = chkBackupOnStartup.Checked;
+			Program.Settings.BackupManager.OnExit = chkBackupOnExit.Checked;
+			Program.Settings.BackupManager.Options = backupOptions;
 		}
 
 		public void Apply()
-        {
-            string cultureName = ((TRInfo)lbLanguages.SelectedItem).CultureName;
-            if (cultureName != Program.Settings.CultureName)
-            {
-                NeedsRestart = true;
-                Program.Settings.CultureName = cultureName;
-            }
-            NeedsRestart |= Plugins != null && !string.IsNullOrEmpty(Program.Settings.PluginsStates) && Plugins.CommandStates != Program.Settings.PluginsStates;
-            FormUtility.RetrieveOptionsFromPanel(pageBehavior, Program.Settings);
-            Program.Settings.MouseWheelSpeed = (float)tbMouseWheel.Value / 10f;
-            Program.Settings.LibraryGaugesFormat = LibraryGauges.None.SetMask(LibraryGauges.Unread, chkLibraryGaugesUnread.Checked).SetMask(LibraryGauges.New, chkLibraryGaugesNew.Checked).SetMask(LibraryGauges.Total, chkLibraryGaugesTotal.Checked)
-                .SetMask(LibraryGauges.Numeric, chkLibraryGaugesNumeric.Checked);
-            Program.Settings.DisplayLibraryGauges = chkLibraryGauges.Checked;
-            Program.Settings.PageImageDisplayOptions = Program.Settings.PageImageDisplayOptions.SetMask(ImageDisplayOptions.AnamorphicScaling, chkAnamorphicScaling.Checked);
-            Program.Settings.PageImageDisplayOptions = Program.Settings.PageImageDisplayOptions.SetMask(ImageDisplayOptions.HighQuality, chkHighQualityDisplay.Checked);
-            Program.Settings.InternetCacheEnabled = chkEnableInternetCache.Checked;
-            Program.Settings.InternetCacheSizeMB = (int)numInternetCacheSize.Value;
-            Program.Settings.ThumbCacheEnabled = chkEnableThumbnailCache.Checked;
-            Program.Settings.ThumbCacheSizeMB = (int)numThumbnailCacheSize.Value;
-            Program.Settings.PageCacheEnabled = chkEnablePageCache.Checked;
-            Program.Settings.PageCacheSizeMB = (int)numPageCacheSize.Value;
-            Program.Settings.MaximumMemoryMB = tbMaximumMemoryUsage.Value * MaximumMemoryStepSize;
-            Program.Settings.MemoryPageCacheOptimized = chkMemPageOptimized.Checked;
-            Program.Settings.MemoryPageCacheCount = (int)numMemPageCount.Value;
-            Program.Settings.MemoryThumbCacheOptimized = chkMemThumbOptimized.Checked;
-            Program.Settings.MemoryThumbCacheSizeMB = (int)numMemThumbSize.Value;
-            BitmapAdjustmentOptions options = (chkAutoContrast.Checked ? BitmapAdjustmentOptions.AutoContrast : BitmapAdjustmentOptions.None);
-            Program.Settings.GlobalColorAdjustment = new BitmapAdjustment((float)tbSaturation.Value / 100f, (float)tbBrightness.Value / 100f, (float)tbContrast.Value / 100f, (float)tbGamma.Value / 100f, options, tbSharpening.Value);
-            Program.Settings.ShowCurrentPageOverlay = chkShowCurrentPageOverlay.Checked;
-            Program.Settings.ShowVisiblePagePartOverlay = chkShowVisiblePartOverlay.Checked;
-            Program.Settings.ShowStatusOverlay = chkShowStatusOverlay.Checked;
-            Program.Settings.ShowNavigationOverlay = chkShowNavigationOverlay.Checked;
-            Program.Settings.NavigationOverlayOnTop = cbNavigationOverlayPosition.SelectedIndex == 1;
-            Program.Settings.CurrentPageShowsName = chkShowPageNames.Checked;
-            Program.Settings.HardwareAcceleration = chkEnableHardware.Checked;
-            Program.Settings.SmoothScrolling = chkSmoothAutoScrolling.Checked;
-            Program.Settings.DisplayChangeAnimation = chkEnableDisplayChangeAnimation.Checked;
-            Program.Settings.SoftwareFiltering = chkEnableSoftwareFiltering.Checked;
-            Program.Settings.HardwareFiltering = chkEnableHardwareFiltering.Checked;
-            Program.Settings.FlowingMouseScrolling = chkEnableInertialMouseScrolling.Checked;
-            Program.Settings.OverlayScaling = tbOverlayScaling.Value;
-            Program.Settings.RemoveMissingFilesOnFullScan = chkAutoRemoveMissing.Checked;
-            Program.Settings.DontAddRemoveFiles = chkDontAddRemovedFiles.Checked;
-            if (!Program.Settings.DontAddRemoveFiles)
-            {
-                Program.Database.ClearBlackList();
-            }
-            Program.Settings.OverwriteAssociations = chkOverwriteAssociations.Checked;
-            Program.Settings.LookForShared = chkLookForShared.Checked;
-            Program.Settings.AutoConnectShares = chkAutoConnectShares.Checked;
-            CopyWatchFoldersToDatabase();
-            RegisterFileTypes();
-            Program.Settings.UpdateComicFiles = chkUpdateComicFiles.Checked;
-            Program.Settings.AutoUpdateComicsFiles = chkAutoUpdateComicFiles.Checked;
-            Program.Settings.IgnoredCoverImages = (string.IsNullOrEmpty(txCoverFilter.Text) ? null : txCoverFilter.Text);
-            Program.Settings.ScriptingLibraries = txLibraries.Text;
-            Program.Settings.Scripting = !chkDisableScripting.Checked;
-            Program.Settings.HideSampleScripts = chkHideSampleScripts.Checked;
-            if (!string.IsNullOrEmpty(BackupFile))
-            {
-                try
-                {
-                    try
-                    {
-                        AutomaticProgressDialog.Process(this, TR.Messages["DatabaseRestore", "Database Restore"], TR.Messages["DatabaseRestoreText", "Restoring database from Backup file"], 1000, delegate
-                        {
-                            Program.DatabaseManager.RestoreFrom(BackupFile, Program.Paths.CustomThumbnailPath);
-                        }, AutomaticProgressDialogOptions.None);
-                    }
-                    catch (Exception)
-                    {
-                        MessageBox.Show(this, TR.Messages["DatabaseRestoreError", "There was an error restoring the Database Backup"], TR.Messages["Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-                    }
-                    BackupFile = null;
-                    NeedsRestart = true;
-                }
-                catch
-                {
-                }
-            }
-            List<ComicLibraryServerConfig> list = (from p in tabShares.TabPages.OfType<Control>()
-                                                   select p.Controls[0] as ServerEditControl into se
-                                                   select se.Config).ToList();
-            if (!list.SequenceEqual(Program.Settings.Shares, new ComicLibraryServerConfig.EqualityComparer()))
-            {
-                NeedsRestart = true;
-                Program.Settings.Shares.Clear();
-                Program.Settings.Shares.AddRange(list);
-            }
-            string text = txPublicServerAddress.Text.Trim();
-            if (text != Program.Settings.ExternalServerAddress)
-            {
-                NeedsRestart = true;
-                Program.Settings.ExternalServerAddress = text;
-            }
-            if (txPrivateListingPassword.Password != Program.Settings.PrivateListingPassword)
-            {
-                NeedsRestart = true;
-                Program.Settings.PrivateListingPassword = txPrivateListingPassword.Password;
-            }
-            Program.Settings.ExtraWifiDeviceAddresses = txWifiAddresses.Text;
+		{
+			string cultureName = ((TRInfo)lbLanguages.SelectedItem).CultureName;
+			if (cultureName != Program.Settings.CultureName)
+			{
+				NeedsRestart = true;
+				Program.Settings.CultureName = cultureName;
+			}
+			NeedsRestart |= Plugins != null && !string.IsNullOrEmpty(Program.Settings.PluginsStates) && Plugins.CommandStates != Program.Settings.PluginsStates;
+			FormUtility.RetrieveOptionsFromPanel(pageBehavior, Program.Settings);
+			Program.Settings.MouseWheelSpeed = (float)tbMouseWheel.Value / 10f;
+			Program.Settings.LibraryGaugesFormat = LibraryGauges.None.SetMask(LibraryGauges.Unread, chkLibraryGaugesUnread.Checked).SetMask(LibraryGauges.New, chkLibraryGaugesNew.Checked).SetMask(LibraryGauges.Total, chkLibraryGaugesTotal.Checked)
+				.SetMask(LibraryGauges.Numeric, chkLibraryGaugesNumeric.Checked);
+			Program.Settings.DisplayLibraryGauges = chkLibraryGauges.Checked;
+			Program.Settings.PageImageDisplayOptions = Program.Settings.PageImageDisplayOptions.SetMask(ImageDisplayOptions.AnamorphicScaling, chkAnamorphicScaling.Checked);
+			Program.Settings.PageImageDisplayOptions = Program.Settings.PageImageDisplayOptions.SetMask(ImageDisplayOptions.HighQuality, chkHighQualityDisplay.Checked);
+			Program.Settings.InternetCacheEnabled = chkEnableInternetCache.Checked;
+			Program.Settings.InternetCacheSizeMB = (int)numInternetCacheSize.Value;
+			Program.Settings.ThumbCacheEnabled = chkEnableThumbnailCache.Checked;
+			Program.Settings.ThumbCacheSizeMB = (int)numThumbnailCacheSize.Value;
+			Program.Settings.PageCacheEnabled = chkEnablePageCache.Checked;
+			Program.Settings.PageCacheSizeMB = (int)numPageCacheSize.Value;
+			Program.Settings.MaximumMemoryMB = tbMaximumMemoryUsage.Value * MaximumMemoryStepSize;
+			Program.Settings.MemoryPageCacheOptimized = chkMemPageOptimized.Checked;
+			Program.Settings.MemoryPageCacheCount = (int)numMemPageCount.Value;
+			Program.Settings.MemoryThumbCacheOptimized = chkMemThumbOptimized.Checked;
+			Program.Settings.MemoryThumbCacheSizeMB = (int)numMemThumbSize.Value;
+			BitmapAdjustmentOptions options = (chkAutoContrast.Checked ? BitmapAdjustmentOptions.AutoContrast : BitmapAdjustmentOptions.None);
+			Program.Settings.GlobalColorAdjustment = new BitmapAdjustment((float)tbSaturation.Value / 100f, (float)tbBrightness.Value / 100f, (float)tbContrast.Value / 100f, (float)tbGamma.Value / 100f, options, tbSharpening.Value);
+			Program.Settings.ShowCurrentPageOverlay = chkShowCurrentPageOverlay.Checked;
+			Program.Settings.ShowVisiblePagePartOverlay = chkShowVisiblePartOverlay.Checked;
+			Program.Settings.ShowStatusOverlay = chkShowStatusOverlay.Checked;
+			Program.Settings.ShowNavigationOverlay = chkShowNavigationOverlay.Checked;
+			Program.Settings.NavigationOverlayOnTop = cbNavigationOverlayPosition.SelectedIndex == 1;
+			Program.Settings.CurrentPageShowsName = chkShowPageNames.Checked;
+			Program.Settings.HardwareAcceleration = chkEnableHardware.Checked;
+			Program.Settings.SmoothScrolling = chkSmoothAutoScrolling.Checked;
+			Program.Settings.DisplayChangeAnimation = chkEnableDisplayChangeAnimation.Checked;
+			Program.Settings.SoftwareFiltering = chkEnableSoftwareFiltering.Checked;
+			Program.Settings.HardwareFiltering = chkEnableHardwareFiltering.Checked;
+			Program.Settings.FlowingMouseScrolling = chkEnableInertialMouseScrolling.Checked;
+			Program.Settings.OverlayScaling = tbOverlayScaling.Value;
+			Program.Settings.RemoveMissingFilesOnFullScan = chkAutoRemoveMissing.Checked;
+			Program.Settings.DontAddRemoveFiles = chkDontAddRemovedFiles.Checked;
+			if (!Program.Settings.DontAddRemoveFiles)
+			{
+				Program.Database.ClearBlackList();
+			}
+			Program.Settings.OverwriteAssociations = chkOverwriteAssociations.Checked;
+			Program.Settings.LookForShared = chkLookForShared.Checked;
+			Program.Settings.AutoConnectShares = chkAutoConnectShares.Checked;
+			CopyWatchFoldersToDatabase();
+			RegisterFileTypes();
+			Program.Settings.UpdateComicFiles = chkUpdateComicFiles.Checked;
+			Program.Settings.UpdateComicBookFiles = chkUpdateComicBookFiles.Checked;
+			Program.Settings.AutoUpdateComicsFiles = chkAutoUpdateComicFiles.Checked;
+			Program.Settings.IgnoredCoverImages = (string.IsNullOrEmpty(txCoverFilter.Text) ? null : txCoverFilter.Text);
+			Program.Settings.ScriptingLibraries = txLibraries.Text;
+			Program.Settings.Scripting = !chkDisableScripting.Checked;
+			Program.Settings.HideSampleScripts = chkHideSampleScripts.Checked;
+			if (!string.IsNullOrEmpty(BackupFile))
+			{
+				try
+				{
+					try
+					{
+						AutomaticProgressDialog.Process(this, TR.Messages["DatabaseRestore", "Database Restore"], TR.Messages["DatabaseRestoreText", "Restoring database from Backup file"], 1000, delegate
+						{
+							Program.DatabaseManager.RestoreFrom(BackupFile, Program.Paths.CustomThumbnailPath);
+						}, AutomaticProgressDialogOptions.None);
+					}
+					catch (Exception)
+					{
+						MessageBox.Show(this, TR.Messages["DatabaseRestoreError", "There was an error restoring the Database Backup"], TR.Messages["Attention"], MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+					}
+					BackupFile = null;
+					NeedsRestart = true;
+				}
+				catch
+				{
+				}
+			}
+			List<ComicLibraryServerConfig> list = (from p in tabShares.TabPages.OfType<Control>()
+												   select p.Controls[0] as ServerEditControl into se
+												   select se.Config).ToList();
+			if (!list.SequenceEqual(Program.Settings.Shares, new ComicLibraryServerConfig.EqualityComparer()))
+			{
+				NeedsRestart = true;
+				Program.Settings.Shares.Clear();
+				Program.Settings.Shares.AddRange(list);
+			}
+			string text = txPublicServerAddress.Text.Trim();
+			if (text != Program.Settings.ExternalServerAddress)
+			{
+				NeedsRestart = true;
+				Program.Settings.ExternalServerAddress = text;
+			}
+			if (txPrivateListingPassword.Password != Program.Settings.PrivateListingPassword)
+			{
+				NeedsRestart = true;
+				Program.Settings.PrivateListingPassword = txPrivateListingPassword.Password;
+			}
+			Program.Settings.ExtraWifiDeviceAddresses = txWifiAddresses.Text;
 			Program.Settings.CurrentWorkspace.PreferencesOutputSize = SafeSize;
-            SaveBackupManagerOptions();
+			SaveBackupManagerOptions();
 			SaveVirtualTags();
-            Program.RefreshAllWindows();
-            Program.ForAllForms(delegate (Form f)
-            {
-                f.FindServices<ISettingsChanged>().ForEach(delegate (ISettingsChanged s)
-                {
-                    s.SettingsChanged();
-                });
-            });
+			Program.RefreshAllWindows();
+			Program.ForAllForms(delegate (Form f)
+			{
+				f.FindServices<ISettingsChanged>().ForEach(delegate (ISettingsChanged s)
+				{
+					s.SettingsChanged();
+				});
+			});
 		}
 
 		private void SetScanButtonText()
-        {
-            btScan.Text = (Program.Scanner.IsScanning ? LocalizeUtility.GetText(this, "Stop", "Stop") : LocalizeUtility.GetText(this, "Scan", "Scan"));
-        }
+		{
+			btScan.Text = (Program.Scanner.IsScanning ? LocalizeUtility.GetText(this, "Stop", "Stop") : LocalizeUtility.GetText(this, "Scan", "Scan"));
+		}
 
-        private void SetSettings()
+		private void SetSettings()
 		{
 			FormUtility.FillPanelWithOptions(pageBehavior, Program.Settings, TR.Load("Settings"));
 			chkLibraryGauges.Checked = Program.Settings.DisplayLibraryGauges;
@@ -1065,6 +1074,7 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 			tbOverlayScaling.Value = Program.Settings.OverlayScaling;
 			chkOverwriteAssociations.Checked = Program.Settings.OverwriteAssociations;
 			chkUpdateComicFiles.Checked = Program.Settings.UpdateComicFiles;
+			chkUpdateComicBookFiles.Checked = Program.Settings.UpdateComicBookFiles;
 			chkAutoUpdateComicFiles.Checked = Program.Settings.AutoUpdateComicsFiles;
 			txCoverFilter.Text = Program.Settings.IgnoredCoverImages;
 			txLibraries.Text = Program.Settings.ScriptingLibraries;
@@ -1092,384 +1102,384 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 		}
 
 		private void AddSharePage(ComicLibraryServerConfig cfg)
-        {
-            TabPage tab = new TabPage(cfg.Name)
-            {
-                UseVisualStyleBackColor = true
-            };
-            ServerEditControl sc = new ServerEditControl
-            {
-                Dock = DockStyle.Fill,
-                Config = cfg,
-                BackColor = ThemeColors.Preferences.ServerEditControl
-            };
-            sc.ShareNameChanged += delegate
-            {
-                tab.Text = sc.ShareName;
-            };
-            // this IS required
-            //ThemeExtensions.Theme(tab);
-            tab.Controls.Add(sc);
-            tabShares.TabPages.Add(tab);
-        }
+		{
+			TabPage tab = new TabPage(cfg.Name)
+			{
+				UseVisualStyleBackColor = true
+			};
+			ServerEditControl sc = new ServerEditControl
+			{
+				Dock = DockStyle.Fill,
+				Config = cfg,
+				BackColor = ThemeColors.Preferences.ServerEditControl
+			};
+			sc.ShareNameChanged += delegate
+			{
+				tab.Text = sc.ShareName;
+			};
+			// this IS required
+			//ThemeExtensions.Theme(tab);
+			tab.Controls.Add(sc);
+			tabShares.TabPages.Add(tab);
+		}
 
-        private void RemoveSharePage(TabPage tab)
-        {
-            Control control = tab.Controls[0];
-            tab.Controls.Remove(control);
-            control.Dispose();
-            tabShares.TabPages.Remove(tab);
-            tab.Dispose();
-        }
+		private void RemoveSharePage(TabPage tab)
+		{
+			Control control = tab.Controls[0];
+			tab.Controls.Remove(control);
+			control.Dispose();
+			tabShares.TabPages.Remove(tab);
+			tab.Dispose();
+		}
 
-        private void CopyWatchFoldersToDatabase()
-        {
-            Program.Database.WatchFolders.Clear();
-            for (int i = 0; i < lbPaths.Items.Count; i++)
-            {
-                Program.Database.WatchFolders.Add(new WatchFolder(lbPaths.Items[i].ToString(), lbPaths.GetItemChecked(i)));
-            }
-        }
+		private void CopyWatchFoldersToDatabase()
+		{
+			Program.Database.WatchFolders.Clear();
+			for (int i = 0; i < lbPaths.Items.Count; i++)
+			{
+				Program.Database.WatchFolders.Add(new WatchFolder(lbPaths.Items[i].ToString(), lbPaths.GetItemChecked(i)));
+			}
+		}
 
-        private void RegisterFileTypes()
-        {
-            for (int i = 0; i < lbFormats.Items.Count; i++)
-            {
-                FileFormat fileFormat = (FileFormat)lbFormats.Items[i];
-                if (lbFormats.GetItemChecked(i))
-                {
-                    fileFormat.RegisterShell(Program.ComicRackTypeId, Program.ComicRackDocumentName, Program.Settings.OverwriteAssociations);
-                }
-                else
-                {
-                    fileFormat.UnregisterShell(Program.ComicRackTypeId);
-                }
-            }
-        }
+		private void RegisterFileTypes()
+		{
+			for (int i = 0; i < lbFormats.Items.Count; i++)
+			{
+				FileFormat fileFormat = (FileFormat)lbFormats.Items[i];
+				if (lbFormats.GetItemChecked(i))
+				{
+					fileFormat.RegisterShell(Program.ComicRackTypeId, Program.ComicRackDocumentName, Program.Settings.OverwriteAssociations);
+				}
+				else
+				{
+					fileFormat.UnregisterShell(Program.ComicRackTypeId);
+				}
+			}
+		}
 
-        private void SetTab(CheckBox cb)
-        {
-            if (blockSetTab)
-            {
-                return;
-            }
-            blockSetTab = true;
-            try
-            {
-                foreach (CheckBox tabButton in tabButtons)
-                {
-                    tabButton.Checked = tabButton == cb;
-                    Control control = tabButton.Tag as Control;
-                    if (control.Tag is Control)
-                    {
-                        control = control.Tag as Control;
-                    }
-                    control.Visible = tabButton.Checked;
-                }
-            }
-            finally
-            {
-                blockSetTab = false;
-            }
-        }
+		private void SetTab(CheckBox cb)
+		{
+			if (blockSetTab)
+			{
+				return;
+			}
+			blockSetTab = true;
+			try
+			{
+				foreach (CheckBox tabButton in tabButtons)
+				{
+					tabButton.Checked = tabButton == cb;
+					Control control = tabButton.Tag as Control;
+					if (control.Tag is Control)
+					{
+						control = control.Tag as Control;
+					}
+					control.Visible = tabButton.Checked;
+				}
+			}
+			finally
+			{
+				blockSetTab = false;
+			}
+		}
 
-        private void UpdateDiskCacheStatus(object sender, EventArgs e)
-        {
-            if (!this.BeginInvokeIfRequired(delegate
-            {
-                UpdateDiskCacheStatus(sender, e);
-            }))
-            {
-                lblInternetCacheUsage.Text = string.Format("({0}/{1})", Program.InternetCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
-                {
-                    Program.InternetCache.Size
-                }));
-                lblPageCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Pages.DiskCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
-                {
-                    Program.ImagePool.Pages.DiskCache.Size
-                }));
-                lblThumbCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Thumbs.DiskCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
-                {
-                    Program.ImagePool.Thumbs.DiskCache.Size
-                }));
-            }
-        }
+		private void UpdateDiskCacheStatus(object sender, EventArgs e)
+		{
+			if (!this.BeginInvokeIfRequired(delegate
+			{
+				UpdateDiskCacheStatus(sender, e);
+			}))
+			{
+				lblInternetCacheUsage.Text = string.Format("({0}/{1})", Program.InternetCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
+				{
+					Program.InternetCache.Size
+				}));
+				lblPageCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Pages.DiskCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
+				{
+					Program.ImagePool.Pages.DiskCache.Size
+				}));
+				lblThumbCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Thumbs.DiskCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
+				{
+					Program.ImagePool.Thumbs.DiskCache.Size
+				}));
+			}
+		}
 
-        private void UpdateMemoryCacheStatus()
-        {
-            if (!this.BeginInvokeIfRequired(UpdateMemoryCacheStatus))
-            {
-                lblPageMemCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Pages.MemoryCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
-                {
-                    Program.ImagePool.Pages.MemoryCache.Size
-                }));
-                lblThumbMemCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Thumbs.MemoryCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
-                {
-                    Program.ImagePool.Thumbs.MemoryCache.Size
-                }));
-            }
-        }
+		private void UpdateMemoryCacheStatus()
+		{
+			if (!this.BeginInvokeIfRequired(UpdateMemoryCacheStatus))
+			{
+				lblPageMemCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Pages.MemoryCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
+				{
+					Program.ImagePool.Pages.MemoryCache.Size
+				}));
+				lblThumbMemCacheUsage.Text = string.Format("({0}/{1})", Program.ImagePool.Thumbs.MemoryCache.Count, string.Format(new FileLengthFormat(), "{0}", new object[1]
+				{
+					Program.ImagePool.Thumbs.MemoryCache.Size
+				}));
+			}
+		}
 
-        private void RefreshPackageList()
-        {
-            lvPackages.Items.Clear();
-            foreach (PackageManager.Package item in (from p in Program.ScriptPackages.GetPackages()
-                                                     orderby p.PackageType
-                                                     select p).Reverse())
-            {
-                ListViewItem listViewItem = lvPackages.Items.Add(item.Name, item.Name, 0);
-                if (item.Image != null)
-                {
-                    packageImageList.Images.Add(item.Image);
-                    listViewItem.ImageIndex = packageImageList.Images.Count - 1;
-                }
-                listViewItem.Tag = item;
-                if (!string.IsNullOrEmpty(item.Version))
-                {
-                    listViewItem.Text = listViewItem.Text + " V" + item.Version;
-                }
-                listViewItem.SubItems.Add(item.Author);
-                listViewItem.SubItems.Add(item.Description);
-                switch (item.PackageType)
-                {
-                    default:
-                        listViewItem.Group = lvPackages.Groups["packageGroupInstalled"];
-                        break;
-                    case PackageManager.PackageType.PendingInstall:
-                        listViewItem.Group = lvPackages.Groups["packageGroupInstall"];
-                        break;
-                    case PackageManager.PackageType.PendingRemove:
-                        listViewItem.Group = lvPackages.Groups["packageGroupRemove"];
-                        break;
-                }
-            }
-        }
+		private void RefreshPackageList()
+		{
+			lvPackages.Items.Clear();
+			foreach (PackageManager.Package item in (from p in Program.ScriptPackages.GetPackages()
+													 orderby p.PackageType
+													 select p).Reverse())
+			{
+				ListViewItem listViewItem = lvPackages.Items.Add(item.Name, item.Name, 0);
+				if (item.Image != null)
+				{
+					packageImageList.Images.Add(item.Image);
+					listViewItem.ImageIndex = packageImageList.Images.Count - 1;
+				}
+				listViewItem.Tag = item;
+				if (!string.IsNullOrEmpty(item.Version))
+				{
+					listViewItem.Text = listViewItem.Text + " V" + item.Version;
+				}
+				listViewItem.SubItems.Add(item.Author);
+				listViewItem.SubItems.Add(item.Description);
+				switch (item.PackageType)
+				{
+					default:
+						listViewItem.Group = lvPackages.Groups["packageGroupInstalled"];
+						break;
+					case PackageManager.PackageType.PendingInstall:
+						listViewItem.Group = lvPackages.Groups["packageGroupInstall"];
+						break;
+					case PackageManager.PackageType.PendingRemove:
+						listViewItem.Group = lvPackages.Groups["packageGroupRemove"];
+						break;
+				}
+			}
+		}
 
-        private void btAssociateExtensions_Click(object sender, EventArgs e)
-        {
-            string str = "-rf \"" + (chkOverwriteAssociations.Checked ? "!" : string.Empty);
-            for (int i = 0; i < lbFormats.Items.Count; i++)
-            {
-                FileFormat fileFormat = (FileFormat)lbFormats.Items[i];
-                if (i != 0)
-                {
-                    str += ",";
-                }
-                if (!lbFormats.GetItemChecked(i))
-                {
-                    str += "-";
-                }
-                str += fileFormat.Name;
-            }
-            str += "\"";
-            if (ProcessRunner.RunElevated(Application.ExecutablePath, str) == 0)
-            {
-                FillExtensionsList();
-            }
-        }
+		private void btAssociateExtensions_Click(object sender, EventArgs e)
+		{
+			string str = "-rf \"" + (chkOverwriteAssociations.Checked ? "!" : string.Empty);
+			for (int i = 0; i < lbFormats.Items.Count; i++)
+			{
+				FileFormat fileFormat = (FileFormat)lbFormats.Items[i];
+				if (i != 0)
+				{
+					str += ",";
+				}
+				if (!lbFormats.GetItemChecked(i))
+				{
+					str += "-";
+				}
+				str += fileFormat.Name;
+			}
+			str += "\"";
+			if (ProcessRunner.RunElevated(Application.ExecutablePath, str) == 0)
+			{
+				FillExtensionsList();
+			}
+		}
 
-        private void btAddShare_Click(object sender, EventArgs e)
-        {
-            ComicLibraryServerConfig comicLibraryServerConfig = new ComicLibraryServerConfig();
-            comicLibraryServerConfig.Name = $"{Environment.UserName}'s Library";
-            if (tabShares.TabCount > 1)
-            {
-                comicLibraryServerConfig.Name += $" ({tabShares.TabCount + 1})";
-            }
-            AddSharePage(comicLibraryServerConfig);
-            tabShares.SelectedIndex = tabShares.TabPages.Count - 1;
-        }
+		private void btAddShare_Click(object sender, EventArgs e)
+		{
+			ComicLibraryServerConfig comicLibraryServerConfig = new ComicLibraryServerConfig();
+			comicLibraryServerConfig.Name = $"{Environment.UserName}'s Library";
+			if (tabShares.TabCount > 1)
+			{
+				comicLibraryServerConfig.Name += $" ({tabShares.TabCount + 1})";
+			}
+			AddSharePage(comicLibraryServerConfig);
+			tabShares.SelectedIndex = tabShares.TabPages.Count - 1;
+		}
 
-        private void btRmoveShare_Click(object sender, EventArgs e)
-        {
-            TabPage selectedTab = tabShares.SelectedTab;
-            if (selectedTab != null)
-            {
-                RemoveSharePage(selectedTab);
-            }
-        }
+		private void btRmoveShare_Click(object sender, EventArgs e)
+		{
+			TabPage selectedTab = tabShares.SelectedTab;
+			if (selectedTab != null)
+			{
+				RemoveSharePage(selectedTab);
+			}
+		}
 
-        public static bool Show(IWin32Window parent, KeyboardShortcuts commands, PluginEngine pe, string autoInstallPlugin = null)
-        {
-            using (PreferencesDialog preferencesDialog = new PreferencesDialog())
-            {
-                preferencesDialog.keyboardShortcutEditor.Shortcuts = commands;
-                preferencesDialog.Plugins = pe;
-                preferencesDialog.AutoInstallPlugin = (File.Exists(autoInstallPlugin) ? autoInstallPlugin : null);
-                bool flag = preferencesDialog.ShowDialog(parent) == DialogResult.OK;
-                if (flag)
-                {
-                    preferencesDialog.Apply();
-                    if (preferencesDialog.NeedsRestart && QuestionDialog.Ask(parent, TR.Messages["RestartQuestion", "ComicRack needs to restart to complete the operation! Do you want to restart now?"], TR.Default["Restart", "Restart"]))
-                    {
-                        Program.MainForm.MenuRestart();
-                    }
-                }
-                else
-                {
-                    Program.ScriptPackages.RemovePending();
-                }
-                return flag;
-            }
-        }
+		public static bool Show(IWin32Window parent, KeyboardShortcuts commands, PluginEngine pe, string autoInstallPlugin = null)
+		{
+			using (PreferencesDialog preferencesDialog = new PreferencesDialog())
+			{
+				preferencesDialog.keyboardShortcutEditor.Shortcuts = commands;
+				preferencesDialog.Plugins = pe;
+				preferencesDialog.AutoInstallPlugin = (File.Exists(autoInstallPlugin) ? autoInstallPlugin : null);
+				bool flag = preferencesDialog.ShowDialog(parent) == DialogResult.OK;
+				if (flag)
+				{
+					preferencesDialog.Apply();
+					if (preferencesDialog.NeedsRestart && QuestionDialog.Ask(parent, TR.Messages["RestartQuestion", "ComicRack needs to restart to complete the operation! Do you want to restart now?"], TR.Default["Restart", "Restart"]))
+					{
+						Program.MainForm.MenuRestart();
+					}
+				}
+				else
+				{
+					Program.ScriptPackages.RemovePending();
+				}
+				return flag;
+			}
+		}
 
-        #region Virtual Tags
-        private void AddVirtualTags()
-        {
-            var VirtualTags = new List<VirtualTag>();
-            
-            for (int id = 1; id <= 20; id++)
-            {
-                VirtualTag vtag = Program.Settings.VirtualTags.FirstOrDefault(x => x.ID == id);
-                string vtagText = LocalizeUtility.GetText(this, "VirtualTag", "Virtual Tag");
+		#region Virtual Tags
+		private void AddVirtualTags()
+		{
+			var VirtualTags = new List<VirtualTag>();
+
+			for (int id = 1; id <= 20; id++)
+			{
+				VirtualTag vtag = Program.Settings.VirtualTags.FirstOrDefault(x => x.ID == id);
+				string vtagText = LocalizeUtility.GetText(this, "VirtualTag", "Virtual Tag");
 				string name = $"{vtagText} #{id:00}";
-                vtag = vtag is null 
+				vtag = vtag is null
 					? new VirtualTag(id, name, name, string.Empty, isDefault: true) //If the data doesn't already exists, create an empty tag.
 					: new VirtualTag(vtag.ID, vtag.Name, vtag.Description, vtag.CaptionFormat, vtag.IsEnabled, vtag.IsDefault); // Otherwise create a new instance so that it doesn't edit the original until we save.
 
 				VirtualTags.Add(vtag);
-            }
+			}
 
-            SetVirtualTagsComboBoxDataSource(VirtualTags);
-            CreateValueContextMenu();
-        }
+			SetVirtualTagsComboBoxDataSource(VirtualTags);
+			CreateValueContextMenu();
+		}
 
-        private void SetVirtualTagsComboBoxDataSource(List<VirtualTag> VirtualTags)
-        {
-            cbVirtualTags.DataSource = VirtualTags;
-            cbVirtualTags.DisplayMember = "DisplayMember";
-        }
+		private void SetVirtualTagsComboBoxDataSource(List<VirtualTag> VirtualTags)
+		{
+			cbVirtualTags.DataSource = VirtualTags;
+			cbVirtualTags.DisplayMember = "DisplayMember";
+		}
 
-        private void CreateValueContextMenu()
-        {
-            components = new Container();
-            ContextMenuBuilder contextMenuBuilder = new ContextMenuBuilder();
-            foreach (string item in ComicBook.GetProperties(false))
-            {
-                contextMenuBuilder.Add(item, topLevel: false, chk: false, SetCaptionField, item, DateTime.MinValue);
-            }
-            ContextMenuStrip cm = new ContextMenuStrip(components);
-            cm.Items.AddRange(contextMenuBuilder.Create(20));
-            btInsertValue.Click += (sender, e) => cm.Show(btInsertValue, 0, btInsertValue.Height);
-        }
+		private void CreateValueContextMenu()
+		{
+			components = new Container();
+			ContextMenuBuilder contextMenuBuilder = new ContextMenuBuilder();
+			foreach (string item in ComicBook.GetProperties(false))
+			{
+				contextMenuBuilder.Add(item, topLevel: false, chk: false, SetCaptionField, item, DateTime.MinValue);
+			}
+			ContextMenuStrip cm = new ContextMenuStrip(components);
+			cm.Items.AddRange(contextMenuBuilder.Create(20));
+			btInsertValue.Click += (sender, e) => cm.Show(btInsertValue, 0, btInsertValue.Height);
+		}
 
-        private void SetCaptionField(object sender, EventArgs e)
-        {
-            //Change the button Text & Tag so that when we click Add the Value will be inserted
-            ToolStripMenuItem toolStripMenuItem = sender as ToolStripMenuItem;
-            btInsertValue.Text = (string)toolStripMenuItem.Tag;
-            btInsertValue.Tag = (string)toolStripMenuItem.Tag;
-        }
+		private void SetCaptionField(object sender, EventArgs e)
+		{
+			//Change the button Text & Tag so that when we click Add the Value will be inserted
+			ToolStripMenuItem toolStripMenuItem = sender as ToolStripMenuItem;
+			btInsertValue.Text = (string)toolStripMenuItem.Tag;
+			btInsertValue.Tag = (string)toolStripMenuItem.Tag;
+		}
 
-        private void cbVirtualTags_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (cbVirtualTags.SelectedIndex == -1)
-                return;
+		private void cbVirtualTags_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			if (cbVirtualTags.SelectedIndex == -1)
+				return;
 
-            VirtualTag vtag = cbVirtualTags.SelectedItem as VirtualTag;
-            if (vtag is null)
-                return;
+			VirtualTag vtag = cbVirtualTags.SelectedItem as VirtualTag;
+			if (vtag is null)
+				return;
 
-            //Fill UI with object from Combo Box
-            txtVirtualTagName.Text = vtag.Name;
-            txtVirtualTagDescription.Text = vtag.Description;
-            rtfVirtualTagCaption.Text = vtag.CaptionFormat;
-            chkVirtualTagEnable.Checked = vtag.IsEnabled;
-            ResetVirtualTagsCaptionControls();
-        }
+			//Fill UI with object from Combo Box
+			txtVirtualTagName.Text = vtag.Name;
+			txtVirtualTagDescription.Text = vtag.Description;
+			rtfVirtualTagCaption.Text = vtag.CaptionFormat;
+			chkVirtualTagEnable.Checked = vtag.IsEnabled;
+			ResetVirtualTagsCaptionControls();
+		}
 
-        private void btnCaptionInsert_Click(object sender, EventArgs e)
-        {
-            if (cbVirtualTags.SelectedIndex == -1)
-                return;
+		private void btnCaptionInsert_Click(object sender, EventArgs e)
+		{
+			if (cbVirtualTags.SelectedIndex == -1)
+				return;
 
-            VirtualTag vtag = cbVirtualTags.SelectedItem as VirtualTag;
-            string caption = btInsertValue.Text;
+			VirtualTag vtag = cbVirtualTags.SelectedItem as VirtualTag;
+			string caption = btInsertValue.Text;
 
-            //We can't add the current VTAG inside it's own VTAG
-            if (vtag?.PropertyName == caption)
-                return;
+			//We can't add the current VTAG inside it's own VTAG
+			if (vtag?.PropertyName == caption)
+				return;
 
-            //Number Formatting
-            if (!string.IsNullOrEmpty(txtCaptionFormat.Text))
-                caption = $"{caption}:{txtCaptionFormat.Text}";
+			//Number Formatting
+			if (!string.IsNullOrEmpty(txtCaptionFormat.Text))
+				caption = $"{caption}:{txtCaptionFormat.Text}";
 
-            string text = $"[{txtCaptionPrefix.Text}{{{caption}}}{txtCaptionSuffix.Text}]";
+			string text = $"[{txtCaptionPrefix.Text}{{{caption}}}{txtCaptionSuffix.Text}]";
 
-            if (!string.IsNullOrEmpty(text) && btInsertValue.Tag != null)
-            {
-                //Insert text into box
-                int cursorPosition = rtfVirtualTagCaption.SelectionStart;
-                rtfVirtualTagCaption.Text = rtfVirtualTagCaption.Text.Insert(cursorPosition, text);
-                rtfVirtualTagCaption.SelectionStart = rtfVirtualTagCaption.TextLength;
+			if (!string.IsNullOrEmpty(text) && btInsertValue.Tag != null)
+			{
+				//Insert text into box
+				int cursorPosition = rtfVirtualTagCaption.SelectionStart;
+				rtfVirtualTagCaption.Text = rtfVirtualTagCaption.Text.Insert(cursorPosition, text);
+				rtfVirtualTagCaption.SelectionStart = rtfVirtualTagCaption.TextLength;
 
-                ResetVirtualTagsCaptionControls();
-            }
-        }
+				ResetVirtualTagsCaptionControls();
+			}
+		}
 
-        private void ResetVirtualTagsCaptionControls()
-        {
-            //Reset Insert Value button, Prefix & Suffix Textbox
-            btInsertValue.Text = "Choose Value";
-            LocalizeUtility.Localize(TR.Load(base.Name), btInsertValue);
-            btInsertValue.Tag = null;
-            txtCaptionPrefix.Text = string.Empty;
-            txtCaptionSuffix.Text = string.Empty;
-            txtCaptionFormat.Text = string.Empty;
-        }
+		private void ResetVirtualTagsCaptionControls()
+		{
+			//Reset Insert Value button, Prefix & Suffix Textbox
+			btInsertValue.Text = "Choose Value";
+			LocalizeUtility.Localize(TR.Load(base.Name), btInsertValue);
+			btInsertValue.Tag = null;
+			txtCaptionPrefix.Text = string.Empty;
+			txtCaptionSuffix.Text = string.Empty;
+			txtCaptionFormat.Text = string.Empty;
+		}
 
-        private void VirtualTag_Validated(object sender, EventArgs e)
-        {
-            VirtualTagUpdate();
-        }
+		private void VirtualTag_Validated(object sender, EventArgs e)
+		{
+			VirtualTagUpdate();
+		}
 
 		private void VirtualTagUpdate()
-        {
-            if (cbVirtualTags.SelectedIndex == -1)
-                return;
+		{
+			if (cbVirtualTags.SelectedIndex == -1)
+				return;
 
-            VirtualTag vtag = cbVirtualTags.SelectedItem as VirtualTag;
+			VirtualTag vtag = cbVirtualTags.SelectedItem as VirtualTag;
 
-            //Don't save if the Caption contains the current vtag own field
-            if (rtfVirtualTagCaption.Text.Contains($"{{{vtag?.PropertyName}"))
-                return;
+			//Don't save if the Caption contains the current vtag own field
+			if (rtfVirtualTagCaption.Text.Contains($"{{{vtag?.PropertyName}"))
+				return;
 
-            //Update the virtualtags object for the setting
-            vtag.Name = txtVirtualTagName.Text;
-            vtag.Description = txtVirtualTagDescription.Text;
-            vtag.IsEnabled = chkVirtualTagEnable.Checked;
-            vtag.CaptionFormat = rtfVirtualTagCaption.Text;
+			//Update the virtualtags object for the setting
+			vtag.Name = txtVirtualTagName.Text;
+			vtag.Description = txtVirtualTagDescription.Text;
+			vtag.IsEnabled = chkVirtualTagEnable.Checked;
+			vtag.CaptionFormat = rtfVirtualTagCaption.Text;
 
-            //If the caption or the name aren't empty, change the IsDefault so it gets saved.
-            if (!string.IsNullOrEmpty(vtag.CaptionFormat) && !string.IsNullOrEmpty(vtag.Name))
-                vtag.IsDefault = false;
-        }
+			//If the caption or the name aren't empty, change the IsDefault so it gets saved.
+			if (!string.IsNullOrEmpty(vtag.CaptionFormat) && !string.IsNullOrEmpty(vtag.Name))
+				vtag.IsDefault = false;
+		}
 
-        private void UpdateVirtualTagsComboBox(object sender, EventArgs e)
-        {
-            VirtualTagUpdate();
+		private void UpdateVirtualTagsComboBox(object sender, EventArgs e)
+		{
+			VirtualTagUpdate();
 
-            //Reset the DataSource, so the name in the dropdown updates
-            List<VirtualTag> vtags = cbVirtualTags.DataSource as List<VirtualTag>;
-            cbVirtualTags.DataSource = null;
-            SetVirtualTagsComboBoxDataSource(vtags);
-        }
+			//Reset the DataSource, so the name in the dropdown updates
+			List<VirtualTag> vtags = cbVirtualTags.DataSource as List<VirtualTag>;
+			cbVirtualTags.DataSource = null;
+			SetVirtualTagsComboBoxDataSource(vtags);
+		}
 
-        private void SaveVirtualTags()
-        {
-            Program.Settings.VirtualTags.Clear();
-            VirtualTagUpdate();
-            foreach (VirtualTag item in cbVirtualTags.Items)
-            {
-                if (!item.IsDefault && !string.IsNullOrEmpty(item.CaptionFormat) && !string.IsNullOrEmpty(item.Name))
-                    Program.Settings.VirtualTags.Add(item);
-            }
-        }
+		private void SaveVirtualTags()
+		{
+			Program.Settings.VirtualTags.Clear();
+			VirtualTagUpdate();
+			foreach (VirtualTag item in cbVirtualTags.Items)
+			{
+				if (!item.IsDefault && !string.IsNullOrEmpty(item.CaptionFormat) && !string.IsNullOrEmpty(item.Name))
+					Program.Settings.VirtualTags.Add(item);
+			}
+		}
 
 		private void btnVTagsHelp_Click(object sender, EventArgs e)
 		{
-            const string VTagWiki = @"https://github.com/maforget/ComicRackCE/wiki/Virtual-Tags";
-            Program.StartDocument(VTagWiki);
+			const string VTagWiki = @"https://github.com/maforget/ComicRackCE/wiki/Virtual-Tags";
+			Program.StartDocument(VTagWiki);
 		}
 		#endregion
 
@@ -1481,17 +1491,17 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 				folderBrowserDialog.ShowNewFolderButton = true;
 				if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
 				{
-                    // TODO: Check if folder is not empty and prompt user to confirm if not
+					// TODO: Check if folder is not empty and prompt user to confirm if not
 					txtBackupLocation.Text = folderBrowserDialog.SelectedPath;
 				}
 			}
 		}
 
 
-        private void lbBackupOptions_Resize(object sender, EventArgs e)
-        {
-            int cw = (lbBackupOptions.Width / 2) - 22;
-            lbBackupOptions.ColumnWidth = cw;
-        }
-    }
+		private void lbBackupOptions_Resize(object sender, EventArgs e)
+		{
+			int cw = (lbBackupOptions.Width / 2) - 22;
+			lbBackupOptions.ColumnWidth = cw;
+		}
+	}
 }

--- a/ComicRack/MainForm.cs
+++ b/ComicRack/MainForm.cs
@@ -3369,11 +3369,11 @@ namespace cYo.Projects.ComicRack.Viewer
 		{
 			if (e.IsComicInfo && e.Book.EditMode.IsLocalComic() && e.Book.FileInfoRetrieved)
 			{
-				e.Book.ComicInfoIsDirty = true;
+				if (e.IsComicInfo)
+					e.Book.ComicInfoIsDirty = true;
+
 				if (!books.IsOpen(e.Book))
-				{
 					Program.QueueManager.AddBookToFileUpdate(e.Book);
-				}
 			}
 		}
 

--- a/ComicRack/MainForm.cs
+++ b/ComicRack/MainForm.cs
@@ -3372,7 +3372,7 @@ namespace cYo.Projects.ComicRack.Viewer
 				if (e.IsComicInfo)
 					e.Book.ComicInfoIsDirty = true;
 
-                if (e.IsComicBook)
+                if (e.IsComicBook && !e.Book.IsDynamicSource)
                     e.Book.ComicBookIsDirty = true;
 
                 if (!books.IsOpen(e.Book))

--- a/ComicRack/MainForm.cs
+++ b/ComicRack/MainForm.cs
@@ -1109,7 +1109,7 @@ namespace cYo.Projects.ComicRack.Viewer
 				e.Cancel = true;
 				return;
 			}
-			if (Program.Settings.UpdateComicFiles)
+			if (Program.Settings.UpdateComicFiles) // TODO: also add support for ComicBookIsDirty when UpdateComicBookFiles is true
 			{
 				IEnumerable<ComicBook> dirtyTempList = Program.BookFactory.TemporaryBooks.Where((ComicBook cb) => cb.ComicInfoIsDirty);
 				int dirtyCount = dirtyTempList.Count();
@@ -3367,12 +3367,15 @@ namespace cYo.Projects.ComicRack.Viewer
 
 		private void WatchedBookHasChanged(object sender, ContainerBookChangedEventArgs e)
 		{
-			if (e.IsComicInfo && e.Book.EditMode.IsLocalComic() && e.Book.FileInfoRetrieved)
+			if ((e.IsComicInfo || e.IsComicBook) && e.Book.EditMode.IsLocalComic() && e.Book.FileInfoRetrieved)
 			{
 				if (e.IsComicInfo)
 					e.Book.ComicInfoIsDirty = true;
 
-				if (!books.IsOpen(e.Book))
+                if (e.IsComicBook)
+                    e.Book.ComicBookIsDirty = true;
+
+                if (!books.IsOpen(e.Book))
 					Program.QueueManager.AddBookToFileUpdate(e.Book);
 			}
 		}

--- a/ComicRack/MainForm.cs
+++ b/ComicRack/MainForm.cs
@@ -1109,9 +1109,12 @@ namespace cYo.Projects.ComicRack.Viewer
 				e.Cancel = true;
 				return;
 			}
-			if (Program.Settings.UpdateComicFiles) // TODO: also add support for ComicBookIsDirty when UpdateComicBookFiles is true
+			if (Program.Settings.UpdateComicFiles)
 			{
-				IEnumerable<ComicBook> dirtyTempList = Program.BookFactory.TemporaryBooks.Where((ComicBook cb) => cb.ComicInfoIsDirty);
+				HashSet<ComicBook> dirtyTempList = Program.BookFactory.TemporaryBooks.Where((ComicBook cb) => cb.ComicInfoIsDirty).ToHashSet();
+				if (Program.Settings.UpdateComicBookFiles)
+					dirtyTempList.AddRange(Program.BookFactory.TemporaryBooks.Where((ComicBook cb) => cb.ComicBookIsDirty));
+
 				int dirtyCount = dirtyTempList.Count();
 				if (dirtyCount != 0 && Program.AskQuestion(this, TR.Messages["AskDirtyItems", "Save changed information for Books that are not in the database?\nAll changes not saved now will be lost!"], TR.Default["Save", "Save"], HiddenMessageBoxes.AskDirtyItems, TR.Messages["AlwaysSaveDirty", "Always save changes"], TR.Default["No", "No"]))
 				{

--- a/ComicRack/Output/ComicRack.ini
+++ b/ComicRack/Output/ComicRack.ini
@@ -125,6 +125,9 @@
 ; Enabling this will force ComicRack to start minimized and with the splash screen disabled regardless of settings. Useful to start with Windows.
 ; StartHidden = true
 
+; If true, the embedded ComicBook.xml file in CBZ/CBR/CB7/CBT files will be ignored when reading comic books.
+; IgnoreEmbeddedComicBookXml = false
+
 ; ------------------------------------------------------------------
 ; Legacy Behavior - These settings are used to return to pre Community Edition behavior.
 

--- a/ComicRack/Output/Languages/fr/ExportComicsDialog.xml
+++ b/ComicRack/Output/Languages/fr/ExportComicsDialog.xml
@@ -57,6 +57,7 @@
     <Text Key="chkAddNewToLibrary" Text="Ajouter les nouveaux Livres à la Bibliothèque" Comment="Add newly created Book to Library" />
     <Text Key="labelComicFormat" Text="Type de fichier :" Comment="Format:" />
     <Text Key="chkEmbedComicInfo" Text="Intégrer Comicinfo.xml" Comment="Embed Book Info" />
+    <Text Key="chkEmbedComicBook" Text="Intégrer ComicBook.xml" Comment="Embed Library Info" />
     <Text Key="labelPageFormat" Text="Type de fichier :" Comment="Format:" />
     <Text Key="cbNamingTemplate.Item1" Text="Légende du Livre" Comment="Book Caption" />
     <Text Key="labelGamma" Text="Gamma" Comment="Gamma" />

--- a/ComicRack/Output/Languages/fr/Matchers.xml
+++ b/ComicRack/Output/Languages/fr/Matchers.xml
@@ -44,7 +44,8 @@
     <Text Key="ComicBookPluginMatcher" Text="Scripts de l'utilisateur" Comment="User Scripts" />
     <Text Key="ComicBookModifiedMatcher" Text="Fichier Modifié le" Comment="File Modified" />
     <Text Key="ComicBookCreationMatcher" Text="Fichier créé le" Comment="File Created" />
-    <Text Key="ComicBookModifiedInfoMatcher" Text="Informations modifiées" Comment="Modified Info" />
+	<Text Key="ComicBookModifiedInfoMatcher" Text="Informations modifiées" Comment="Modified Info" />
+	<Text Key="ComicBookModifiedLibraryInfoMatcher" Text="Informations bibliothèque modifiées" Comment="Modified Library Info" />
     <Text Key="ComicBookBookmarkCountMatcher" Text="Nombre de favoris" Comment="Bookmark Count" />
     <Text Key="OnOffOperators" Text="Oui|Non" Comment="On|Off" />
     <Text Key="ComicBookTeamsMatcher" Text="Équipes" Comment="Teams" />

--- a/ComicRack/Output/Languages/fr/PreferencesDialog.xml
+++ b/ComicRack/Output/Languages/fr/PreferencesDialog.xml
@@ -176,5 +176,6 @@
     <Text Key="chkBackupOnStartup" Text="Démarrage" Comment="Startup" />
     <Text Key="chkBackupOnExit" Text="Fermeture" Comment="Shut Down" />
     <Text Key="VirtualTag" Text="Étiquette Virtuelle" Comment="Virtual Tag" />
+    <Text Key="chkUpdateComicBookFiles" Text="Insérer les informations de la Bibliothèque dans le fichier." Comment="Allow writing of Library info into files" />
   </Texts>
 </TR>

--- a/ComicRack/Views/ComicBrowserControl.cs
+++ b/ComicRack/Views/ComicBrowserControl.cs
@@ -2929,7 +2929,7 @@ namespace cYo.Projects.ComicRack.Viewer.Views
                 }
             }
             miShowOnly.Visible = miShowOnly.DropDownItems.Count != 0;
-            miUpdateComicFiles.Visible = enumerable.Any((ComicBook cb) => cb.ComicInfoIsDirty);
+            miUpdateComicFiles.Visible = enumerable.Any((ComicBook cb) => cb.ComicInfoIsDirty ||cb.ComicBookIsDirty);
             contextMenuItems.FixSeparators();
             miPasteData.Enabled = isPasteComicDataEnabled();
         }


### PR DESCRIPTION
Added functionality to Embed Library metadata into Book Files

- It adds a new file named `ComicBook.xml`, that doesn't interfere with the `ComicInfo.xml`.
- Contains most of the extra data only available in the library like Read Progress, Custom Value or Color Adjustments.
- The `ComicInfo.xml` will always take precedence even if a `ComicBook.xml` contents differ. It will only keep the extra values part not part of `ComicInfo.xml`. Since other programs also use the `ComicInfo.xml` file, this makes sure you always have the most up-to-date information.
- There is a new setting in Export Profiles Settings called "Embed Library Info" that will create the `ComicBook.xml` on Export (disabled by default).
- There is a new setting in the Preferences called "Allow writing of Library info into files" required if your want the new `ComicBook.xml` to be included during an update.
- Enabling the "Allow writing of Library info into files" option will enable the "Catalog" & "Custom" tabs in the Info dialog in the "Folder" tab.
- If you want to ignore reading the `ComicBook.xml` file completely, there is an option in the `ComicRack.ini` file (`IgnoreEmbeddedComicBookXml`).
- NTFS Streams (`ComicRackBook`) & Sidecar metadata files have also been added. 
- For the XML Book Information export, if "Embed Library Info" is enabled it will output a `ComicBook.xml`, otherwise a regular `ComicInfo.xml`.
- For the others export format both are embedded when "Embed Library Info" is enabled.
- Adds a new `ComicBookIsDirty` to track the changes exclusive to `ComicBook`.
- Added `ComicBookModifiedBookInfoMatcher` ("Modified Library Info" smart list field) to check for `ComicBookIsDirty`. It isn't part of the default "Files to Update" smart list, must be added manually.

NOTE: Not all `ComicBook` field are tracked for `ComicBookIsDirty`
Properties Tracked:
    - `ReleasedTime`
    - `Rating`
    - `ColorAdjustment`
    - `SeriesComplete`
    - `BookPrice`
    - `BookAge`
    - `BookCondition`
    - `BookStore`
    - `BookOwner`
    - `BookCollectionStatus`
    - `BookNotes`
    - `BookLocation`
    - `ISBN`
    - `CustomValuesStore`

Ref: #260

NOTE: Something to check for, I had an instance of some Custom Values in my Library disappearing. Unsure how it happened or if it's even an issue. The exported copy of the book I used to test had the custom values properly stored in the `ComicBook.xml` but the original file in the Library had potentially lost it's value.