### PR TITLE
Allow typing a network/UNC path when adding Library Folders

### DIFF
--- a/ComicRack/Dialogs/PreferencesDialog.cs
+++ b/ComicRack/Dialogs/PreferencesDialog.cs
@@ -362,17 +362,13 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 
 		private void btAddFolder_Click(object sender, EventArgs e)
 		{
-			using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
+			string path = SelectItemDialog.GetName(this, LocalizeUtility.GetText(this, "SelectComicFolder", "Please select a folder containing Books"), string.Empty, BrowseForComicFolder);
+			if (!string.IsNullOrEmpty(path))
 			{
-				folderBrowserDialog.Description = LocalizeUtility.GetText(this, "SelectComicFolder", "Please select a folder containing Books");
-				folderBrowserDialog.ShowNewFolderButton = true;
-				if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
+				lbPaths.Items.Add(path);
+				if (lbPaths.SelectedIndex == -1)
 				{
-					lbPaths.Items.Add(folderBrowserDialog.SelectedPath);
-					if (lbPaths.SelectedIndex == -1)
-					{
-						lbPaths.SelectedIndex = 0;
-					}
+					lbPaths.SelectedIndex = 0;
 				}
 			}
 		}
@@ -384,16 +380,25 @@ namespace cYo.Projects.ComicRack.Viewer.Dialogs
 			{
 				return;
 			}
+			string path = SelectItemDialog.GetName(this, LocalizeUtility.GetText(this, "SelectComicFolder", "Please select a folder containing Books"), text, BrowseForComicFolder);
+			if (!string.IsNullOrEmpty(path))
+			{
+				lbPaths.Items[lbPaths.SelectedIndex] = path;
+			}
+		}
+
+		private string BrowseForComicFolder(IWin32Window parent)
+		{
 			using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
 			{
 				folderBrowserDialog.Description = LocalizeUtility.GetText(this, "SelectComicFolder", "Please select a folder containing Books");
 				folderBrowserDialog.ShowNewFolderButton = true;
-				folderBrowserDialog.SelectedPath = text;
-				if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
+				if (folderBrowserDialog.ShowDialog(parent) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
 				{
-					lbPaths.Items[lbPaths.SelectedIndex] = folderBrowserDialog.SelectedPath;
+					return folderBrowserDialog.SelectedPath;
 				}
 			}
+			return null;
 		}
 
 		private void btAddLibraryFolder_Click(object sender, EventArgs e)

--- a/ComicRack/MainForm.cs
+++ b/ComicRack/MainForm.cs
@@ -1920,15 +1920,25 @@ namespace cYo.Projects.ComicRack.Viewer
 
 		public void AddFolderToLibrary()
 		{
+			string path = SelectItemDialog.GetName<string>(this, TR.Messages["AddFolderLibraryTitle", "Add Folder to Library"], string.Empty, null, TR.Messages["AddFolderLibraryManualPath", "Folder or network path"], BrowseForLibraryFolder);
+			if (!string.IsNullOrEmpty(path))
+			{
+				Program.Scanner.ScanFileOrFolder(path, all: true, removeMissing: false);
+			}
+		}
+
+		private string BrowseForLibraryFolder(IWin32Window parent)
+		{
 			using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
 			{
 				folderBrowserDialog.Description = TR.Messages["AddFolderLibrary", "Books in this Folder and all sub Folders will be added to the library."];
 				folderBrowserDialog.ShowNewFolderButton = true;
-				if (folderBrowserDialog.ShowDialog(this) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
+				if (folderBrowserDialog.ShowDialog(parent) == DialogResult.OK && !string.IsNullOrEmpty(folderBrowserDialog.SelectedPath))
 				{
-					Program.Scanner.ScanFileOrFolder(folderBrowserDialog.SelectedPath, all: true, removeMissing: false);
+					return folderBrowserDialog.SelectedPath;
 				}
 			}
+			return null;
 		}
 
 		public void StartFullScan()

--- a/ComicRack/Output/Languages/fr/Messages.xml
+++ b/ComicRack/Output/Languages/fr/Messages.xml
@@ -108,6 +108,8 @@
     <Text Key="WriteData" Text="Écrire données" Comment="Pasting Data" />
     <Text Key="WriteDataText" Text="Écriture des données dans les Livres sélectionnés" Comment="Pasting Data into selected Books" />
     <Text Key="AddFolderLibrary" Text="Tous les Livres de ce dossier et des sous-dossiers seront ajoutés à la Bibliothèque." Comment="Books in this Folder and all sub Folders will be added to the library." />
+	<Text Key="AddFolderLibraryTitle" Text="Ajouter un dossier à la Bibliothèque" Comment="Add Folder to Library" />
+	<Text Key="AddFolderLibraryManualPath" Text="Dossier ou chemin réseau" Comment="Folder or network path" />
     <Text Key="ExportQueueMessage" Text="Conversion du Livre '{0}'" Comment="Export Book '{0}'" />
     <Text Key="RefreshInfoQueueMessage" Text="Actualisation des informations du Livre '{0}'" Comment="Refresh information for Book '{0}'" />
     <Text Key="WriteInfoQueueMessage" Text="Écriture des informations dans le Livre '{0}'" Comment="Write information to Book file '{0}'" />

--- a/cYo.Common.Windows/Forms/SelectItemDialog.Designer.cs
+++ b/cYo.Common.Windows/Forms/SelectItemDialog.Designer.cs
@@ -31,6 +31,7 @@ namespace cYo.Common.Windows.Forms
             this.cbName = new System.Windows.Forms.ComboBox();
             this.txtName = new System.Windows.Forms.TextBox();
             this.chkOption = new System.Windows.Forms.CheckBox();
+            this.btBrowse = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // btCancel
@@ -93,14 +94,28 @@ namespace cYo.Common.Windows.Forms
             this.chkOption.Text = "Lorem Ipsum";
             this.chkOption.UseVisualStyleBackColor = true;
             this.chkOption.Visible = false;
-            // 
+            //
+            // btBrowse
+            //
+            this.btBrowse.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btBrowse.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.btBrowse.Location = new System.Drawing.Point(244, 39);
+            this.btBrowse.Name = "btBrowse";
+            this.btBrowse.Size = new System.Drawing.Size(88, 23);
+            this.btBrowse.TabIndex = 6;
+            this.btBrowse.Text = "&Browse...";
+            this.btBrowse.UseVisualStyleBackColor = true;
+            this.btBrowse.Visible = false;
+            this.btBrowse.Click += new System.EventHandler(this.BrowseClick);
+            //
             // SelectItemDialog
-            // 
+            //
             this.AcceptButton = this.btOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btCancel;
             this.ClientSize = new System.Drawing.Size(344, 130);
+            this.Controls.Add(this.btBrowse);
             this.Controls.Add(this.chkOption);
             this.Controls.Add(this.txtName);
             this.Controls.Add(this.cbName);
@@ -126,5 +141,6 @@ namespace cYo.Common.Windows.Forms
 		private ComboBox cbName;
 		private TextBox txtName;
 		private CheckBox chkOption;
+		private Button btBrowse;
 	}
 }

