### PR TITLE
Add continuous long-form comic reading mode

### DIFF
--- a/ComicRack.Engine.Display.Forms/ComicDisplayControl.cs
+++ b/ComicRack.Engine.Display.Forms/ComicDisplayControl.cs
@@ -2558,14 +2558,9 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 			}
 			ImageFitMode imageDisplayMode = config.ImageDisplayMode;
 			bool fitOnlyIfOversized = config.FitOnlyIfOversized;
-			if (imageDisplayMode == ImageFitMode.FitWidth || imageDisplayMode == ImageFitMode.FitWidthAdaptive)
-			{
-				fitOnlyIfOversized = false;
-			}
-			else if (imageDisplayMode == ImageFitMode.BestFit || imageDisplayMode == ImageFitMode.FitHeight || imageDisplayMode == ImageFitMode.Fit)
+			if (imageDisplayMode == ImageFitMode.BestFit || imageDisplayMode == ImageFitMode.FitHeight || imageDisplayMode == ImageFitMode.Fit)
 			{
 				imageDisplayMode = ImageFitMode.FitWidth;
-				fitOnlyIfOversized = true;
 			}
 			// RTL still controls page navigation, but a vertical strip must not mirror
 			// its horizontal viewport.

--- a/ComicRack.Engine.Display.Forms/ComicDisplayControl.cs
+++ b/ComicRack.Engine.Display.Forms/ComicDisplayControl.cs
@@ -257,11 +257,19 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 
 		private int continuousContentWidth;
 
-		private bool continuousLayoutPreservesSourceSize;
-
 		private ContinuousPageLayout.Anchor continuousViewportAnchor;
 
+		private ImageFitMode continuousImageFitMode;
+
+		private bool continuousFitOnlyIfOversized;
+
 		private bool continuousLayoutRebuildPending;
+
+		private ContinuousPageLayout.Anchor continuousLayoutRebuildAnchor;
+
+		private bool continuousViewportRestorePending;
+
+		private bool continuousFitResetPending;
 
 		private bool continuousNavigationSync;
 
@@ -1534,11 +1542,30 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 
 		private ContinuousPageLayout.Anchor CaptureContinuousViewportAnchor()
 		{
+			if (continuousViewportRestorePending)
+			{
+				return continuousViewportAnchor;
+			}
+			if (TryGetContinuousViewport(out Rectangle viewport))
+			{
+				return continuousLayout.CaptureAnchor(viewport.Top);
+			}
 			if (continuousLayout != null)
 			{
-				return continuousLayout.CaptureAnchor(base.PagePartBounds.Top);
+				return continuousViewportAnchor;
 			}
 			return new ContinuousPageLayout.Anchor(CurrentPage, 0);
+		}
+
+		private bool TryGetContinuousViewport(out Rectangle viewport)
+		{
+			viewport = Rectangle.Empty;
+			if (continuousLayout == null || base.ClientSize.Width <= 0 || base.ClientSize.Height <= 0)
+			{
+				return false;
+			}
+			viewport = base.PagePartBounds;
+			return viewport.Width > 0 && viewport.Height > 0;
 		}
 
 		private long CaptureContinuousHorizontalAnchor()
@@ -1558,13 +1585,13 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 			return (int)Math.Max(0L, Math.Min(position, maximum));
 		}
 