--- a/cYo.Common.Windows/Forms/SelectItemDialog.cs
+++ b/cYo.Common.Windows/Forms/SelectItemDialog.cs
@@ -52,6 +52,12 @@ namespace cYo.Common.Windows.Forms
 		}
 
 		public List<string> SelectionItems => selectionItems;
+		
+		public Func<IWin32Window, string> BrowseAction
+		{
+			get;
+			set;
+		}
 
 		public SelectItemDialog()
 		{
@@ -71,6 +77,11 @@ namespace cYo.Common.Windows.Forms
 				chkOption.Text = CheckOptionText;
 				chkOption.Checked = DefaultCheckResult;
 				chkOption.Visible = true;
+			}
+			if (BrowseAction != null)
+			{
+				btBrowse.Visible = true;
+				cbName.Width = btBrowse.Left - cbName.Left - 8;
 			}
 			if (flag)
 			{
@@ -102,13 +113,30 @@ namespace cYo.Common.Windows.Forms
 			btOK.Enabled = !string.IsNullOrEmpty(cbName.Visible ? cbName.Text : txtName.Text);
 		}
 
-		public static string GetName<T>(IWin32Window parent, string caption, string itemValue, IEnumerable<T> list, string itemCaption = null)
+		private void BrowseClick(object sender, EventArgs e)
+		{
+			string text = BrowseAction?.Invoke(this);
+			if (!string.IsNullOrEmpty(text))
+			{
+				if (cbName.Visible)
+				{
+					cbName.Text = text;
+				}
+				else
+				{
+					txtName.Text = text;
+				}
+			}
+		}
+
+		public static string GetName<T>(IWin32Window parent, string caption, string itemValue, IEnumerable<T> list, string itemCaption = null, Func<IWin32Window, string> browseAction = null)
 		{
 			using (SelectItemDialog selectItemDialog = new SelectItemDialog())
 			{
 				selectItemDialog.Text = caption;
 				selectItemDialog.TextValue = itemValue;
 				selectItemDialog.TextCaption = itemCaption;
+				selectItemDialog.BrowseAction = browseAction;
 				if (list != null)
 				{
 					selectItemDialog.SelectionItems.AddRange(list.Select((T x) => x.ToString()).ToArray());
@@ -117,9 +145,9 @@ namespace cYo.Common.Windows.Forms
 			}
 		}
 
-		public static string GetName(IWin32Window parent, string caption, string itemValue)
+		public static string GetName(IWin32Window parent, string caption, string itemValue, Func<IWin32Window, string> browseAction = null)
 		{
-			return GetName<string>(parent, caption, itemValue, null);
+			return GetName<string>(parent, caption, itemValue, null, null, browseAction);
 		}
 	}
 }


### PR DESCRIPTION
*Issue*: Network shares, such as Samba shares on a Linux server, often don't appear in the standard Windows FolderBrowserDialog when using Add Folder to Library or when adding folders to the watched Library Folders list in Preferences. 

*Fix*: this adds a manual path entry option alongside the existing browse button.

<img width="1426" height="870" alt="image" src="https://github.com/user-attachments/assets/7de90e85-cb62-4653-b422-bad936d274d0" />