-		private void RebuildContinuousLayout(ContinuousPageLayout.Anchor anchor)
+		private void RebuildContinuousLayout(ContinuousPageLayout.Anchor anchor, bool centerHorizontally = false)
 		{
 			if (PageLayout != PageLayoutMode.Continuous)
 			{
 				return;
 			}
-			long horizontalAnchor = continuousLayout == null ? 0L : CaptureContinuousHorizontalAnchor();
+			long horizontalAnchor = centerHorizontally || continuousLayout == null ? 0L : CaptureContinuousHorizontalAnchor();
 			List<ContinuousPageLayout.SourcePage> pages = new List<ContinuousPageLayout.SourcePage>();
 			if (Book != null)
 			{
@@ -1584,7 +1611,8 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 				? pages.Where((ContinuousPageLayout.SourcePage page) => page.SourceSize.Width > 0).Select((ContinuousPageLayout.SourcePage page) => page.SourceSize.Width).DefaultIfEmpty(ContinuousFallbackWidth).Max()
 				: GetContinuousContentWidth();
 			continuousLayout = new ContinuousPageLayout(pages, contentWidth, preserveSourceSize);
-			continuousLayoutPreservesSourceSize = preserveSourceSize;
+			continuousImageFitMode = base.ImageFitMode;
+			continuousFitOnlyIfOversized = base.ImageFitOnlyIfOversized;
 			int y = continuousLayout.ResolveAnchor(anchor);
 			continuousViewportAnchor = continuousLayout.CaptureAnchor(y);
 			base.ImageVisiblePart = new ImagePartInfo(0, ResolveContinuousHorizontalAnchor(horizontalAnchor), y);
@@ -1593,7 +1621,13 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 
 		private void ScheduleContinuousLayoutRebuild(ContinuousPageLayout.Anchor anchor)
 		{
-			if (continuousLayoutRebuildPending || PageLayout != PageLayoutMode.Continuous || IsDisposed)
+			if (PageLayout != PageLayoutMode.Continuous || IsDisposed)
+			{
+				return;
+			}
+			continuousLayoutRebuildAnchor = anchor;
+			continuousViewportRestorePending = true;
+			if (continuousLayoutRebuildPending)
 			{
 				return;
 			}
@@ -1602,9 +1636,16 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 			MethodInvoker rebuild = delegate
 			{
 				continuousLayoutRebuildPending = false;
-				if (PageLayout == PageLayoutMode.Continuous && !IsDisposed && continuousLayout == scheduledLayout)
+				try
 				{
-					RebuildContinuousLayout(anchor);
+					if (PageLayout == PageLayoutMode.Continuous && !IsDisposed && continuousLayout == scheduledLayout)
+					{
+						RebuildContinuousLayout(continuousLayoutRebuildAnchor);
+					}
+				}
+				finally
+				{
+					continuousViewportRestorePending = false;
 				}
 			};
 			if (!IsHandleCreated)
@@ -1619,6 +1660,7 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 			catch (InvalidOperationException)
 			{
 				continuousLayoutRebuildPending = false;
+				continuousViewportRestorePending = false;
 			}
 		}
 
@@ -1916,7 +1958,10 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 			{
 				return;
 			}
-			continuousViewportAnchor = layout.CaptureAnchor(source.Top);
+			if (!continuousViewportRestorePending)
+			{
+				continuousViewportAnchor = layout.CaptureAnchor(source.Top);
+			}
 			float destinationScaleX = (float)destination.Width / source.Width;
 			float destinationScaleY = (float)destination.Height / source.Height;
 			List<int> visiblePages = new List<int>();
@@ -2285,12 +2330,38 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 
 		protected override void OnPageDisplayModeChanged()
 		{
-			base.OnPageDisplayModeChanged();
-			if (PageLayout == PageLayoutMode.Continuous && continuousLayout != null && continuousLayoutPreservesSourceSize != (base.ImageFitMode == ImageFitMode.Original))
+			bool continuous = PageLayout == PageLayoutMode.Continuous && continuousLayout != null;
+			bool fitSettingsChanged = continuous && (continuousImageFitMode != base.ImageFitMode || continuousFitOnlyIfOversized != base.ImageFitOnlyIfOversized);
+			ContinuousPageLayout.Anchor anchor = fitSettingsChanged ? continuousViewportAnchor : default;
+			if (fitSettingsChanged)
 			{
-				ScheduleContinuousLayoutRebuild(continuousViewportAnchor);
+				continuousFitResetPending = false;
+				continuousViewportRestorePending = true;
 			}
-			if (PageLayout == PageLayoutMode.Continuous && continuousLayout != null)
+			if (continuous)
+			{
+				continuousImageFitMode = base.ImageFitMode;
+				continuousFitOnlyIfOversized = base.ImageFitOnlyIfOversized;
+			}
+			base.OnPageDisplayModeChanged();
+			if (fitSettingsChanged && PageLayout == PageLayoutMode.Continuous && continuousLayout != null)
+			{
+				RebuildContinuousLayout(anchor, centerHorizontally: true);
+				// ImageDisplayControl clears the visible part after this callback. If
+				// that would move the viewport, replace the reset synchronously in
+				// OnVisiblePartChanged so the page-start frame is never rendered.
+				continuousFitResetPending = base.ImageVisiblePart != Display.GetBestPartFit(ImagePartInfo.Empty);
+				if (!continuousFitResetPending)
+				{
+					continuousViewportRestorePending = continuousLayoutRebuildPending;
+				}
+			}
+			else if (fitSettingsChanged)
+			{
+				continuousFitResetPending = false;
+				continuousViewportRestorePending = false;
+			}
+			else if (PageLayout == PageLayoutMode.Continuous && continuousLayout != null && !continuousViewportRestorePending)
 			{
 				Rectangle viewport = base.PagePartBounds;
 				int centeredLeft = ResolveContinuousHorizontalAnchor(0L);
@@ -2304,13 +2375,25 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 
 		protected override void OnVisiblePartChanged()
 		{
-			base.OnVisiblePartChanged();
-			if (PageLayout == PageLayoutMode.Continuous && continuousLayout != null)
+			if (continuousFitResetPending)
 			{
-				ContinuousPageLayout.PageEntry page = continuousLayout.HitTest(base.PagePartBounds.Top);
+				continuousFitResetPending = false;
+				if (PageLayout == PageLayoutMode.Continuous && continuousLayout != null)
+				{
+					int y = continuousLayout.ResolveAnchor(continuousViewportAnchor);
+					base.ImageVisiblePart = new ImagePartInfo(0, ResolveContinuousHorizontalAnchor(0L), y);
+					continuousViewportRestorePending = continuousLayoutRebuildPending;
+					return;
+				}
+				continuousViewportRestorePending = false;
+			}
+			base.OnVisiblePartChanged();
+			if (PageLayout == PageLayoutMode.Continuous && !continuousViewportRestorePending && TryGetContinuousViewport(out Rectangle viewport))
+			{
+				ContinuousPageLayout.PageEntry page = continuousLayout.HitTest(viewport.Top);
 				if (page != null)
 				{
-					continuousViewportAnchor = continuousLayout.CaptureAnchor(base.PagePartBounds.Top);
+					continuousViewportAnchor = continuousLayout.CaptureAnchor(viewport.Top);
 					if (!continuousNavigationSync && Book != null && page.Page != CurrentPage)
 					{
 						continuousNavigationSync = true;
@@ -2330,8 +2413,12 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 
 		protected override void OnResize(EventArgs e)
 		{
-			ContinuousPageLayout.Anchor anchor = CaptureContinuousViewportAnchor();
 			bool restoreContinuousAnchor = PageLayout == PageLayoutMode.Continuous && continuousLayout != null;
+			ContinuousPageLayout.Anchor anchor = restoreContinuousAnchor ? continuousViewportAnchor : default;
+			if (restoreContinuousAnchor)
+			{
+				continuousViewportRestorePending = true;
+			}
 			base.OnResize(e);
 			navigationOverlay.Size = CalcNavigationOverlaySize();
 			if (navigationOverlay.Visible)
@@ -2340,10 +2427,16 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 				navigationOverlay.X = (base.ClientRectangle.Width - navigationOverlay.Width) / 2;
 			}
 			UpdatePartOverlay(always: true);
-			if (restoreContinuousAnchor && continuousLayout != null)
+			if (restoreContinuousAnchor && TryGetContinuousViewport(out _))
 			{
 				int y = continuousLayout.ResolveAnchor(anchor);
+				continuousViewportAnchor = continuousLayout.CaptureAnchor(y);
 				base.ImageVisiblePart = new ImagePartInfo(0, ResolveContinuousHorizontalAnchor(0L), y);
+				continuousViewportRestorePending = continuousLayoutRebuildPending;
+			}
+			else if (!restoreContinuousAnchor)
+			{
+				continuousViewportRestorePending = false;
 			}
 		}
 
@@ -2474,7 +2567,9 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 				imageDisplayMode = ImageFitMode.FitWidth;
 				fitOnlyIfOversized = true;
 			}
-			return new DisplayOutputConfig(config.ViewSize, config.ImageSize, imageDisplayMode, fitOnlyIfOversized, config.RightToLeftReadingMode, config.RightToLeftReading, config.Part, config.ImageZoom, config.ImageZoom, ImageRotation.None, twoPageAutoScroll: false);
+			// RTL still controls page navigation, but a vertical strip must not mirror
+			// its horizontal viewport.
+			return new DisplayOutputConfig(config.ViewSize, config.ImageSize, imageDisplayMode, fitOnlyIfOversized, config.RightToLeftReadingMode, rightToLeftReading: false, config.Part, config.ImageZoom, config.ImageZoom, ImageRotation.None, twoPageAutoScroll: false);
 		}
 
 		protected override Size GetImageSize()

--- a/ComicRack.Engine.Display.Forms/ComicDisplayControl.cs
+++ b/ComicRack.Engine.Display.Forms/ComicDisplayControl.cs
@@ -201,6 +201,8 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 
 		public const int DefaultFadeTime = 100;
 
+		private const int ContinuousFallbackWidth = 1000;
+
 		private static readonly int NavigationOverlayDefaultHeight = FormUtility.ScaleDpiY(200);
 
 		private static readonly Size pageInfoSize = new Size(150, 25).ScaleDpi();
@@ -248,6 +250,20 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 		private bool leftRightMovementReversed;
 
 		private volatile PageLayoutMode pageLayout;
+
+		private readonly Dictionary<int, Size> continuousPageSizes = new Dictionary<int, Size>();
+
+		private ContinuousPageLayout continuousLayout;
+
+		private int continuousContentWidth;
+
+		private bool continuousLayoutPreservesSourceSize;
+
+		private ContinuousPageLayout.Anchor continuousViewportAnchor;
+
+		private bool continuousLayoutRebuildPending;
+
+		private bool continuousNavigationSync;
 
 		private volatile float doublePageOverlap;
 
@@ -314,6 +330,14 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 		private Point mouseDown;
 
 		private bool panMagnifier;
+
+		private Point continuousPanStartLocation;
+
+		private Point continuousPanStartOffset;
+
+		private bool continuousPanDirectionLocked;
+
+		private bool continuousPanVertical;
 
 		private int cachedPartOverlay = -1;
 
@@ -439,10 +463,13 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 					comicBookNavigator.PageFilterChanged -= book_PageFilterOrPagesChanged;
 					comicBookNavigator.PagesChanged -= book_PageFilterOrPagesChanged;
 					comicBookNavigator.Comic.BookChanged -= Comic_BookChanged;
-					comicBookNavigator.PagePart = base.ImageVisiblePart;
+					comicBookNavigator.PagePart = (PageLayout == PageLayoutMode.Continuous) ? ImagePartInfo.Empty : base.ImageVisiblePart;
 					comicBookNavigator.RightToLeftReading = (base.RightToLeftReading ? YesNo.Yes : YesNo.No);
 				}
 				book = value;
+				continuousPageSizes.Clear();
+				continuousLayout = null;
+				continuousContentWidth = 0;
 				OnBookChanged();
 				lastValidKey = null;
 				if (value != null)
@@ -457,11 +484,15 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 					value.PagesChanged += book_PageFilterOrPagesChanged;
 					value.Comic.BookChanged += Comic_BookChanged;
 					CurrentPage = value.CurrentPage;
-					base.ImageVisiblePart = value.PagePart;
+					base.ImageVisiblePart = (PageLayout == PageLayoutMode.Continuous) ? ImagePartInfo.Empty : value.PagePart;
 					if (value.RightToLeftReading != YesNo.Unknown)
 					{
 						base.RightToLeftReading = value.RightToLeftReading == YesNo.Yes;
 					}
+				}
+				if (PageLayout == PageLayoutMode.Continuous)
+				{
+					RebuildContinuousLayout(new ContinuousPageLayout.Anchor(CurrentPage, 0));
 				}
 				navigationOverlay.Provider = value;
 				navigationOverlay.ImageKeyProvider = value;
@@ -548,7 +579,17 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 			{
 				if (pageLayout != value)
 				{
+					PageLayoutMode oldLayout = pageLayout;
 					pageLayout = value;
+					if (value == PageLayoutMode.Continuous)
+					{
+						RebuildContinuousLayout(new ContinuousPageLayout.Anchor(CurrentPage, 0));
+					}
+					else if (oldLayout == PageLayoutMode.Continuous)
+					{
+						continuousLayout = null;
+						base.ImageVisiblePart = ImagePartInfo.Empty;
+					}
 					OnDisplayChanged();
 					Invalidate();
 				}
@@ -790,7 +831,7 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 		{
 			get
 			{
-				if (LeftRightMovementReversed)
+				if (PageLayout != PageLayoutMode.Continuous && LeftRightMovementReversed)
 				{
 					return IsFlipped;
 				}
@@ -949,7 +990,7 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 			}
 		}
 
-		public bool TwoPageDisplay => PageLayout != PageLayoutMode.Single;
+		public bool TwoPageDisplay => PageLayout == PageLayoutMode.Double || PageLayout == PageLayoutMode.DoubleAdaptive;
 
 		public bool ShouldPagingBlend
 		{
@@ -999,7 +1040,7 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 			}
 		}
 
-		public override bool IsDoubleImage => GetImageInfo().IsDoubleImage;
+		public override bool IsDoubleImage => PageLayout != PageLayoutMode.Continuous && GetImageInfo().IsDoubleImage;
 
 		private int NavigationOverlayVisibleY
 		{
@@ -1448,6 +1489,157 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 			return pageKey;
 		}
 
+		private Size GetContinuousPageSize(int page)
+		{
+			if (continuousPageSizes.TryGetValue(page, out Size size) && size.Width > 0 && size.Height > 0)
+			{
+				return size;
+			}
+			try
+			{
+				ComicPageInfo pageInfo = Book.Comic.GetPage(page);
+				size = new Size(pageInfo.ImageWidth, pageInfo.ImageHeight);
+				if (size.Width > 0 && size.Height > 0)
+				{
+					return size;
+				}
+			}
+			catch
+			{
+			}
+			return new Size(ContinuousFallbackWidth, ContinuousFallbackWidth);
+		}
+
+		private int GetContinuousContentWidth()
+		{
+			if (continuousContentWidth > 0)
+			{
+				return continuousContentWidth;
+			}
+			Size size = Size.Empty;
+			if (IsValid && CurrentPage >= 0 && CurrentPage < Book.ProviderPageCount)
+			{
+				using (IItemLock<PageImage> image = pagePool.GetPage(GetPageKey(CurrentPage), onlyMemory: true))
+				{
+					size = image?.Item?.Size ?? Size.Empty;
+				}
+			}
+			if (size.Width <= 0)
+			{
+				size = GetContinuousPageSize(CurrentPage);
+			}
+			continuousContentWidth = size.Width > 0 ? size.Width : ContinuousFallbackWidth;
+			return continuousContentWidth;
+		}
+
+		private ContinuousPageLayout.Anchor CaptureContinuousViewportAnchor()
+		{
+			if (continuousLayout != null)
+			{
+				return continuousLayout.CaptureAnchor(base.PagePartBounds.Top);
+			}
+			return new ContinuousPageLayout.Anchor(CurrentPage, 0);
+		}
+
+		private long CaptureContinuousHorizontalAnchor()
+		{
+			Rectangle viewport = base.PagePartBounds;
+			int contentWidth = continuousLayout?.TotalSize.Width ?? viewport.Width;
+			// Keep twice the center offset so odd source widths retain half-pixel alignment.
+			return 2L * viewport.Left + viewport.Width - contentWidth;
+		}
+
+		private int ResolveContinuousHorizontalAnchor(long anchor)
+		{
+			Rectangle viewport = base.PagePartBounds;
+			int contentWidth = continuousLayout?.TotalSize.Width ?? viewport.Width;
+			long position = (contentWidth + anchor - viewport.Width) / 2L;
+			long maximum = Math.Max(0L, (long)contentWidth - viewport.Width);
+			return (int)Math.Max(0L, Math.Min(position, maximum));
+		}
+
+		private void RebuildContinuousLayout(ContinuousPageLayout.Anchor anchor)
+		{
+			if (PageLayout != PageLayoutMode.Continuous)
+			{
+				return;
+			}
+			long horizontalAnchor = continuousLayout == null ? 0L : CaptureContinuousHorizontalAnchor();
+			List<ContinuousPageLayout.SourcePage> pages = new List<ContinuousPageLayout.SourcePage>();
+			if (Book != null)
+			{
+				try
+				{
+					foreach (int page in Book.GetPages())
+					{
+						pages.Add(new ContinuousPageLayout.SourcePage(page, GetContinuousPageSize(page)));
+					}
+				}
+				catch
+				{
+				}
+			}
+			bool preserveSourceSize = base.ImageFitMode == ImageFitMode.Original;
+			int contentWidth = preserveSourceSize
+				? pages.Where((ContinuousPageLayout.SourcePage page) => page.SourceSize.Width > 0).Select((ContinuousPageLayout.SourcePage page) => page.SourceSize.Width).DefaultIfEmpty(ContinuousFallbackWidth).Max()
+				: GetContinuousContentWidth();
+			continuousLayout = new ContinuousPageLayout(pages, contentWidth, preserveSourceSize);
+			continuousLayoutPreservesSourceSize = preserveSourceSize;
+			int y = continuousLayout.ResolveAnchor(anchor);
+			continuousViewportAnchor = continuousLayout.CaptureAnchor(y);
+			base.ImageVisiblePart = new ImagePartInfo(0, ResolveContinuousHorizontalAnchor(horizontalAnchor), y);
+			Invalidate();
+		}
+
+		private void ScheduleContinuousLayoutRebuild(ContinuousPageLayout.Anchor anchor)
+		{
+			if (continuousLayoutRebuildPending || PageLayout != PageLayoutMode.Continuous || IsDisposed)
+			{
+				return;
+			}
+			ContinuousPageLayout scheduledLayout = continuousLayout;
+			continuousLayoutRebuildPending = true;
+			MethodInvoker rebuild = delegate
+			{
+				continuousLayoutRebuildPending = false;
+				if (PageLayout == PageLayoutMode.Continuous && !IsDisposed && continuousLayout == scheduledLayout)
+				{
+					RebuildContinuousLayout(anchor);
+				}
+			};
+			if (!IsHandleCreated)
+			{
+				rebuild();
+				return;
+			}
+			try
+			{
+				BeginInvoke(rebuild);
+			}
+			catch (InvalidOperationException)
+			{
+				continuousLayoutRebuildPending = false;
+			}
+		}
+
+		private IItemLock<PageImage> GetContinuousImage(int page)
+		{
+			if (!IsValid || page < 0 || page >= Book.ProviderPageCount)
+			{
+				return new ItemLock<PageImage>(null);
+			}
+			PageKey pageKey = GetPageKey(page);
+			IItemLock<PageImage> image = pagePool.GetPage(pageKey, onlyMemory: true);
+			if (image == null)
+			{
+				pagePool.CachePage(pageKey, fastMem: true, Book, bottom: false);
+				return new ItemLock<PageImage>(null);
+			}
+			image.Tag = true;
+			firstPageHasBeenLoaded = true;
+			return image;
+		}
+
 		private bool IsPageInCache(int page, int offset = 0, bool fastMem = true, bool putInCache = true)
 		{
 			int num = SeekPage(page, offset);
@@ -1697,6 +1889,14 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 
 		public override Bitmap CreatePageImage()
 		{
+			if (PageLayout == PageLayoutMode.Continuous)
+			{
+				using (IItemLock<PageImage> image = GetContinuousImage(CurrentPage))
+				{
+					Bitmap bitmap = image?.Item?.Bitmap;
+					return bitmap == null ? null : new Bitmap(bitmap);
+				}
+			}
 			bool flag = RealisticPages;
 			RealisticPages = false;
 			try
@@ -1709,10 +1909,84 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 			}
 		}
 
+		private void DrawContinuousImage(IBitmapRenderer gr, Rectangle destination, Rectangle source)
+		{
+			ContinuousPageLayout layout = continuousLayout;
+			if (layout == null || source.Width <= 0 || source.Height <= 0)
+			{
+				return;
+			}
+			continuousViewportAnchor = layout.CaptureAnchor(source.Top);
+			float destinationScaleX = (float)destination.Width / source.Width;
+			float destinationScaleY = (float)destination.Height / source.Height;
+			List<int> visiblePages = new List<int>();
+			List<Rectangle> visibleAreas = new List<Rectangle>();
+			int hash = 17;
+			foreach (ContinuousPageLayout.PageEntry page in layout.GetVisible(source))
+			{
+				Rectangle intersection = Rectangle.Intersect(page.Bounds, source);
+				if (intersection.Width <= 0 || intersection.Height <= 0)
+				{
+					continue;
+				}
+				RectangleF target = new RectangleF(destination.X + (intersection.X - source.X) * destinationScaleX, destination.Y + (intersection.Y - source.Y) * destinationScaleY, intersection.Width * destinationScaleX, intersection.Height * destinationScaleY);
+				using (IItemLock<PageImage> image = GetContinuousImage(page.Page))
+				{
+					if (image.Item == null)
+					{
+						DrawPage(gr, image, target, RectangleF.Empty);
+					}
+					else
+					{
+						Size actualSize = image.Item.Size;
+						if (actualSize.Width > 0 && actualSize.Height > 0)
+						{
+							if (actualSize != page.SourceSize)
+							{
+								continuousPageSizes[page.Page] = actualSize;
+								continuousContentWidth = 0;
+								ScheduleContinuousLayoutRebuild(continuousViewportAnchor);
+							}
+							float sourceScaleX = (float)actualSize.Width / page.Bounds.Width;
+							float sourceScaleY = (float)actualSize.Height / page.Bounds.Height;
+							RectangleF pageSource = new RectangleF((intersection.X - page.Bounds.X) * sourceScaleX, (intersection.Y - page.Bounds.Y) * sourceScaleY, intersection.Width * sourceScaleX, intersection.Height * sourceScaleY);
+							DrawPage(gr, image, target, pageSource);
+							hash = unchecked(hash * 31 + image.Item.GetHashCode());
+						}
+					}
+				}
+				visiblePages.Add(page.Page);
+				visibleAreas.Add(target.Round());
+			}
+			if (visiblePages.Count != 0)
+			{
+				CachePage(visiblePages[0], -1, fastMem: true, bottom: false);
+				CachePage(visiblePages[visiblePages.Count - 1], 1, fastMem: true, bottom: false);
+				int lastVisiblePage = visiblePages.Max();
+				if (Book != null && lastVisiblePage > Book.LastPageRead)
+				{
+					Book.LastPageRead = lastVisiblePage;
+				}
+			}
+			int previousHash = displayHash;
+			displayHash = hash;
+			displayedPages = visiblePages.ToArray();
+			displayedPageAreas = visibleAreas.ToArray();
+			if (previousHash != displayHash)
+			{
+				OnDisplayChanged();
+			}
+		}
+
 		protected override void DrawImage(IBitmapRenderer gr, Rectangle destination, Rectangle source, bool clipToDestination)
 		{
 			if (!IsValid)
 			{
+				return;
+			}
+			if (PageLayout == PageLayoutMode.Continuous)
+			{
+				DrawContinuousImage(gr, destination, source);
 				return;
 			}
 			int num = displayHash;
@@ -1881,6 +2155,10 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 
 		protected override void RenderImageEffect(IBitmapRenderer bitmapRenderer, DisplayOutput display)
 		{
+			if (PageLayout == PageLayoutMode.Continuous)
+			{
+				return;
+			}
 			base.RenderImageEffect(bitmapRenderer, display);
 			if (bitmapRenderer.IsHardware && workingPaperTexture != null)
 			{
@@ -1989,6 +2267,10 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 				panMagnifier = true;
 				base.MouseActionHappened = true;
 			}
+			continuousPanStartLocation = base.GestureLocation;
+			continuousPanStartOffset = base.ImageVisiblePart.Offset;
+			continuousPanDirectionLocked = false;
+			continuousPanVertical = false;
 		}
 
 		protected override void OnPan()
@@ -2004,17 +2286,52 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 		protected override void OnPageDisplayModeChanged()
 		{
 			base.OnPageDisplayModeChanged();
+			if (PageLayout == PageLayoutMode.Continuous && continuousLayout != null && continuousLayoutPreservesSourceSize != (base.ImageFitMode == ImageFitMode.Original))
+			{
+				ScheduleContinuousLayoutRebuild(continuousViewportAnchor);
+			}
+			if (PageLayout == PageLayoutMode.Continuous && continuousLayout != null)
+			{
+				Rectangle viewport = base.PagePartBounds;
+				int centeredLeft = ResolveContinuousHorizontalAnchor(0L);
+				if (viewport.Left != centeredLeft)
+				{
+					base.ImageVisiblePart = new ImagePartInfo(0, centeredLeft, viewport.Top);
+				}
+			}
 			UpdatePartOverlay(always: true);
 		}
 
 		protected override void OnVisiblePartChanged()
 		{
 			base.OnVisiblePartChanged();
+			if (PageLayout == PageLayoutMode.Continuous && continuousLayout != null)
+			{
+				ContinuousPageLayout.PageEntry page = continuousLayout.HitTest(base.PagePartBounds.Top);
+				if (page != null)
+				{
+					continuousViewportAnchor = continuousLayout.CaptureAnchor(base.PagePartBounds.Top);
+					if (!continuousNavigationSync && Book != null && page.Page != CurrentPage)
+					{
+						continuousNavigationSync = true;
+						try
+						{
+							Book.Navigate(page.Page, PageSeekOrigin.Absolute);
+						}
+						finally
+						{
+							continuousNavigationSync = false;
+						}
+					}
+				}
+			}
 			UpdatePartOverlay(always: false);
 		}
 
 		protected override void OnResize(EventArgs e)
 		{
+			ContinuousPageLayout.Anchor anchor = CaptureContinuousViewportAnchor();
+			bool restoreContinuousAnchor = PageLayout == PageLayoutMode.Continuous && continuousLayout != null;
 			base.OnResize(e);
 			navigationOverlay.Size = CalcNavigationOverlaySize();
 			if (navigationOverlay.Visible)
@@ -2023,6 +2340,34 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 				navigationOverlay.X = (base.ClientRectangle.Width - navigationOverlay.Width) / 2;
 			}
 			UpdatePartOverlay(always: true);
+			if (restoreContinuousAnchor && continuousLayout != null)
+			{
+				int y = continuousLayout.ResolveAnchor(anchor);
+				base.ImageVisiblePart = new ImagePartInfo(0, ResolveContinuousHorizontalAnchor(0L), y);
+			}
+		}
+
+		protected override Point AdjustPanOffset(Point offset)
+		{
+			offset = base.AdjustPanOffset(offset);
+			if (PageLayout != PageLayoutMode.Continuous || panMagnifier)
+			{
+				return offset;
+			}
+
+			int horizontalDistance = Math.Abs(base.PanLocation.X - continuousPanStartLocation.X);
+			int verticalDistance = Math.Abs(base.PanLocation.Y - continuousPanStartLocation.Y);
+			if (!continuousPanDirectionLocked && Math.Max(horizontalDistance, verticalDistance) >= Math.Max(4, SystemInformation.DragSize.Width))
+			{
+				continuousPanDirectionLocked = true;
+				// Favor the strip's reading axis unless the gesture is clearly horizontal.
+				continuousPanVertical = verticalDistance * 4 >= horizontalDistance * 3;
+			}
+			if (!continuousPanDirectionLocked || continuousPanVertical)
+			{
+				offset.X = continuousPanStartOffset.X;
+			}
+			return offset;
 		}
 
 		protected override void OnRenderImageOverlay(RenderEventArgs e)
@@ -2105,11 +2450,39 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 
 		protected override bool IsImageValid()
 		{
+			if (PageLayout == PageLayoutMode.Continuous)
+			{
+				return continuousLayout != null && continuousLayout.TotalHeight > 0L;
+			}
 			return GetImageInfo().IsValid;
+		}
+
+		protected override DisplayOutputConfig GetEffectiveDisplayConfig(DisplayOutputConfig config)
+		{
+			if (PageLayout != PageLayoutMode.Continuous)
+			{
+				return config;
+			}
+			ImageFitMode imageDisplayMode = config.ImageDisplayMode;
+			bool fitOnlyIfOversized = config.FitOnlyIfOversized;
+			if (imageDisplayMode == ImageFitMode.FitWidth || imageDisplayMode == ImageFitMode.FitWidthAdaptive)
+			{
+				fitOnlyIfOversized = false;
+			}
+			else if (imageDisplayMode == ImageFitMode.BestFit)
+			{
+				imageDisplayMode = ImageFitMode.FitWidth;
+				fitOnlyIfOversized = true;
+			}
+			return new DisplayOutputConfig(config.ViewSize, config.ImageSize, imageDisplayMode, fitOnlyIfOversized, config.RightToLeftReadingMode, config.RightToLeftReading, config.Part, config.ImageZoom, config.ImageZoom, ImageRotation.None, twoPageAutoScroll: false);
 		}
 
 		protected override Size GetImageSize()
 		{
+			if (PageLayout == PageLayoutMode.Continuous)
+			{
+				return continuousLayout?.TotalSize ?? Size.Empty;
+			}
 			return GetImageInfo().Size;
 		}
 
@@ -2194,6 +2567,11 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 
 		private void UpdatePartOverlay(bool always)
 		{
+			if (PageLayout == PageLayoutMode.Continuous)
+			{
+				visiblePartOverlay.Visible = false;
+				return;
+			}
 			int num = CurrentPage * 100 + base.ImageVisiblePart.Part;
 			Point offset = base.ImageVisiblePart.Offset;
 			if (num == cachedPartOverlay && cachedPartOffset == offset && !always)
@@ -2495,6 +2873,25 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 
 		private void book_Navigation(object sender, BookPageEventArgs e)
 		{
+			if (PageLayout == PageLayoutMode.Continuous)
+			{
+				Blender = null;
+				ShouldPagingBlend = false;
+				OnPageChange(e);
+				currentPage = Book.CurrentPage;
+				if (!continuousNavigationSync)
+				{
+					long horizontalAnchor = CaptureContinuousHorizontalAnchor();
+					int y = continuousLayout?.ResolveAnchor(new ContinuousPageLayout.Anchor(currentPage, 0)) ?? 0;
+					continuousViewportAnchor = new ContinuousPageLayout.Anchor(currentPage, 0);
+					base.ImageVisiblePart = new ImagePartInfo(0, ResolveContinuousHorizontalAnchor(horizontalAnchor), y);
+				}
+				Invalidate();
+				OnPageChanged(e);
+				UpdateNavigationOverlay(redraw: false);
+				lastBlend = Machine.Ticks;
+				return;
+			}
 			bool flag = e.OldPage < e.Page;
 			if (IsFlipped)
 			{
@@ -2567,6 +2964,12 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 
 		private void book_PageFilterOrPagesChanged(object sender, EventArgs e)
 		{
+			if (PageLayout == PageLayoutMode.Continuous)
+			{
+				continuousPageSizes.Clear();
+				continuousContentWidth = 0;
+				RebuildContinuousLayout(CaptureContinuousViewportAnchor());
+			}
 			Invalidate();
 			UpdateNavigationOverlay(redraw: true);
 		}
@@ -2594,6 +2997,11 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 
 		private void book_IndexRetrievalCompleted(object sender, EventArgs e)
 		{
+			if (PageLayout == PageLayoutMode.Continuous)
+			{
+				continuousContentWidth = 0;
+				RebuildContinuousLayout(CaptureContinuousViewportAnchor());
+			}
 			UpdateNavigationOverlay(redraw: true);
 			Invalidate();
 		}

--- a/ComicRack.Engine.Display.Forms/ComicDisplayControl.cs
+++ b/ComicRack.Engine.Display.Forms/ComicDisplayControl.cs
@@ -2469,7 +2469,7 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 			{
 				fitOnlyIfOversized = false;
 			}
-			else if (imageDisplayMode == ImageFitMode.BestFit)
+			else if (imageDisplayMode == ImageFitMode.BestFit || imageDisplayMode == ImageFitMode.FitHeight || imageDisplayMode == ImageFitMode.Fit)
 			{
 				imageDisplayMode = ImageFitMode.FitWidth;
 				fitOnlyIfOversized = true;

--- a/ComicRack.Engine.Display.Forms/ContinuousPageLayout.cs
+++ b/ComicRack.Engine.Display.Forms/ContinuousPageLayout.cs
@@ -58,20 +58,20 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 		}
 
 		/// <summary>
-		/// A stable page-plus-pixel position that can be carried across a layout
-		/// rebuild.  Offset is relative to the rendered top of the page.
+		/// A stable page-plus-relative-position anchor that can be carried across a
+		/// layout rebuild, even when the page's rendered height changes.
 		/// </summary>
 		public readonly struct Anchor
 		{
-			public Anchor(int page, int offset)
+			public Anchor(int page, double relativeOffset)
 			{
 				Page = page;
-				Offset = offset;
+				RelativeOffset = double.IsNaN(relativeOffset) ? 0d : Math.Max(0d, Math.Min(relativeOffset, 1d));
 			}
 
 			public int Page { get; }
 
-			public int Offset { get; }
+			public double RelativeOffset { get; }
 		}
 
 		private readonly List<PageEntry> pages;
@@ -247,14 +247,15 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 				coordinate = totalHeight - 1L;
 			}
 
-			long offset = Clamp(coordinate - page.Top, 0L, page.Height);
-			return new Anchor(page.Page, ClampToInt(offset));
+			long offset = Clamp(coordinate - page.Top, 0L, Math.Max(0L, page.Height - 1L));
+			double relativeOffset = page.Height > 0L ? (double)offset / page.Height : 0d;
+			return new Anchor(page.Page, relativeOffset);
 		}
 
 		/// <summary>
 		/// Resolves an anchor to a clamped virtual y coordinate.  If the anchored
 		/// page is unavailable, the nearest available page by page number is used;
-		/// offsets are clamped to that page's rendered height.
+		/// relative positions are clamped within that page's rendered height.
 		/// </summary>
 		public int ResolveAnchor(Anchor anchor)
 		{
@@ -264,7 +265,8 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 			}
 
 			PageEntry page = FindPage(anchor.Page);
-			long offset = Clamp(anchor.Offset, 0L, page.Height);
+			long offset = (long)(anchor.RelativeOffset * page.Height);
+			offset = Clamp(offset, 0L, Math.Max(0L, page.Height - 1L));
 			long coordinate = SaturatingAdd(page.Top, offset);
 			if (totalHeight > 0L)
 			{

--- a/ComicRack.Engine.Display.Forms/ContinuousPageLayout.cs
+++ b/ComicRack.Engine.Display.Forms/ContinuousPageLayout.cs
@@ -1,0 +1,372 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+
+namespace cYo.Projects.ComicRack.Engine.Display.Forms
+{
+	/// <summary>
+	/// Deterministic geometry for an ordered sequence of vertically stacked comic
+	/// pages. Virtual coordinates are kept as <see cref="long"/> values;
+	/// GDI-facing rectangles and sizes are clipped to the limits of <see cref="int"/>.
+	/// </summary>
+	internal sealed class ContinuousPageLayout
+	{
+		/// <summary>Source metadata for one page in the ordered input sequence.</summary>
+		public readonly struct SourcePage
+		{
+			public SourcePage(int page, Size sourceSize)
+			{
+				Page = page;
+				SourceSize = sourceSize;
+			}
+
+			public int Page { get; }
+
+			public Size SourceSize { get; }
+		}
+
+		/// <summary>
+		/// A page's output geometry. Pages have no vertical spacing. Depending on the
+		/// selected fit mode, source images either use the shared content width or
+		/// preserve their native dimensions and are centered within that width.
+		/// </summary>
+		public sealed class PageEntry
+		{
+			private readonly long top;
+			private readonly long height;
+
+			internal PageEntry(int page, Size sourceSize, int left, long top, long height, int renderedWidth)
+			{
+				Page = page;
+				SourceSize = sourceSize;
+				this.top = top;
+				this.height = height;
+				Bounds = ToRectangle(left, top, renderedWidth, height);
+			}
+
+			public int Page { get; }
+
+			public Size SourceSize { get; }
+
+			public Rectangle Bounds { get; }
+
+			internal long Top => top;
+
+			internal long Height => height;
+
+			internal long Bottom => SaturatingAdd(top, height);
+		}
+
+		/// <summary>
+		/// A stable page-plus-pixel position that can be carried across a layout
+		/// rebuild.  Offset is relative to the rendered top of the page.
+		/// </summary>
+		public readonly struct Anchor
+		{
+			public Anchor(int page, int offset)
+			{
+				Page = page;
+				Offset = offset;
+			}
+
+			public int Page { get; }
+
+			public int Offset { get; }
+		}
+
+		private readonly List<PageEntry> pages;
+		private readonly Dictionary<int, PageEntry> pagesByNumber;
+		private readonly int contentWidth;
+		private readonly long totalHeight;
+
+		public ContinuousPageLayout(IEnumerable<SourcePage> sourcePages, int contentWidth, bool preserveSourceSize = false)
+		{
+			if (sourcePages == null)
+			{
+				throw new ArgumentNullException(nameof(sourcePages));
+			}
+			if (contentWidth <= 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(contentWidth), contentWidth, "Content width must be positive.");
+			}
+
+			this.contentWidth = contentWidth;
+			List<PageEntry> entries = new List<PageEntry>();
+			pagesByNumber = new Dictionary<int, PageEntry>();
+			long top = 0L;
+			foreach (SourcePage sourcePage in sourcePages)
+			{
+				bool validSize = sourcePage.SourceSize.Width > 0 && sourcePage.SourceSize.Height > 0;
+				int renderedWidth = validSize ? (preserveSourceSize ? sourcePage.SourceSize.Width : contentWidth) : 0;
+				long height = preserveSourceSize ? (validSize ? sourcePage.SourceSize.Height : 0L) : GetScaledHeight(contentWidth, sourcePage.SourceSize);
+				int left = preserveSourceSize ? Math.Max(0, (contentWidth - renderedWidth) / 2) : 0;
+				PageEntry entry = new PageEntry(sourcePage.Page, sourcePage.SourceSize, left, top, height, renderedWidth);
+				entries.Add(entry);
+				if (!pagesByNumber.ContainsKey(sourcePage.Page))
+				{
+					pagesByNumber.Add(sourcePage.Page, entry);
+				}
+				top = SaturatingAdd(top, height);
+			}
+
+			pages = entries;
+			totalHeight = top;
+		}
+
+		/// <summary>Full virtual height.  It may exceed <see cref="int.MaxValue"/>.</summary>
+		public long TotalHeight => totalHeight;
+
+		public Size TotalSize => new Size(contentWidth, ClampToInt(totalHeight));
+
+		/// <summary>
+		/// Ordered pages that intersect the viewport.  Bounds use half-open
+		/// intervals, so a page ending exactly on an edge is not returned.
+		/// </summary>
+		public IEnumerable<PageEntry> GetVisible(Rectangle viewport)
+		{
+			if (pages.Count == 0 || viewport.Width <= 0 || viewport.Height <= 0)
+			{
+				yield break;
+			}
+
+			long viewportLeft = viewport.X;
+			long viewportRight = SaturatingAdd(viewportLeft, viewport.Width);
+			if (viewportRight <= 0L || viewportLeft >= contentWidth)
+			{
+				yield break;
+			}
+
+			long viewportTop = viewport.Y;
+			long viewportBottom = SaturatingAdd(viewportTop, viewport.Height);
+			int low = 0;
+			int high = pages.Count;
+			while (low < high)
+			{
+				int middle = low + ((high - low) / 2);
+				if (pages[middle].Bottom <= viewportTop)
+				{
+					low = middle + 1;
+				}
+				else
+				{
+					high = middle;
+				}
+			}
+
+			for (int i = low; i < pages.Count; i++)
+			{
+				PageEntry page = pages[i];
+				if (page.Top >= viewportBottom)
+				{
+					yield break;
+				}
+				if (page.Bounds.Width <= 0 || page.Height <= 0L)
+				{
+					continue;
+				}
+				if (page.Bounds.Left < viewportRight && page.Bounds.Right > viewportLeft && page.Top < viewportBottom && page.Bottom > viewportTop)
+				{
+					yield return page;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Finds the page containing y.  For a nonempty layout y is clamped to the
+		/// strip, which makes this suitable for capturing anchors at either edge.
+		/// </summary>
+		public PageEntry HitTest(int y)
+		{
+			if (pages.Count == 0)
+			{
+				return null;
+			}
+			if (totalHeight <= 0L)
+			{
+				return pages[0];
+			}
+
+			long coordinate = y;
+			if (coordinate < 0L)
+			{
+				coordinate = 0L;
+			}
+			else if (coordinate >= totalHeight)
+			{
+				coordinate = totalHeight - 1L;
+			}
+
+			int low = 0;
+			int high = pages.Count - 1;
+			while (low <= high)
+			{
+				int middle = low + ((high - low) / 2);
+				PageEntry page = pages[middle];
+				if (coordinate < page.Top)
+				{
+					high = middle - 1;
+				}
+				else if (coordinate >= page.Bottom || page.Height <= 0L)
+				{
+					low = middle + 1;
+				}
+				else
+				{
+					return page;
+				}
+			}
+
+			// Zero-sized metadata pages have no hit area.  Return the nearest page
+			// in input order so anchor capture remains deterministic.
+			if (low >= pages.Count)
+			{
+				return pages[pages.Count - 1];
+			}
+			if (high < 0)
+			{
+				return pages[0];
+			}
+			return pages[low].Top > coordinate ? pages[Math.Max(0, high)] : pages[Math.Min(pages.Count - 1, low)];
+		}
+
+		public Anchor CaptureAnchor(int y)
+		{
+			PageEntry page = HitTest(y);
+			if (page == null)
+			{
+				return default;
+			}
+
+			long coordinate = y;
+			if (coordinate < 0L)
+			{
+				coordinate = 0L;
+			}
+			else if (totalHeight > 0L && coordinate >= totalHeight)
+			{
+				coordinate = totalHeight - 1L;
+			}
+
+			long offset = Clamp(coordinate - page.Top, 0L, page.Height);
+			return new Anchor(page.Page, ClampToInt(offset));
+		}
+
+		/// <summary>
+		/// Resolves an anchor to a clamped virtual y coordinate.  If the anchored
+		/// page is unavailable, the nearest available page by page number is used;
+		/// offsets are clamped to that page's rendered height.
+		/// </summary>
+		public int ResolveAnchor(Anchor anchor)
+		{
+			if (pages.Count == 0)
+			{
+				return 0;
+			}
+
+			PageEntry page = FindPage(anchor.Page);
+			long offset = Clamp(anchor.Offset, 0L, page.Height);
+			long coordinate = SaturatingAdd(page.Top, offset);
+			if (totalHeight > 0L)
+			{
+				coordinate = Clamp(coordinate, 0L, totalHeight - 1L);
+			}
+			return ClampToInt(coordinate);
+		}
+
+		private PageEntry FindPage(int pageNumber)
+		{
+			if (pagesByNumber.TryGetValue(pageNumber, out PageEntry exact))
+			{
+				return exact;
+			}
+
+			PageEntry nearest = pages[0];
+			long distance = Distance(nearest.Page, pageNumber);
+			for (int i = 1; i < pages.Count; i++)
+			{
+				PageEntry candidate = pages[i];
+				long candidateDistance = Distance(candidate.Page, pageNumber);
+				if (candidateDistance < distance)
+				{
+					nearest = candidate;
+					distance = candidateDistance;
+				}
+			}
+			return nearest;
+		}
+
+		private static long Distance(int left, int right)
+		{
+			return Math.Abs((long)left - right);
+		}
+
+		private static long GetScaledHeight(int width, Size sourceSize)
+		{
+			if (sourceSize.Width <= 0 || sourceSize.Height <= 0)
+			{
+				return 0L;
+			}
+
+			long numerator = SaturatingMultiply(width, sourceSize.Height);
+			long rounded = SaturatingAdd(numerator, sourceSize.Width / 2L);
+			long height = rounded / sourceSize.Width;
+			return height > 0L ? height : 1L;
+		}
+
+		private static long SaturatingMultiply(long left, long right)
+		{
+			if (left <= 0L || right <= 0L)
+			{
+				return 0L;
+			}
+			if (left > long.MaxValue / right)
+			{
+				return long.MaxValue;
+			}
+			return left * right;
+		}
+
+		private static long SaturatingAdd(long left, long right)
+		{
+			if (right > 0L && left > long.MaxValue - right)
+			{
+				return long.MaxValue;
+			}
+			if (right < 0L && left < long.MinValue - right)
+			{
+				return long.MinValue;
+			}
+			return left + right;
+		}
+
+		private static long Clamp(long value, long minimum, long maximum)
+		{
+			if (value < minimum)
+			{
+				return minimum;
+			}
+			if (value > maximum)
+			{
+				return maximum;
+			}
+			return value;
+		}
+
+		private static int ClampToInt(long value)
+		{
+			if (value <= 0L)
+			{
+				return 0;
+			}
+			return value >= int.MaxValue ? int.MaxValue : (int)value;
+		}
+
+		private static Rectangle ToRectangle(int left, long top, int width, long height)
+		{
+			int y = ClampToInt(top);
+			long availableHeight = int.MaxValue - (long)y;
+			long clippedHeight = Math.Min(height, availableHeight);
+			return new Rectangle(left, y, width, ClampToInt(clippedHeight));
+		}
+	}
+}

--- a/ComicRack.Engine.Display.Forms/ImageDisplayControl.cs
+++ b/ComicRack.Engine.Display.Forms/ImageDisplayControl.cs
@@ -1365,7 +1365,8 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 				Size imageSize = GetImageSize();
 				bool flag = imageSize.Width > imageSize.Height && !IsDoubleImage;
 				ImageRotation rotation = ((ImageAutoRotate && imageSize.Width > imageSize.Height) ? ImageRotation.RotateLeft() : ImageRotation);
-				return new DisplayOutputConfig(base.ClientRectangle.Size, imageSize, ImageFitMode, ImageFitOnlyIfOversized, (!flag) ? RightToLeftReadingMode : RightToLeftReadingMode.FlipParts, RightToLeftReading, ImageVisiblePart, ImageZoom, ImageZoom * (PageMargin ? (1f - PageMarginPercentWidth) : 1f), rotation, flag && TwoPageNavigation);
+				DisplayOutputConfig config = new DisplayOutputConfig(base.ClientRectangle.Size, imageSize, ImageFitMode, ImageFitOnlyIfOversized, (!flag) ? RightToLeftReadingMode : RightToLeftReadingMode.FlipParts, RightToLeftReading, ImageVisiblePart, ImageZoom, ImageZoom * (PageMargin ? (1f - PageMarginPercentWidth) : 1f), rotation, flag && TwoPageNavigation);
+				return GetEffectiveDisplayConfig(config);
 			}
 		}
 
@@ -2087,6 +2088,11 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 			return false;
 		}
 
+		protected virtual DisplayOutputConfig GetEffectiveDisplayConfig(DisplayOutputConfig config)
+		{
+			return config;
+		}
+
 		protected virtual Size GetImageSize()
 		{
 			return Size.Empty;
@@ -2524,6 +2530,7 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 				Point point = ClientToImage(panStart);
 				Point point2 = ClientToImage(panLocation);
 				Point offset = new Point(panPart.Offset.X + (point.X - point2.X), panPart.Offset.Y + (point.Y - point2.Y));
+				offset = AdjustPanOffset(offset);
 				SetVisiblePart(new ImagePartInfo(panPart.Part, offset));
 			}
 		}
@@ -2590,6 +2597,11 @@ namespace cYo.Projects.ComicRack.Engine.Display.Forms
 			{
 				this.Pan(this, EventArgs.Empty);
 			}
+		}
+
+		protected virtual Point AdjustPanOffset(Point offset)
+		{
+			return offset;
 		}
 
 		protected virtual void OnPanEnd()

--- a/ComicRack.Engine/Display/ComicDisplay.cs
+++ b/ComicRack.Engine/Display/ComicDisplay.cs
@@ -756,42 +756,42 @@ namespace cYo.Projects.ComicRack.Engine.Display
 				display.ImageRotation = display.CurrentImageRotation;
 				switch (value)
 				{
-				default:
+					default:
 					Animate(delegate(float p)
-					{
-						display.DoublePageOverlap = p;
-					});
-					break;
-				case PageLayoutMode.Double:
-					if (!TwoPageDisplay || (TwoPageDisplay && !IsDoubleImage))
-					{
-						display.PageLayout = value;
-						Animate(delegate(float p)
 						{
-							display.DoublePageOverlap = 1f - p;
+							display.DoublePageOverlap = p;
 						});
-					}
-					break;
-				case PageLayoutMode.DoubleAdaptive:
-					if (TwoPageDisplay)
-					{
-						if (!IsDoubleImage)
+						break;
+					case PageLayoutMode.Double:
+						if (!TwoPageDisplay || (TwoPageDisplay && !IsDoubleImage))
 						{
-							Animate(delegate(float p)
+							display.PageLayout = value;
+						Animate(delegate(float p)
 							{
-								display.DoublePageOverlap = p;
+								display.DoublePageOverlap = 1f - p;
 							});
 						}
-					}
-					else
-					{
-						display.PageLayout = value;
-						Animate(delegate(float p)
+						break;
+					case PageLayoutMode.DoubleAdaptive:
+						if (TwoPageDisplay)
 						{
-							display.DoublePageOverlap = 1f - p;
-						});
-					}
-					break;
+							if (!IsDoubleImage)
+							{
+							Animate(delegate(float p)
+								{
+									display.DoublePageOverlap = p;
+								});
+							}
+						}
+						else
+						{
+							display.PageLayout = value;
+						Animate(delegate(float p)
+							{
+								display.DoublePageOverlap = 1f - p;
+							});
+						}
+						break;
 				}
 				display.PageLayout = value;
 				display.DoublePageOverlap = 0f;
@@ -1458,18 +1458,18 @@ namespace cYo.Projects.ComicRack.Engine.Display
 		{
 			switch (PageLayout)
 			{
-			case PageLayoutMode.Single:
-				PageLayout = PageLayoutMode.Double;
-				break;
-			case PageLayoutMode.Double:
-				PageLayout = PageLayoutMode.DoubleAdaptive;
-				break;
-			case PageLayoutMode.DoubleAdaptive:
-				PageLayout = PageLayoutMode.Single;
-				break;
-			case PageLayoutMode.Continuous:
-				PageLayout = PageLayoutMode.Single;
-				break;
+				case PageLayoutMode.Single:
+					PageLayout = PageLayoutMode.Double;
+					break;
+				case PageLayoutMode.Double:
+					PageLayout = PageLayoutMode.DoubleAdaptive;
+					break;
+				case PageLayoutMode.DoubleAdaptive:
+					PageLayout = PageLayoutMode.Single;
+					break;
+				case PageLayoutMode.Continuous:
+					PageLayout = PageLayoutMode.Single;
+					break;
 			}
 		}
 
@@ -1495,7 +1495,8 @@ namespace cYo.Projects.ComicRack.Engine.Display
 
 		public void SetPageFitAll()
 		{
-			ImageFitMode = ImageFitMode.Fit;
+			if (PageLayout != PageLayoutMode.Continuous)
+				ImageFitMode = ImageFitMode.Fit;
 		}
 
 		public void SetPageFitWidth()
@@ -1510,7 +1511,8 @@ namespace cYo.Projects.ComicRack.Engine.Display
 
 		public void SetPageFitHeight()
 		{
-			ImageFitMode = ImageFitMode.FitHeight;
+			if (PageLayout != PageLayoutMode.Continuous)
+				ImageFitMode = ImageFitMode.FitHeight;
 		}
 
 		public void SetPageBestFit()
@@ -1521,6 +1523,11 @@ namespace cYo.Projects.ComicRack.Engine.Display
 		public bool IsPageFitHeight()
 		{
 			return ImageFitMode == ImageFitMode.FitHeight;
+		}
+
+		public bool IsPageFitAll()
+		{
+			return ImageFitMode == ImageFitMode.Fit;
 		}
 
 		public bool IsPageFitWidth()
@@ -1699,62 +1706,62 @@ namespace cYo.Projects.ComicRack.Engine.Display
 		{
 			switch (e.Area)
 			{
-			case ContentAlignment.TopLeft:
-				if (!e.Double)
-				{
-					return CommandKey.Gesture1;
-				}
-				return CommandKey.GestureDouble1;
-			case ContentAlignment.TopCenter:
-				if (!e.Double)
-				{
-					return CommandKey.Gesture2;
-				}
-				return CommandKey.GestureDouble2;
-			case ContentAlignment.TopRight:
-				if (!e.Double)
-				{
-					return CommandKey.Gesture3;
-				}
-				return CommandKey.GestureDouble3;
-			case ContentAlignment.MiddleLeft:
-				if (!e.Double)
-				{
-					return CommandKey.Gesture4;
-				}
-				return CommandKey.GestureDouble4;
-			case ContentAlignment.MiddleCenter:
-				if (!e.Double)
-				{
-					return CommandKey.Gesture5;
-				}
-				return CommandKey.GestureDouble5;
-			case ContentAlignment.MiddleRight:
-				if (!e.Double)
-				{
-					return CommandKey.Gesture6;
-				}
-				return CommandKey.GestureDouble6;
-			case ContentAlignment.BottomLeft:
-				if (!e.Double)
-				{
-					return CommandKey.Gesture7;
-				}
-				return CommandKey.GestureDouble7;
-			case ContentAlignment.BottomCenter:
-				if (!e.Double)
-				{
-					return CommandKey.Gesture8;
-				}
-				return CommandKey.GestureDouble8;
-			case ContentAlignment.BottomRight:
-				if (!e.Double)
-				{
-					return CommandKey.Gesture9;
-				}
-				return CommandKey.GestureDouble9;
-			default:
-				return CommandKey.None;
+				case ContentAlignment.TopLeft:
+					if (!e.Double)
+					{
+						return CommandKey.Gesture1;
+					}
+					return CommandKey.GestureDouble1;
+				case ContentAlignment.TopCenter:
+					if (!e.Double)
+					{
+						return CommandKey.Gesture2;
+					}
+					return CommandKey.GestureDouble2;
+				case ContentAlignment.TopRight:
+					if (!e.Double)
+					{
+						return CommandKey.Gesture3;
+					}
+					return CommandKey.GestureDouble3;
+				case ContentAlignment.MiddleLeft:
+					if (!e.Double)
+					{
+						return CommandKey.Gesture4;
+					}
+					return CommandKey.GestureDouble4;
+				case ContentAlignment.MiddleCenter:
+					if (!e.Double)
+					{
+						return CommandKey.Gesture5;
+					}
+					return CommandKey.GestureDouble5;
+				case ContentAlignment.MiddleRight:
+					if (!e.Double)
+					{
+						return CommandKey.Gesture6;
+					}
+					return CommandKey.GestureDouble6;
+				case ContentAlignment.BottomLeft:
+					if (!e.Double)
+					{
+						return CommandKey.Gesture7;
+					}
+					return CommandKey.GestureDouble7;
+				case ContentAlignment.BottomCenter:
+					if (!e.Double)
+					{
+						return CommandKey.Gesture8;
+					}
+					return CommandKey.GestureDouble8;
+				case ContentAlignment.BottomRight:
+					if (!e.Double)
+					{
+						return CommandKey.Gesture9;
+					}
+					return CommandKey.GestureDouble9;
+				default:
+					return CommandKey.None;
 			}
 		}
 
@@ -1770,27 +1777,27 @@ namespace cYo.Projects.ComicRack.Engine.Display
 		{
 			switch (e.Gesture)
 			{
-			case GestureType.Click:
-				if (MouseClickEnabled)
-				{
-					e.Handled = keyboardMap.HandleKey(e.MouseButton, e.Double, e.IsTouch);
-				}
-				break;
-			case GestureType.PressAndTap:
-				e.Handled = keyboardMap.HandleKey(CommandKey.TouchPressAndTap);
-				break;
-			case GestureType.TwoFingerTap:
-				e.Handled = keyboardMap.HandleKey(CommandKey.TouchTwoFingerTap);
-				break;
-			case GestureType.Touch:
-				e.Handled = keyboardMap.HandleKey(TranslateTouchGesture(e));
-				break;
-			case GestureType.FlickLeft:
-				e.Handled = keyboardMap.HandleKey(CommandKey.FlickLeft);
-				break;
-			case GestureType.FlickRight:
-				e.Handled = keyboardMap.HandleKey(CommandKey.FlickRight);
-				break;
+				case GestureType.Click:
+					if (MouseClickEnabled)
+					{
+						e.Handled = keyboardMap.HandleKey(e.MouseButton, e.Double, e.IsTouch);
+					}
+					break;
+				case GestureType.PressAndTap:
+					e.Handled = keyboardMap.HandleKey(CommandKey.TouchPressAndTap);
+					break;
+				case GestureType.TwoFingerTap:
+					e.Handled = keyboardMap.HandleKey(CommandKey.TouchTwoFingerTap);
+					break;
+				case GestureType.Touch:
+					e.Handled = keyboardMap.HandleKey(TranslateTouchGesture(e));
+					break;
+				case GestureType.FlickLeft:
+					e.Handled = keyboardMap.HandleKey(CommandKey.FlickLeft);
+					break;
+				case GestureType.FlickRight:
+					e.Handled = keyboardMap.HandleKey(CommandKey.FlickRight);
+					break;
 			}
 		}
 
@@ -1851,25 +1858,25 @@ namespace cYo.Projects.ComicRack.Engine.Display
 			}
 			switch (pageSeekOrigin)
 			{
-			case PageSeekOrigin.Beginning:
-				DisplayFirstPage();
-				break;
-			case PageSeekOrigin.End:
-				DisplayLastPage();
-				break;
-			case PageSeekOrigin.Current:
-				if (num < 0)
-				{
-					DisplayPreviousPage(PagingMode.Double);
-				}
-				else
-				{
-					DisplayNextPage(PagingMode.Double);
-				}
-				break;
-			case PageSeekOrigin.Absolute:
-				Book.Navigate(num, pageSeekOrigin);
-				break;
+				case PageSeekOrigin.Beginning:
+					DisplayFirstPage();
+					break;
+				case PageSeekOrigin.End:
+					DisplayLastPage();
+					break;
+				case PageSeekOrigin.Current:
+					if (num < 0)
+					{
+						DisplayPreviousPage(PagingMode.Double);
+					}
+					else
+					{
+						DisplayNextPage(PagingMode.Double);
+					}
+					break;
+				case PageSeekOrigin.Absolute:
+					Book.Navigate(num, pageSeekOrigin);
+					break;
 			}
 		}
 

--- a/ComicRack.Engine/Display/ComicDisplay.cs
+++ b/ComicRack.Engine/Display/ComicDisplay.cs
@@ -78,7 +78,7 @@ namespace cYo.Projects.ComicRack.Engine.Display
 
 		private float mouseWheelSpeed = 2f;
 
-		public bool TwoPageDisplay => PageLayout != PageLayoutMode.Single;
+		public bool TwoPageDisplay => PageLayout == PageLayoutMode.Double || PageLayout == PageLayoutMode.DoubleAdaptive;
 
 		public bool SupressContextMenu
 		{
@@ -744,6 +744,12 @@ namespace cYo.Projects.ComicRack.Engine.Display
 				{
 					return;
 				}
+				if (value == PageLayoutMode.Continuous || display.PageLayout == PageLayoutMode.Continuous)
+				{
+					display.PageLayout = value;
+					display.DoublePageOverlap = 0f;
+					return;
+				}
 				bool imageAutoRotate = display.ImageAutoRotate;
 				ImageRotation imageRotation = display.ImageRotation;
 				display.ImageAutoRotate = false;
@@ -1202,6 +1208,14 @@ namespace cYo.Projects.ComicRack.Engine.Display
 
 		public void DisplayNextPageOrPart(bool forceNewPage = false)
 		{
+			if (PageLayout == PageLayoutMode.Continuous)
+			{
+				if (!EatScrolling() && !DisplayPart(PartPageToDisplay.Next))
+				{
+					OnLastPageReached();
+				}
+				return;
+			}
 			if (!EatScrolling() && (forceNewPage || !DisplayPart(PartPageToDisplay.Next)))
 			{
 				DisplayNextPage(PagingMode.Double | PagingMode.Walled);
@@ -1210,6 +1224,14 @@ namespace cYo.Projects.ComicRack.Engine.Display
 
 		public void DisplayPreviousPageOrPart(bool forceNewPage = false)
 		{
+			if (PageLayout == PageLayoutMode.Continuous)
+			{
+				if (!EatScrolling() && !DisplayPart(PartPageToDisplay.Previous))
+				{
+					OnFirstPageReached();
+				}
+				return;
+			}
 			if (!EatScrolling() && (forceNewPage || !DisplayPart(PartPageToDisplay.Previous)))
 			{
 				DisplayPreviousPage(PagingMode.Double | PagingMode.Walled);
@@ -1362,7 +1384,11 @@ namespace cYo.Projects.ComicRack.Engine.Display
 		{
 			if (!EatScrolling())
 			{
-				if (AutoScrolling)
+				if (PageLayout == PageLayoutMode.Continuous)
+				{
+					ScrollUp(lines, withPageChange: false);
+				}
+				else if (AutoScrolling)
 				{
 					DisplayPreviousPageOrPart();
 				}
@@ -1382,7 +1408,11 @@ namespace cYo.Projects.ComicRack.Engine.Display
 		{
 			if (!EatScrolling())
 			{
-				if (AutoScrolling)
+				if (PageLayout == PageLayoutMode.Continuous)
+				{
+					ScrollDown(lines, withPageChange: false);
+				}
+				else if (AutoScrolling)
 				{
 					DisplayNextPageOrPart();
 				}
@@ -1435,6 +1465,9 @@ namespace cYo.Projects.ComicRack.Engine.Display
 				PageLayout = PageLayoutMode.DoubleAdaptive;
 				break;
 			case PageLayoutMode.DoubleAdaptive:
+				PageLayout = PageLayoutMode.Single;
+				break;
+			case PageLayoutMode.Continuous:
 				PageLayout = PageLayoutMode.Single;
 				break;
 			}
@@ -1600,6 +1633,11 @@ namespace cYo.Projects.ComicRack.Engine.Display
 		{
 			bool isDoubleImage = IsDoubleImage;
 			Size imageSize = ImageSize;
+			if (PageLayout == PageLayoutMode.Continuous)
+			{
+				int line = Math.Max(1, imageSize.Width / 16);
+				return new Size(line, line);
+			}
 			return new Size(imageSize.Width / (isDoubleImage ? 32 : 16), imageSize.Height / 32);
 		}
 
@@ -1623,6 +1661,10 @@ namespace cYo.Projects.ComicRack.Engine.Display
 		private void display_PageChange(object sender, BookPageEventArgs e)
 		{
 			oldZoom = 0f;
+			if (PageLayout == PageLayoutMode.Continuous)
+			{
+				return;
+			}
 			if (ImageZoom != 1f)
 			{
 				if (resetZoomOnPageChange)

--- a/ComicRack.Engine/Display/PageLayoutMode.cs
+++ b/ComicRack.Engine/Display/PageLayoutMode.cs
@@ -4,6 +4,7 @@ namespace cYo.Projects.ComicRack.Engine.Display
 	{
 		Single,
 		Double,
-		DoubleAdaptive
+		DoubleAdaptive,
+		Continuous
 	}
 }

--- a/ComicRack/MainForm.Designer.cs
+++ b/ComicRack/MainForm.Designer.cs
@@ -177,6 +177,7 @@ namespace cYo.Projects.ComicRack.Viewer
 			this.miSinglePage = new System.Windows.Forms.ToolStripMenuItem();
 			this.miTwoPages = new System.Windows.Forms.ToolStripMenuItem();
 			this.miTwoPagesAdaptive = new System.Windows.Forms.ToolStripMenuItem();
+			this.miContinuous = new System.Windows.Forms.ToolStripMenuItem();
 			this.miRightToLeft = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolStripMenuItem44 = new System.Windows.Forms.ToolStripSeparator();
 			this.miOnlyFitOversized = new System.Windows.Forms.ToolStripMenuItem();
@@ -279,6 +280,7 @@ namespace cYo.Projects.ComicRack.Viewer
 			this.cmSinglePage = new System.Windows.Forms.ToolStripMenuItem();
 			this.cmTwoPages = new System.Windows.Forms.ToolStripMenuItem();
 			this.cmTwoPagesAdaptive = new System.Windows.Forms.ToolStripMenuItem();
+			this.cmContinuous = new System.Windows.Forms.ToolStripMenuItem();
 			this.cmRightToLeft = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolStripMenuItem38 = new System.Windows.Forms.ToolStripSeparator();
 			this.cmRotate0 = new System.Windows.Forms.ToolStripMenuItem();
@@ -325,6 +327,7 @@ namespace cYo.Projects.ComicRack.Viewer
 			this.tbSinglePage = new System.Windows.Forms.ToolStripMenuItem();
 			this.tbTwoPages = new System.Windows.Forms.ToolStripMenuItem();
 			this.tbTwoPagesAdaptive = new System.Windows.Forms.ToolStripMenuItem();
+			this.tbContinuous = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolStripMenuItem54 = new System.Windows.Forms.ToolStripSeparator();
 			this.tbRightToLeft = new System.Windows.Forms.ToolStripMenuItem();
 			this.tbFit = new System.Windows.Forms.ToolStripSplitButton();
@@ -1356,6 +1359,7 @@ namespace cYo.Projects.ComicRack.Viewer
             this.miSinglePage,
             this.miTwoPages,
             this.miTwoPagesAdaptive,
+            this.miContinuous,
             this.miRightToLeft,
             this.toolStripMenuItem44,
             this.miOnlyFitOversized});
@@ -1440,6 +1444,13 @@ namespace cYo.Projects.ComicRack.Viewer
 			this.miTwoPagesAdaptive.Size = new System.Drawing.Size(247, 22);
 			this.miTwoPagesAdaptive.Text = "Two Pages (adaptive)";
 			this.miTwoPagesAdaptive.ToolTipText = "Show one or two pages";
+			//
+			// miContinuous
+			//
+			this.miContinuous.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.SinglePage;
+			this.miContinuous.Name = "miContinuous";
+			this.miContinuous.Size = new System.Drawing.Size(247, 22);
+			this.miContinuous.Text = "Long Form (Continuous)";
 			// 
 			// miRightToLeft
 			// 
@@ -2258,6 +2269,7 @@ namespace cYo.Projects.ComicRack.Viewer
             this.cmSinglePage,
             this.cmTwoPages,
             this.cmTwoPagesAdaptive,
+            this.cmContinuous,
             this.cmRightToLeft,
             this.toolStripMenuItem38,
             this.cmRotate0,
@@ -2349,6 +2361,13 @@ namespace cYo.Projects.ComicRack.Viewer
 			this.cmTwoPagesAdaptive.Size = new System.Drawing.Size(241, 22);
 			this.cmTwoPagesAdaptive.Text = "Two Pages (adaptive)";
 			this.cmTwoPagesAdaptive.ToolTipText = "Show one or two pages";
+			//
+			// cmContinuous
+			//
+			this.cmContinuous.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.SinglePage;
+			this.cmContinuous.Name = "cmContinuous";
+			this.cmContinuous.Size = new System.Drawing.Size(241, 22);
+			this.cmContinuous.Text = "Long Form (Continuous)";
 			// 
 			// cmRightToLeft
 			// 
@@ -2735,6 +2754,7 @@ namespace cYo.Projects.ComicRack.Viewer
             this.tbSinglePage,
             this.tbTwoPages,
             this.tbTwoPagesAdaptive,
+            this.tbContinuous,
             this.toolStripMenuItem54,
             this.tbRightToLeft});
 			this.tbPageLayout.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.SinglePage;
@@ -2767,6 +2787,13 @@ namespace cYo.Projects.ComicRack.Viewer
 			this.tbTwoPagesAdaptive.Size = new System.Drawing.Size(225, 22);
 			this.tbTwoPagesAdaptive.Text = "Two Pages (adaptive)";
 			this.tbTwoPagesAdaptive.ToolTipText = "Show one or two pages";
+			//
+			// tbContinuous
+			//
+			this.tbContinuous.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.SinglePage;
+			this.tbContinuous.Name = "tbContinuous";
+			this.tbContinuous.Size = new System.Drawing.Size(225, 22);
+			this.tbContinuous.Text = "Long Form (Continuous)";
 			// 
 			// toolStripMenuItem54
 			// 
@@ -3781,12 +3808,15 @@ namespace cYo.Projects.ComicRack.Viewer
 		private ToolStripMenuItem tbTwoPagesAdaptive;
 		private ToolStripMenuItem tbSinglePage;
 		private ToolStripMenuItem tbTwoPages;
+		private ToolStripMenuItem tbContinuous;
 		private ToolStripSeparator toolStripMenuItem54;
 		private ToolStripMenuItem tbRightToLeft;
 		private ToolStripMenuItem miTwoPagesAdaptive;
 		private ToolStripMenuItem miTwoPages;
 		private ToolStripMenuItem miSinglePage;
+		private ToolStripMenuItem miContinuous;
 		private ToolStripMenuItem cmSinglePage;
+		private ToolStripMenuItem cmContinuous;
 		private ToolStripMenuItem cmTwoPages;
 		private ToolStripMenuItem cmTwoPagesAdaptive;
 		private ToolStripSeparator toolStripMenuItem55;

--- a/ComicRack/MainForm.Designer.cs
+++ b/ComicRack/MainForm.Designer.cs
@@ -1450,7 +1450,7 @@ namespace cYo.Projects.ComicRack.Viewer
 			this.miContinuous.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.SinglePage;
 			this.miContinuous.Name = "miContinuous";
 			this.miContinuous.Size = new System.Drawing.Size(247, 22);
-			this.miContinuous.Text = "Long Form (Continuous)";
+			this.miContinuous.Text = "Continuous";
 			// 
 			// miRightToLeft
 			// 
@@ -2367,7 +2367,7 @@ namespace cYo.Projects.ComicRack.Viewer
 			this.cmContinuous.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.SinglePage;
 			this.cmContinuous.Name = "cmContinuous";
 			this.cmContinuous.Size = new System.Drawing.Size(241, 22);
-			this.cmContinuous.Text = "Long Form (Continuous)";
+			this.cmContinuous.Text = "Continuous";
 			// 
 			// cmRightToLeft
 			// 
@@ -2793,7 +2793,7 @@ namespace cYo.Projects.ComicRack.Viewer
 			this.tbContinuous.Image = global::cYo.Projects.ComicRack.Viewer.Properties.Resources.SinglePage;
 			this.tbContinuous.Name = "tbContinuous";
 			this.tbContinuous.Size = new System.Drawing.Size(225, 22);
-			this.tbContinuous.Text = "Long Form (Continuous)";
+			this.tbContinuous.Text = "Continuous";
 			// 
 			// toolStripMenuItem54
 			// 

--- a/ComicRack/MainForm.cs
+++ b/ComicRack/MainForm.cs
@@ -1360,12 +1360,13 @@ namespace cYo.Projects.ComicRack.Viewer
 			{
 				ComicDisplay.PageLayout = PageLayoutMode.Continuous;
 			}, true, () => ComicDisplay.PageLayout == PageLayoutMode.Continuous, miContinuous, tbContinuous, cmContinuous);
+			UpdateHandler notContinuousLayout = () => ComicDisplay.PageLayout != PageLayoutMode.Continuous;
 			commands.Add(ComicDisplay.TogglePageFit, tbFit);
 			commands.Add(ComicDisplay.SetPageOriginal, true, () => ComicDisplay.ImageFitMode == ImageFitMode.Original, miOriginal, cmOriginal, tbOriginal);
-			commands.Add(ComicDisplay.SetPageFitAll, true, () => ComicDisplay.ImageFitMode == ImageFitMode.Fit, miFitAll, tbFitAll, cmFitAll);
+			commands.Add(ComicDisplay.SetPageFitAll, notContinuousLayout, ComicDisplay.IsPageFitAll, miFitAll, tbFitAll, cmFitAll);
 			commands.Add(ComicDisplay.SetPageFitWidth, true, ComicDisplay.IsPageFitWidth, miFitWidth, tbFitWidth, cmFitWidth);
 			commands.Add(ComicDisplay.SetPageFitWidthAdaptive, true, ComicDisplay.IsPageFitWidthAdaptive, miFitWidthAdaptive, tbFitWidthAdaptive, cmFitWidthAdaptive);
-			commands.Add(ComicDisplay.SetPageFitHeight, true, ComicDisplay.IsPageFitHeight, miFitHeight, tbFitHeight, cmFitHeight);
+			commands.Add(ComicDisplay.SetPageFitHeight, notContinuousLayout, ComicDisplay.IsPageFitHeight, miFitHeight, tbFitHeight, cmFitHeight);
 			commands.Add(ComicDisplay.SetPageBestFit, true, ComicDisplay.IsPageFitBest, miBestFit, tbBestFit, cmFitBest);
 			commands.Add(ComicDisplay.ToggleFitOnlyIfOversized, true, () => ComicDisplay.ImageFitOnlyIfOversized, miOnlyFitOversized, tbOnlyFitOversized, cmOnlyFitOversized);
 			commands.Add(delegate
@@ -1414,35 +1415,34 @@ namespace cYo.Projects.ComicRack.Viewer
 			{
 				ComicDisplay.ImageZoom = ZoomDialog.Show(this, ComicDisplay.ImageZoom);
 			}, miZoomCustom, tbZoomCustom);
-			UpdateHandler rotationAvailable = () => ComicDisplay.PageLayout != PageLayoutMode.Continuous;
 			commands.Add(delegate
 			{
 				ComicDisplay.ImageRotation = ImageRotation.None;
-			}, rotationAvailable, () => ComicDisplay.ImageRotation == ImageRotation.None, miRotate0, tbRotate0, cmRotate0);
+			}, notContinuousLayout, () => ComicDisplay.ImageRotation == ImageRotation.None, miRotate0, tbRotate0, cmRotate0);
 			commands.Add(delegate
 			{
 				ComicDisplay.ImageRotation = ImageRotation.Rotate90;
-			}, rotationAvailable, () => ComicDisplay.ImageRotation == ImageRotation.Rotate90, miRotate90, tbRotate90, cmRotate90);
+			}, notContinuousLayout, () => ComicDisplay.ImageRotation == ImageRotation.Rotate90, miRotate90, tbRotate90, cmRotate90);
 			commands.Add(delegate
 			{
 				ComicDisplay.ImageRotation = ImageRotation.Rotate180;
-			}, rotationAvailable, () => ComicDisplay.ImageRotation == ImageRotation.Rotate180, miRotate180, tbRotate180, cmRotate180);
+			}, notContinuousLayout, () => ComicDisplay.ImageRotation == ImageRotation.Rotate180, miRotate180, tbRotate180, cmRotate180);
 			commands.Add(delegate
 			{
 				ComicDisplay.ImageRotation = ImageRotation.Rotate270;
-			}, rotationAvailable, () => ComicDisplay.ImageRotation == ImageRotation.Rotate270, miRotate270, tbRotate270, cmRotate270);
+			}, notContinuousLayout, () => ComicDisplay.ImageRotation == ImageRotation.Rotate270, miRotate270, tbRotate270, cmRotate270);
 			commands.Add(delegate
 			{
 				ComicDisplay.ImageRotation = ComicDisplay.ImageRotation.RotateLeft();
-			}, rotationAvailable, miRotateLeft, tbRotateLeft);
+			}, notContinuousLayout, miRotateLeft, tbRotateLeft);
 			commands.Add(delegate
 			{
 				ComicDisplay.ImageRotation = ComicDisplay.ImageRotation.RotateRight();
-			}, rotationAvailable, miRotateRight, tbRotateRight, tbRotate);
+			}, notContinuousLayout, miRotateRight, tbRotateRight, tbRotate);
 			commands.Add(delegate
 			{
 				ComicDisplay.ImageAutoRotate = !ComicDisplay.ImageAutoRotate;
-			}, rotationAvailable, () => ComicDisplay.ImageAutoRotate, miAutoRotate, tbAutoRotate);
+			}, notContinuousLayout, () => ComicDisplay.ImageAutoRotate, miAutoRotate, tbAutoRotate);
 			commands.Add(ComicDisplay.ToggleMagnifier, true, () => ComicDisplay.MagnifierVisible, miMagnify, tbMagnify, cmMagnify);
 			commands.Add(delegate
 			{

--- a/ComicRack/MainForm.cs
+++ b/ComicRack/MainForm.cs
@@ -1705,7 +1705,7 @@ namespace cYo.Projects.ComicRack.Viewer
 			{
 				CommandKey.D9
 			}));
-			ComicDisplay.KeyboardMap.Commands.Add(new KeyboardCommand(miContinuous.Image, "Continuous", group, "Long Form (Continuous)", (Action)delegate
+			ComicDisplay.KeyboardMap.Commands.Add(new KeyboardCommand(miContinuous.Image, "Continuous", group, "Continuous", (Action)delegate
 			{
 				ComicDisplay.PageLayout = PageLayoutMode.Continuous;
 			}));

--- a/ComicRack/MainForm.cs
+++ b/ComicRack/MainForm.cs
@@ -1356,6 +1356,10 @@ namespace cYo.Projects.ComicRack.Viewer
 			{
 				ComicDisplay.PageLayout = PageLayoutMode.DoubleAdaptive;
 			}, true, () => ComicDisplay.PageLayout == PageLayoutMode.DoubleAdaptive, miTwoPagesAdaptive, tbTwoPagesAdaptive, cmTwoPagesAdaptive);
+			commands.Add(delegate
+			{
+				ComicDisplay.PageLayout = PageLayoutMode.Continuous;
+			}, true, () => ComicDisplay.PageLayout == PageLayoutMode.Continuous, miContinuous, tbContinuous, cmContinuous);
 			commands.Add(ComicDisplay.TogglePageFit, tbFit);
 			commands.Add(ComicDisplay.SetPageOriginal, true, () => ComicDisplay.ImageFitMode == ImageFitMode.Original, miOriginal, cmOriginal, tbOriginal);
 			commands.Add(ComicDisplay.SetPageFitAll, true, () => ComicDisplay.ImageFitMode == ImageFitMode.Fit, miFitAll, tbFitAll, cmFitAll);
@@ -1410,34 +1414,35 @@ namespace cYo.Projects.ComicRack.Viewer
 			{
 				ComicDisplay.ImageZoom = ZoomDialog.Show(this, ComicDisplay.ImageZoom);
 			}, miZoomCustom, tbZoomCustom);
+			UpdateHandler rotationAvailable = () => ComicDisplay.PageLayout != PageLayoutMode.Continuous;
 			commands.Add(delegate
 			{
 				ComicDisplay.ImageRotation = ImageRotation.None;
-			}, true, () => ComicDisplay.ImageRotation == ImageRotation.None, miRotate0, tbRotate0, cmRotate0);
+			}, rotationAvailable, () => ComicDisplay.ImageRotation == ImageRotation.None, miRotate0, tbRotate0, cmRotate0);
 			commands.Add(delegate
 			{
 				ComicDisplay.ImageRotation = ImageRotation.Rotate90;
-			}, true, () => ComicDisplay.ImageRotation == ImageRotation.Rotate90, miRotate90, tbRotate90, cmRotate90);
+			}, rotationAvailable, () => ComicDisplay.ImageRotation == ImageRotation.Rotate90, miRotate90, tbRotate90, cmRotate90);
 			commands.Add(delegate
 			{
 				ComicDisplay.ImageRotation = ImageRotation.Rotate180;
-			}, true, () => ComicDisplay.ImageRotation == ImageRotation.Rotate180, miRotate180, tbRotate180, cmRotate180);
+			}, rotationAvailable, () => ComicDisplay.ImageRotation == ImageRotation.Rotate180, miRotate180, tbRotate180, cmRotate180);
 			commands.Add(delegate
 			{
 				ComicDisplay.ImageRotation = ImageRotation.Rotate270;
-			}, true, () => ComicDisplay.ImageRotation == ImageRotation.Rotate270, miRotate270, tbRotate270, cmRotate270);
+			}, rotationAvailable, () => ComicDisplay.ImageRotation == ImageRotation.Rotate270, miRotate270, tbRotate270, cmRotate270);
 			commands.Add(delegate
 			{
 				ComicDisplay.ImageRotation = ComicDisplay.ImageRotation.RotateLeft();
-			}, miRotateLeft, tbRotateLeft);
+			}, rotationAvailable, miRotateLeft, tbRotateLeft);
 			commands.Add(delegate
 			{
 				ComicDisplay.ImageRotation = ComicDisplay.ImageRotation.RotateRight();
-			}, miRotateRight, tbRotateRight, tbRotate);
+			}, rotationAvailable, miRotateRight, tbRotateRight, tbRotate);
 			commands.Add(delegate
 			{
 				ComicDisplay.ImageAutoRotate = !ComicDisplay.ImageAutoRotate;
-			}, true, () => ComicDisplay.ImageAutoRotate, miAutoRotate, tbAutoRotate);
+			}, rotationAvailable, () => ComicDisplay.ImageAutoRotate, miAutoRotate, tbAutoRotate);
 			commands.Add(ComicDisplay.ToggleMagnifier, true, () => ComicDisplay.MagnifierVisible, miMagnify, tbMagnify, cmMagnify);
 			commands.Add(delegate
 			{
@@ -1700,6 +1705,10 @@ namespace cYo.Projects.ComicRack.Viewer
 			{
 				CommandKey.D9
 			}));
+			ComicDisplay.KeyboardMap.Commands.Add(new KeyboardCommand(miContinuous.Image, "Continuous", group, "Long Form (Continuous)", (Action)delegate
+			{
+				ComicDisplay.PageLayout = PageLayoutMode.Continuous;
+			}));
 			ComicDisplay.KeyboardMap.Commands.Add(new KeyboardCommand(miRightToLeft.Image, "RightToLeft", group, "Right to Left", (Action)delegate
 			{
 				ComicDisplay.RightToLeftReading = !ComicDisplay.RightToLeftReading;
@@ -1711,21 +1720,30 @@ namespace cYo.Projects.ComicRack.Viewer
 			group = "ZoomAndRotate";
 			ComicDisplay.KeyboardMap.Commands.Add(new KeyboardCommand(miRotateRight.Image, "RotateC", group, "Rotate Right", (Action)delegate
 			{
-				ComicDisplay.ImageRotation = ComicDisplay.ImageRotation.RotateRight();
+				if (ComicDisplay.PageLayout != PageLayoutMode.Continuous)
+				{
+					ComicDisplay.ImageRotation = ComicDisplay.ImageRotation.RotateRight();
+				}
 			}, new CommandKey[1]
 			{
 				CommandKey.R
 			}));
 			ComicDisplay.KeyboardMap.Commands.Add(new KeyboardCommand(miRotateLeft.Image, "RotateCC", group, "Rotate Left", (Action)delegate
 			{
-				ComicDisplay.ImageRotation = ComicDisplay.ImageRotation.RotateLeft();
+				if (ComicDisplay.PageLayout != PageLayoutMode.Continuous)
+				{
+					ComicDisplay.ImageRotation = ComicDisplay.ImageRotation.RotateLeft();
+				}
 			}, new CommandKey[1]
 			{
 				CommandKey.R | CommandKey.Shift
 			}));
 			ComicDisplay.KeyboardMap.Commands.Add(new KeyboardCommand(miAutoRotate.Image, "AutoRotate", group, "Autorotate Double Pages", (Action)delegate
 			{
-				ComicDisplay.ImageAutoRotate = !ComicDisplay.ImageAutoRotate;
+				if (ComicDisplay.PageLayout != PageLayoutMode.Continuous)
+				{
+					ComicDisplay.ImageAutoRotate = !ComicDisplay.ImageAutoRotate;
+				}
 			}, new CommandKey[1]
 			{
 				CommandKey.A
@@ -3363,6 +3381,8 @@ namespace cYo.Projects.ComicRack.Viewer
 						return miTwoPagesAdaptive.Image;
 					}
 					return TwoPagesAdaptiveRtl;
+				case PageLayoutMode.Continuous:
+					return miContinuous.Image;
 			}
 		}
 

--- a/ComicRack/Output/Languages/fr/Keyboard.xml
+++ b/ComicRack/Output/Languages/fr/Keyboard.xml
@@ -57,7 +57,8 @@
     <Text Key="ToggleRealisticPages" Text="Activer l'affichage réaliste" Comment="Toggle Realistic Display" />
     <Text Key="SinglePage" Text="Page seule" Comment="Single Page" />
     <Text Key="TwoPages" Text="Deux pages" Comment="Two Pages" />
-    <Text Key="TwoPagesAdaptive" Text="Deux pages (adaptatif)" Comment="Two Pages (adaptive)" />
+	<Text Key="TwoPagesAdaptive" Text="Deux pages (adaptatif)" Comment="Two Pages (adaptive)" />
+	<Text Key="Continuous" Text="Continu" Comment="Continuous" />
     <Text Key="RightToLeft" Text="Droite à Gauche" Comment="Right to Left" />
     <Text Key="ZoomAndRotate" Text="Zoom et rotation" Comment="Zoom and Rotate" />
     <Text Key="ToggleNavigationOverlay" Text="Activer Miniatures de Navigation" Comment="Toggle Navigation Overlay" />

--- a/ComicRack/Output/Languages/fr/MainForm.xml
+++ b/ComicRack/Output/Languages/fr/MainForm.xml
@@ -212,6 +212,9 @@
     <Text Key="miTwoPagesAdaptive" Text="Deux pages (adaptatif)" Comment="Two Pages (adaptive)" />
     <Text Key="cmTwoPagesAdaptive" Text="Deux pages (adaptatif)" Comment="Two Pages (adaptive)" />
     <Text Key="tbTwoPagesAdaptive" Text="Deux pages (adaptatif)" Comment="Two Pages (adaptive)" />
+	<Text Key="miContinuous" Text="Continu" Comment="Continuous" />
+	<Text Key="cmContinuous" Text="Continu" Comment="Continuous" />
+	<Text Key="tbContinuous" Text="Continu" Comment="Continuous" />
     <Text Key="miSinglePage" Text="Page seule" Comment="Single Page" />
     <Text Key="cmSinglePage" Text="Page seule" Comment="Single Page" />
     <Text Key="tbSinglePage" Text="Page seule" Comment="Single Page" />

--- a/ComicRack/Views/SmallComicPreview.cs
+++ b/ComicRack/Views/SmallComicPreview.cs
@@ -26,7 +26,7 @@ namespace cYo.Projects.ComicRack.Viewer.Views
         {
             get
             {
-                return pageViewer.PageLayout != PageLayoutMode.Single;
+                return pageViewer.PageLayout == PageLayoutMode.Double || pageViewer.PageLayout == PageLayoutMode.DoubleAdaptive;
             }
             set
             {


### PR DESCRIPTION
## What this adds

This adds a fourth page layout, **Long Form (Continuous)**, for webtoons, manhwa, and other comics made from vertically ordered images.

In this mode ComicRack treats the filtered book as one scrollable strip:

- pages are stacked top-to-bottom without artificial gaps;
- mouse wheel, keyboard, drag, and touch input move smoothly across page boundaries instead of triggering paged navigation;
- Original keeps each image at its native dimensions and centers narrower pages;
- Fit Width fills the reader, while Fit Best keeps a narrower bounded column;
- the current page and reading progress follow the leading visible page.

The mode is available from the existing Page Layout menus and can be assigned in keyboard shortcuts. Existing Single Page, Two Pages, and Adaptive behavior remains unchanged, as do saved rotation and page-margin settings outside continuous mode.

## Implementation notes

The reader keeps lightweight geometry for the ordered pages, but decodes and renders only visible pages and their immediate neighbors through the existing page pool. It reuses the existing renderer, scrolling surface, fit controls, and navigation state rather than introducing a separate viewer.

Automatic webtoon detection, per-comic layout defaults, a dedicated icon, and translation updates are deliberately left out of this first pass.

## Screenshots

### Page Layout menu

![Long Form (Continuous) in the Page Layout menu](https://raw.githubusercontent.com/illusive5943/ComicRackCE/0ef8fa643d5f39c391390a28fb3301764d7e6384/.github/pr-images/275/long-form-page-layout-menu.png)

### Continuous Fit Width view

![Mixed-width generated pages stitched together in Continuous Fit Width mode](https://raw.githubusercontent.com/illusive5943/ComicRackCE/0ef8fa643d5f39c391390a28fb3301764d7e6384/.github/pr-images/275/long-form-continuous-fit-width.png)

### Continuous Original Size view

![Mixed native page widths preserved and centered in Continuous Original Size mode](https://raw.githubusercontent.com/illusive5943/ComicRackCE/5a13e0d5620a044406e5ec2cc93bbf77f507a940/.github/pr-images/275/long-form-continuous-original-size.png)

All three screenshots use a generated test comic and contain no personal desktop or library content.

## Testing

- restored packages and built the Release configuration with Visual Studio MSBuild;
- tested hardware and software rendering in isolated ComicRack profiles;
- tested mixed native widths and tall pages with Original, Fit Width, and Fit Best;
- tested wheel, keyboard, drag, and background scrolling across page seams;
- tested 125% zoom and resizing for stable horizontal centering;
- tested saved layout restoration in a fresh profile;
- ran focused layout checks for visibility, hit-testing, anchor restoration, resize retention, and virtual heights above `Int32.MaxValue`.

## Development note

This feature was developed iteratively with AI-assisted, or “vibe coded,” implementation, followed by a manual review of the final diff, a clean rebase onto `dev`, focused geometry checks, and application-level testing in isolated profiles. I am calling that out plainly so reviewers know how the patch was produced; feedback on the viewer integration is welcome.

Closes #54

Refs #223